### PR TITLE
feat: unify transform data structure

### DIFF
--- a/STYLY-NetSync-Server/tests/integration/test_client.py
+++ b/STYLY-NetSync-Server/tests/integration/test_client.py
@@ -65,6 +65,8 @@ from styly_netsync.binary_serializer import (
     serialize_rpc_client_message,
     serialize_rpc_message,
     serialize_rpc_request,
+    TransformData,
+    Vector3,
 )
 
 # Configure logging
@@ -144,43 +146,23 @@ class TestClient:
         # Build transform data
         transform_data = {
             'deviceId': self.device_id,
-            'physical': {
-                'posX': self.position_x,
-                'posY': 0,
-                'posZ': self.position_z,
-                'rotX': 0,
-                'rotY': self.rotation_y,
-                'rotZ': 0,
-                'isLocalSpace': True
-            },
-            'head': {
-                'posX': self.position_x,
-                'posY': 1.6,  # Head height
-                'posZ': self.position_z,
-                'rotX': 0,
-                'rotY': self.rotation_y,
-                'rotZ': 0,
-                'isLocalSpace': False
-            },
-            'rightHand': {
-                'posX': self.position_x + 0.3,
-                'posY': 1.2,
-                'posZ': self.position_z,
-                'rotX': 0,
-                'rotY': 0,
-                'rotZ': 0,
-                'isLocalSpace': False
-            },
-            'leftHand': {
-                'posX': self.position_x - 0.3,
-                'posY': 1.2,
-                'posZ': self.position_z,
-                'rotX': 0,
-                'rotY': 0,
-                'rotZ': 0,
-                'isLocalSpace': False
-            },
-            'virtuals': []  # No virtual objects for this test
+            'physical': TransformData(
+                position=Vector3(self.position_x, 0, self.position_z),
+                rotation=Vector3(0, self.rotation_y, 0)
+            ),
+            'head': TransformData(
+                position=Vector3(self.position_x, 1.6, self.position_z),
+                rotation=Vector3(0, self.rotation_y, 0)
+            ),
+            'rightHand': TransformData(
+                position=Vector3(self.position_x + 0.3, 1.2, self.position_z),
+                rotation=Vector3(0, 0, 0)
+            ),
+            'leftHand': TransformData(
+                position=Vector3(self.position_x - 0.3, 1.2, self.position_z),
+                rotation=Vector3(0, 0, 0)
+            ),
+            'virtuals': []
         }
 
         # Serialize and send

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal/BinarySerializer.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal/BinarySerializer.cs
@@ -19,11 +19,19 @@ namespace Styly.NetSync
         public const byte MSG_CLIENT_VAR_SET = 9;  // Set client variable
         public const byte MSG_CLIENT_VAR_SYNC = 10;  // Sync client variables
 
-        // Transform data type identifiers
-        private const byte TRANSFORM_PHYSICAL = 1;  // 3 floats: posX, posZ, rotY
-        private const byte TRANSFORM_VIRTUAL = 2;   // 6 floats: full transform
+        private const int MAX_VIRTUAL_TRANSFORMS = 50;
 
         #region === Serialization ===
