### PR TITLE
feat: Add optional defaultValue parameter to GetGlobalVariable

### DIFF
--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal/NetworkVariableManager.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal/NetworkVariableManager.cs
@@ -77,6 +77,11 @@ namespace Styly.NetSync
             return _globalVariables.TryGetValue(name, out var value) ? value : null;
         }
         
+        public string GetGlobalVariable(string name, string defaultValue = null)
+        {
+            return _globalVariables.TryGetValue(name, out var value) ? value : defaultValue;
+        }
+        
         // Client Variables API
         public bool SetClientVariable(int targetClientNo, string name, string value, string roomId)
         {

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/NetSyncManager.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/NetSyncManager.cs
@@ -86,6 +86,11 @@ namespace Styly.NetSync
             return _networkVariableManager?.GetGlobalVariable(name);
         }
 
+        public string GetGlobalVariable(string name, string defaultValue = null)
+        {
+            return _networkVariableManager?.GetGlobalVariable(name, defaultValue) ?? defaultValue;
+        }
+
         public bool SetClientVariable(string name, string value)
         {
             return _networkVariableManager?.SetClientVariable(_clientNo, name, value, _roomId) ?? false;


### PR DESCRIPTION
Add overloaded method GetGlobalVariable(string name, string defaultValue = null)

- Implemented in both NetSyncManager and NetworkVariableManager
- Maintains backward compatibility with existing method signature
- Returns defaultValue when variable doesn't exist in global variables

Resolves #7

🤖 Generated with [Claude Code](https://claude.ai/code)