### PR TITLE
Prevented SendTransformUpdates() from being processed until the connection was established.

### DIFF
--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/NetSyncManager.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/NetSyncManager.cs
@@ -430,7 +430,7 @@ namespace Styly.NetSync
 
         private void SendTransformUpdates()
         {
-            if (!_connectionManager.IsConnectionError && _transformSyncManager.ShouldSendTransform(Time.time))
+            if (_connectionManager.IsConnected && !_connectionManager.IsConnectionError && _transformSyncManager.ShouldSendTransform(Time.time))
             {
                 if (_isStealthMode)
                 {


### PR DESCRIPTION
When the Unity scene at startup is scene A and the scene where NetSyncManager is placed is scene B, the following error may occur when transitioning from scene A to scene B.

```
[NetSyncManager] Send failed – disconnected?
UnityEngine.Debug:LogError (object)
Styly.NetSync.NetSyncManager:HandleConnectionError (string) (at 
./Packages/com.styly.styly-netsync/Runtime/NetSyncManager.cs:477)
Styly.NetSync.NetSyncManager:SendTransformUpdates () (at 
./Packages/com.styly.styly-netsync/Runtime/NetSyncManager.cs:449)
Styly.NetSync.NetSyncManager:Update () (at ./Packages/com.styly.styly-netsync/Runtime/NetSyncManager.cs:240)
```

Upon investigation, it was found that _connectionManager.DealerSocket was null at [this point](https://github.com/styly-dev/STYLY-NetSync/blob/b765935b0377ba6edf79c8036bdc9c0f00d13c79/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal/TransformSyncManager.cs#L27) in time.

The above problem did not occur when Scene B was launched directly, probably because the connection was established before SendTransformUpdates() in NetSyncManager.Update().