+
+        private static void WriteTransformData(BinaryWriter writer, TransformData data)
+        {
+            writer.Write(data?.position.x ?? 0f);
+            writer.Write(data?.position.y ?? 0f);
+            writer.Write(data?.position.z ?? 0f);
+            writer.Write(data?.rotation.x ?? 0f);
+            writer.Write(data?.rotation.y ?? 0f);
+            writer.Write(data?.rotation.z ?? 0f);
+        }
 
         public static byte[] SerializeClientTransform(ClientTransformData data)
         {
@@ -40,44 +48,18 @@ namespace Styly.NetSync
 
                 // Note: Client number is not sent by client, only assigned by server
 
-                // Physical transform (optimized: 3 floats only)
-                {
-                    writer.Write(data.physical.posX);
-                    writer.Write(data.physical.posZ);
-                    writer.Write(data.physical.rotY);
-                }
+                // Physical transform (6 floats)
+                WriteTransformData(writer, data.physical ?? new TransformData());
 
-                // Head transform
-                {
-                    writer.Write(data.head.posX);
-                    writer.Write(data.head.posY);
-                    writer.Write(data.head.posZ);
-                    writer.Write(data.head.rotX);
-                    writer.Write(data.head.rotY);
-                    writer.Write(data.head.rotZ);
-                }
+                // Head transform (6 floats)
+                WriteTransformData(writer, data.head ?? new TransformData());
 
-                // Right hand transform
-                {
-                    writer.Write(data.rightHand.posX);
-                    writer.Write(data.rightHand.posY);
-                    writer.Write(data.rightHand.posZ);
-                    writer.Write(data.rightHand.rotX);
-                    writer.Write(data.rightHand.rotY);
-                    writer.Write(data.rightHand.rotZ);
-                }
+                // Right hand transform (6 floats)
+                WriteTransformData(writer, data.rightHand ?? new TransformData());
 
-                // Left hand transform
-                {
-                    writer.Write(data.leftHand.posX);
-                    writer.Write(data.leftHand.posY);
-                    writer.Write(data.leftHand.posZ);
-                    writer.Write(data.leftHand.rotX);
-                    writer.Write(data.leftHand.rotY);
-                    writer.Write(data.leftHand.rotZ);
-                }
+                // Left hand transform (6 floats)
+                WriteTransformData(writer, data.leftHand ?? new TransformData());
 
-                // Virtual transforms count
                 var virtualCount = data.virtuals?.Count ?? 0;
                 if (virtualCount > MAX_VIRTUAL_TRANSFORMS)
                 {
@@ -85,19 +67,9 @@ namespace Styly.NetSync
                 }
                 writer.Write((byte)virtualCount);
 
-                // Virtual transforms (always full 6DOF)
-                if (data.virtuals != null && virtualCount > 0)
+                for (int i = 0; i < virtualCount; i++)
                 {
-                    for (int i = 0; i < virtualCount; i++)
-                    {
-                        var vt = data.virtuals[i];
-                        writer.Write(vt.posX);
-                        writer.Write(vt.posY);
-                        writer.Write(vt.posZ);
-                        writer.Write(vt.rotX);
-                        writer.Write(vt.rotY);
-                        writer.Write(vt.rotZ);
-                    }
+                    WriteTransformData(writer, data.virtuals[i] ?? new TransformData());
                 }
 
                 return ms.ToArray();
@@ -117,40 +89,25 @@ namespace Styly.NetSync
                 writer.Write((byte)deviceIdBytes.Length);
                 writer.Write(deviceIdBytes);
 
-                // Physical transform with NaN values (stealth mode indicator)
-                writer.Write(float.NaN); // posX
-                writer.Write(float.NaN); // posZ
-                writer.Write(float.NaN); // rotY
+                // Physical transform NaNs (6 floats)
+                for (int i = 0; i < 6; i++) writer.Write(float.NaN);
 
-                // Head transform (NaN values)
-                for (int i = 0; i < 6; i++) // posX, posY, posZ, rotX, rotY, rotZ
-                {
-                    writer.Write(float.NaN);
-                }
+                // Head transform NaNs
+                for (int i = 0; i < 6; i++) writer.Write(float.NaN);
 
-                // Right hand transform (NaN values)
-                for (int i = 0; i < 6; i++)
-                {
-                    writer.Write(float.NaN);
-                }
+                // Right hand transform NaNs
+                for (int i = 0; i < 6; i++) writer.Write(float.NaN);
 
-                // Left hand transform (NaN values)
-                for (int i = 0; i < 6; i++)
-                {
-                    writer.Write(float.NaN);
-                }
+                // Left hand transform NaNs
+                for (int i = 0; i < 6; i++) writer.Write(float.NaN);
 
-                // No virtual transforms for stealth handshake
-                writer.Write((byte)0);
+                writer.Write((byte)0); // No virtuals
 
                 return ms.ToArray();
             }
         }
 
         #region === Deserialization ===
-
-        // Maximum allowed virtual transforms to prevent memory issues
-        private const int MAX_VIRTUAL_TRANSFORMS = 50;
 
         public static (byte messageType, object data) Deserialize(byte[] bytes)
         {
@@ -204,92 +161,41 @@ namespace Styly.NetSync
         }
 
 
+        private static TransformData ReadTransformData(BinaryReader reader)
+        {
+            return new TransformData
+            {
+                position = new Vector3(reader.ReadSingle(), reader.ReadSingle(), reader.ReadSingle()),
+                rotation = new Vector3(reader.ReadSingle(), reader.ReadSingle(), reader.ReadSingle())
+            };
+        }
+
         private static RoomTransformData DeserializeRoomTransform(BinaryReader reader)
         {
             var data = new RoomTransformData();
 
-            // Room ID
             var roomIdLength = reader.ReadByte();
             data.roomId = System.Text.Encoding.UTF8.GetString(reader.ReadBytes(roomIdLength));
 
-            // Number of clients
             var clientCount = reader.ReadUInt16();
             data.clients = new List<ClientTransformData>(clientCount);
 
-            // Each client with short ID
             for (int i = 0; i < clientCount; i++)
             {
                 var client = new ClientTransformData();
-
-                // Client number (2 bytes)
                 client.clientNo = reader.ReadUInt16();
 
-                // Note: Device ID is no longer sent in MSG_ROOM_TRANSFORM
-                // Device ID will be resolved from client number using mapping table
+                client.physical = ReadTransformData(reader);
+                client.head = ReadTransformData(reader);
+                client.rightHand = ReadTransformData(reader);
+                client.leftHand = ReadTransformData(reader);
 
-                // Physical transform
-                {
-                    var posX = reader.ReadSingle();
-                    var posZ = reader.ReadSingle();
-                    var rotY = reader.ReadSingle();
-                    client.physical = new Transform3D(posX, 0, posZ, 0, rotY, 0, true);
-                }
-
-                // Head transform
-                {
-                    var posX = reader.ReadSingle();
-                    var posY = reader.ReadSingle();
-                    var posZ = reader.ReadSingle();
-                    var rotX = reader.ReadSingle();
-                    var rotY = reader.ReadSingle();
-                    var rotZ = reader.ReadSingle();
-                    client.head = new Transform3D(posX, posY, posZ, rotX, rotY, rotZ, false);
-                }
-
-                // Right hand transform
-                {
-                    var posX = reader.ReadSingle();
-                    var posY = reader.ReadSingle();
-                    var posZ = reader.ReadSingle();
-                    var rotX = reader.ReadSingle();
-                    var rotY = reader.ReadSingle();
-                    var rotZ = reader.ReadSingle();
-                    client.rightHand = new Transform3D(posX, posY, posZ, rotX, rotY, rotZ, false);
-                }
-
-                // Left hand transform
-                {
-                    var posX = reader.ReadSingle();
-                    var posY = reader.ReadSingle();
-                    var posZ = reader.ReadSingle();
-                    var rotX = reader.ReadSingle();
-                    var rotY = reader.ReadSingle();
-                    var rotZ = reader.ReadSingle();
-                    client.leftHand = new Transform3D(posX, posY, posZ, rotX, rotY, rotZ, false);
-                }
-
-                // Virtual transforms
                 var virtualCount = reader.ReadByte();
-
-                // Validate virtual count to prevent memory issues
-                if (virtualCount > MAX_VIRTUAL_TRANSFORMS)
+                if (virtualCount > MAX_VIRTUAL_TRANSFORMS) virtualCount = MAX_VIRTUAL_TRANSFORMS;
+                client.virtuals = new List<TransformData>(virtualCount);
+                for (int j = 0; j < virtualCount; j++)
                 {
-                    virtualCount = MAX_VIRTUAL_TRANSFORMS;
-                }
-
-                if (virtualCount > 0)
-                {
-                    client.virtuals = new List<Transform3D>(virtualCount);
-                    for (int j = 0; j < virtualCount; j++)
-                    {
-                        var posX = reader.ReadSingle();
-                        var posY = reader.ReadSingle();
-                        var posZ = reader.ReadSingle();
-                        var rotX = reader.ReadSingle();
-                        var rotY = reader.ReadSingle();
-                        var rotZ = reader.ReadSingle();
-                        client.virtuals.Add(new Transform3D(posX, posY, posZ, rotX, rotY, rotZ, false));
-                    }
+                    client.virtuals.Add(ReadTransformData(reader));
                 }
 
                 data.clients.Add(client);
@@ -305,28 +211,14 @@ namespace Styly.NetSync
         public static int CalculateClientTransformSize(ClientTransformData data)
         {
             int size = 1; // Message type
-            size += 1 + System.Text.Encoding.UTF8.GetByteCount(data.deviceId); // Device ID
+            size += 1 + System.Text.Encoding.UTF8.GetByteCount(data.deviceId ?? string.Empty); // Device ID
 
-            // Physical transform
-            if (data.physical != null && data.physical.isLocalSpace)
-            {
-                size += 1 + 12; // Type + 3 floats
-            }
-            else if (data.physical != null)
-            {
-                size += 1 + 24; // Type + 6 floats
-            }
-            else
-            {
-                size += 1; // Just type (0)
-            }
+            // 4 transforms * 6 floats (physical + head + right + left)
+            size += 24 * 4;
 
             // Virtual transforms
-            size += 1; // Count
-            if (data.virtuals != null)
-            {
-                size += data.virtuals.Count * 24; // 6 floats each
-            }
+            var virtualCount = data.virtuals?.Count ?? 0;
+            size += 1 + virtualCount * 24;
 
             return size;
         }

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal/DataStructure.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal/DataStructure.cs
@@ -5,30 +5,16 @@ using UnityEngine;
 
 namespace Styly.NetSync
 {
-    // Unified transform data structure (supports both local and world coordinates)
     [Serializable]
-    public class Transform3D
+    public class TransformData
     {
-        public float posX;
-        public float posY;
-        public float posZ;
-        public float rotX;
-        public float rotY;
-        public float rotZ;
-        public bool isLocalSpace; // true for local/physical, false for world/virtual
+        public Vector3 position;
+        public Vector3 rotation;
 
-        public Transform3D() { }
-
-        // Constructor for virtual/world transforms (full 6DOF)
-        public Transform3D(float x, float y, float z, float rotX, float rotY, float rotZ, bool local = false)
+        public TransformData()
         {
-            posX = x;
-            posY = y;
-            posZ = z;
-            this.rotX = rotX;
-            this.rotY = rotY;
-            this.rotZ = rotZ;
-            isLocalSpace = local;
+            position = Vector3.zero;
+            rotation = Vector3.zero;
         }
     }
 
@@ -38,11 +24,11 @@ namespace Styly.NetSync
     {
         public string deviceId;
         public int clientNo;  // Client number assigned by server (0 if not assigned)
-        public Transform3D physical;
-        public Transform3D head;
-        public Transform3D rightHand;
-        public Transform3D leftHand;
-        public List<Transform3D> virtuals;
+        public TransformData physical;
+        public TransformData head;
+        public TransformData rightHand;
+        public TransformData leftHand;
+        public List<TransformData> virtuals;
     }
 
     // Room data from server

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/NetSyncAvatar.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/NetSyncAvatar.cs
@@ -38,11 +38,11 @@ namespace Styly.NetSync
         public bool IsLocalAvatar { get; private set; }
 
         // Variables for interpolation
-        private Transform3D _targetPhysical;
-        private Transform3D _targetHead;
-        private Transform3D _targetRightHand;
-        private Transform3D _targetLeftHand;
-        private List<Transform3D> _targetVirtuals = new List<Transform3D>();
+        private TransformData _targetPhysical;
+        private TransformData _targetHead;
+        private TransformData _targetRightHand;
+        private TransformData _targetLeftHand;
+        private List<TransformData> _targetVirtuals = new List<TransformData>();
         private bool _hasTargetData = false;
 
         // Reference to NetSyncManager
@@ -95,14 +95,14 @@ namespace Styly.NetSync
             if (!isLocalAvatar)
             {
                 // For remote players, set initial data for interpolation
-                _targetPhysical = new Transform3D();
-                _targetHead = new Transform3D();
-                _targetRightHand = new Transform3D();
-                _targetLeftHand = new Transform3D();
+                _targetPhysical = new TransformData();
+                _targetHead = new TransformData();
+                _targetRightHand = new TransformData();
+                _targetLeftHand = new TransformData();
                 _targetVirtuals.Clear();
                 for (int i = 0; i < _virtualTransforms.Length; i++)
                 {
-                    _targetVirtuals.Add(new Transform3D());
+                    _targetVirtuals.Add(new TransformData());
                 }
             }
         }
@@ -116,14 +116,14 @@ namespace Styly.NetSync
             _netSyncManager = manager;
 
             // For remote players, set initial data for interpolation
-            _targetPhysical = new Transform3D();
-            _targetHead = new Transform3D();
-            _targetRightHand = new Transform3D();
-            _targetLeftHand = new Transform3D();
+            _targetPhysical = new TransformData();
+            _targetHead = new TransformData();
+            _targetRightHand = new TransformData();
+            _targetLeftHand = new TransformData();
             _targetVirtuals.Clear();
             for (int i = 0; i < _virtualTransforms.Length; i++)
             {
-                _targetVirtuals.Add(new Transform3D());
+                _targetVirtuals.Add(new TransformData());
             }
         }
 
@@ -160,11 +160,11 @@ namespace Styly.NetSync
             {
                 deviceId = _deviceId,
                 clientNo = _clientNo,
-                physical = ConvertToTransform3D(_physicalTransform, true),
-                head = ConvertToTransform3D(_head, false),
-                rightHand = ConvertToTransform3D(_rightHand, false),
-                leftHand = ConvertToTransform3D(_leftHand, false),
-                virtuals = ConvertToTransform3DList(_virtualTransforms, false)
+                physical = ConvertToTransformData(_physicalTransform, true),
+                head = ConvertToTransformData(_head, false),
+                rightHand = ConvertToTransformData(_rightHand, false),
+                leftHand = ConvertToTransformData(_leftHand, false),
+                virtuals = ConvertToTransformDataList(_virtualTransforms, false)
             };
         }
 
@@ -188,38 +188,30 @@ namespace Styly.NetSync
                 // Set physical transform immediately
                 if (_physicalTransform != null && data.physical != null)
                 {
-                    _physicalPosition = new Vector3(data.physical.posX, data.physical.posY, data.physical.posZ);
-                    Vector3 newPhysicalPosition = new Vector3(data.physical.posX, data.physical.posY, data.physical.posZ);
-                    Vector3 newPhysicalRotation = new Vector3(data.physical.rotX, data.physical.rotY, data.physical.rotZ);
-                    _physicalPosition = newPhysicalPosition;
-                    _physicalRotation = newPhysicalRotation;
-                    _physicalTransform.localPosition = newPhysicalPosition;
-                    _physicalTransform.localEulerAngles = newPhysicalRotation;
-                    _physicalTransform.localPosition = _physicalPosition;
-                    _physicalTransform.localEulerAngles = _physicalRotation;
+                    _physicalPosition = data.physical.position;
+                    _physicalRotation = data.physical.rotation;
+                    _physicalTransform.localPosition = data.physical.position;
+                    _physicalTransform.localEulerAngles = data.physical.rotation;
                 }
 
-                // Set head transform immediately
                 if (_head != null && data.head != null)
                 {
-                    _head.position = new Vector3(data.head.posX, data.head.posY, data.head.posZ);
-                    _head.rotation = Quaternion.Euler(data.head.rotX, data.head.rotY, data.head.rotZ);
+                    _head.position = data.head.position;
+                    _head.rotation = Quaternion.Euler(data.head.rotation);
                 }
 
-                // Set hand transforms immediately
                 if (_rightHand != null && data.rightHand != null)
                 {
-                    _rightHand.position = new Vector3(data.rightHand.posX, data.rightHand.posY, data.rightHand.posZ);
-                    _rightHand.rotation = Quaternion.Euler(data.rightHand.rotX, data.rightHand.rotY, data.rightHand.rotZ);
+                    _rightHand.position = data.rightHand.position;
+                    _rightHand.rotation = Quaternion.Euler(data.rightHand.rotation);
                 }
 
                 if (_leftHand != null && data.leftHand != null)
                 {
-                    _leftHand.position = new Vector3(data.leftHand.posX, data.leftHand.posY, data.leftHand.posZ);
-                    _leftHand.rotation = Quaternion.Euler(data.leftHand.rotX, data.leftHand.rotY, data.leftHand.rotZ);
+                    _leftHand.position = data.leftHand.position;
+                    _leftHand.rotation = Quaternion.Euler(data.leftHand.rotation);
                 }
 
-                // Set virtual transforms immediately
                 if (_virtualTransforms != null && data.virtuals != null)
                 {
                     int count = Mathf.Min(_virtualTransforms.Length, data.virtuals.Count);
@@ -228,97 +220,76 @@ namespace Styly.NetSync
                         if (_virtualTransforms[i] != null && data.virtuals[i] != null)
                         {
                             var vt = data.virtuals[i];
-                            _virtualTransforms[i].position = new Vector3(vt.posX, vt.posY, vt.posZ);
-                            _virtualTransforms[i].rotation = Quaternion.Euler(vt.rotX, vt.rotY, vt.rotZ);
+                            _virtualTransforms[i].position = vt.position;
+                            _virtualTransforms[i].rotation = Quaternion.Euler(vt.rotation);
                         }
                     }
                 }
             }
 
+            _targetPhysical = data.physical;
             _targetHead = data.head;
             _targetRightHand = data.rightHand;
             _targetLeftHand = data.leftHand;
             _targetVirtuals = data.virtuals;
             _hasTargetData = true;
-            _physicalPosition = new Vector3(data.physical.posX, data.physical.posY, data.physical.posZ);
-            _physicalRotation = new Vector3(data.physical.rotX, data.physical.rotY, data.physical.rotZ);
+            _physicalPosition = data.physical.position;
+            _physicalRotation = data.physical.rotation;
 
             // Update client number for remote players
             _clientNo = data.clientNo;
         }
 
-        // Unified transform conversion method
-        // isLocalSpace: whether to read from local space (physical) vs world space (virtual)
-        private Transform3D ConvertToTransform3D(Transform transform, bool isLocalSpace)
+        private TransformData ConvertToTransformData(Transform t, bool isLocal)
         {
-            if (transform == null) { return new Transform3D(); }
-
-            if (isLocalSpace)
+            if (t == null) return new TransformData();
+            return new TransformData
             {
-                // Physical/local transform (XZ position, Y rotation only)
-                return new Transform3D(
-                    transform.localPosition.x,
-                    0,
-                    transform.localPosition.z,
-                    0,
-                    transform.localEulerAngles.y,
-                    0,
-                    true
-                );
-            }
-            else
-            {
-                // Virtual/world transform (full 6DOF)
-                return new Transform3D(
-                    transform.position.x,
-                    transform.position.y,
-                    transform.position.z,
-                    transform.eulerAngles.x,
-                    transform.eulerAngles.y,
-                    transform.eulerAngles.z,
-                    false
-                );
-            }
+                position = isLocal ? t.localPosition : t.position,
+                rotation = isLocal ? t.localEulerAngles : t.eulerAngles
+            };
         }
 
-        // Convert transform array to Transform3D list
-        private List<Transform3D> ConvertToTransform3DList(Transform[] transforms, bool isLocalSpace)
+        private List<TransformData> ConvertToTransformDataList(Transform[] transforms, bool isLocal)
         {
-            var result = new List<Transform3D>();
+            var result = new List<TransformData>();
             if (transforms != null)
             {
                 foreach (var t in transforms)
                 {
                     if (t != null)
                     {
-                        result.Add(ConvertToTransform3D(t, isLocalSpace));
+                        result.Add(ConvertToTransformData(t, isLocal));
                     }
                 }
             }
             return result;
         }
 
-        // Simplified transform interpolation
         private void InterpolateTransforms()
         {
             float deltaTime = Time.deltaTime * _interpolationSpeed;
-            // Head Transform interpolation (world space)
-            if (_head != null && _targetHead != null)
+
+            if (_physicalTransform != null && _targetPhysical != null)
             {
-                InterpolateSingleTransform(_head, _targetHead, deltaTime, false);
-            }
-            // Right Hand Transform interpolation (world space)
-            if (_rightHand != null && _targetRightHand != null)
-            {
-                InterpolateSingleTransform(_rightHand, _targetRightHand, deltaTime, false);
-            }
-            // Left Hand Transform interpolation (world space)
-            if (_leftHand != null && _targetLeftHand != null)
-            {
-                InterpolateSingleTransform(_leftHand, _targetLeftHand, deltaTime, false);
+                InterpolateSingleTransform(_physicalTransform, _targetPhysical, deltaTime);
             }
 
-            // Virtual Transforms interpolation (world space)
+            if (_head != null && _targetHead != null)
+            {
+                InterpolateSingleTransform(_head, _targetHead, deltaTime);
+            }
+
+            if (_rightHand != null && _targetRightHand != null)
+            {
+                InterpolateSingleTransform(_rightHand, _targetRightHand, deltaTime);
+            }
+
+            if (_leftHand != null && _targetLeftHand != null)
+            {
+                InterpolateSingleTransform(_leftHand, _targetLeftHand, deltaTime);
+            }
+
             if (_virtualTransforms != null && _targetVirtuals != null)
             {
                 int count = Mathf.Min(_virtualTransforms.Length, _targetVirtuals.Count);
@@ -326,22 +297,18 @@ namespace Styly.NetSync
                 {
                     if (_virtualTransforms[i] != null)
                     {
-                        InterpolateSingleTransform(_virtualTransforms[i], _targetVirtuals[i], deltaTime, false);
+                        InterpolateSingleTransform(_virtualTransforms[i], _targetVirtuals[i], deltaTime);
                     }
                 }
             }
         }
 
-        // Unified interpolation method for any transform
-        // isLocalSpace: interpolate using localPosition/localRotation vs world position/rotation
-        private void InterpolateSingleTransform(Transform transform, Transform3D target, float deltaTime, bool isLocalSpace)
+        private void InterpolateSingleTransform(Transform transform, TransformData target, float deltaTime)
         {
-            Vector3 targetPos = isLocalSpace
-                ? new Vector3(target.posX, transform.localPosition.y, target.posZ)
-                : new Vector3(target.posX, target.posY, target.posZ);
-            Quaternion targetRot = Quaternion.Euler(target.rotX, target.rotY, target.rotZ);
+            Vector3 targetPos = target.position;
+            Quaternion targetRot = Quaternion.Euler(target.rotation);
 
-            if (isLocalSpace)
+            if (transform == _physicalTransform)
             {
                 transform.localPosition = Vector3.Lerp(transform.localPosition, targetPos, deltaTime);
                 transform.localRotation = Quaternion.Lerp(transform.localRotation, targetRot, deltaTime);


### PR DESCRIPTION
## Summary
- send full position and rotation for all transforms
- remove Transform3D and use Vector3-based TransformData
- update Python serializer and test client for new format

## Testing
- `pytest` *(fails: KeyboardInterrupt during zmq import)*

------
https://chatgpt.com/codex/tasks/task_e_689d5fd4314c83288a86755e1e4c58bd