### PR TITLE
feat: unify transform data structure

### DIFF
--- a/STYLY-NetSync-Server/src/styly_netsync/binary_serializer.py
+++ b/STYLY-NetSync-Server/src/styly_netsync/binary_serializer.py
@@ -1,139 +1,112 @@
 import math
 import struct
+from dataclasses import dataclass, field
 from typing import Any, Dict, List, Tuple, Union
 
 # Message type identifiers
 MSG_CLIENT_TRANSFORM = 1
 MSG_ROOM_TRANSFORM = 2  # Room transform with short IDs only
 MSG_RPC_BROADCAST = 3  # Broadcast function call
-MSG_RPC_SERVER    = 4  # Client-to-server RPC call
-MSG_RPC_CLIENT    = 5  # Client-to-client RPC call
+MSG_RPC_SERVER = 4  # Client-to-server RPC call
+MSG_RPC_CLIENT = 5  # Client-to-client RPC call
 MSG_DEVICE_ID_MAPPING = 6  # Device ID mapping notification
 MSG_GLOBAL_VAR_SET = 7  # Set global variable
 MSG_GLOBAL_VAR_SYNC = 8  # Sync global variables
 MSG_CLIENT_VAR_SET = 9  # Set client variable
 MSG_CLIENT_VAR_SYNC = 10  # Sync client variables
 
-# Transform data type identifiers
-TRANSFORM_PHYSICAL = 1  # 3 floats: posX, posZ, rotY
-TRANSFORM_VIRTUAL = 2   # 6 floats: full transform
-
 # Maximum allowed virtual transforms to prevent memory issues
 MAX_VIRTUAL_TRANSFORMS = 50
 
+
+@dataclass
+class Vector3:
+    x: float = 0.0
+    y: float = 0.0
+    z: float = 0.0
+
+
+@dataclass
+class TransformData:
+    position: Vector3 = field(default_factory=Vector3)
+    rotation: Vector3 = field(default_factory=Vector3)
+
+
 # Stealth mode detection utilities
-def _is_nan_transform(transform: Dict[str, Any]) -> bool:
-    """Check if a transform contains all NaN values (stealth mode indicator)"""
-    # Check physical transform (posX, posZ, rotY)
-    physical = transform.get('physical', {})
-    if not physical:
+def _is_nan_transform(transform: TransformData) -> bool:
+    if transform is None:
         return False
+    values = [
+        transform.position.x,
+        transform.position.y,
+        transform.position.z,
+        transform.rotation.x,
+        transform.rotation.y,
+        transform.rotation.z,
+    ]
+    return all(math.isnan(v) for v in values)
 
-    # All physical values must be NaN
-    if not (math.isnan(physical.get('posX', 0)) and
-            math.isnan(physical.get('posZ', 0)) and
-            math.isnan(physical.get('rotY', 0))):
-        return False
-
-    # Check head transform (all 6 values must be NaN)
-    head = transform.get('head', {})
-    if not head:
-        return False
-    for key in ['posX', 'posY', 'posZ', 'rotX', 'rotY', 'rotZ']:
-        if not math.isnan(head.get(key, 0)):
-            return False
-
-    # Check right hand transform (all 6 values must be NaN)
-    right_hand = transform.get('rightHand', {})
-    if not right_hand:
-        return False
-    for key in ['posX', 'posY', 'posZ', 'rotX', 'rotY', 'rotZ']:
-        if not math.isnan(right_hand.get(key, 0)):
-            return False
-
-    # Check left hand transform (all 6 values must be NaN)
-    left_hand = transform.get('leftHand', {})
-    if not left_hand:
-        return False
-    for key in ['posX', 'posY', 'posZ', 'rotX', 'rotY', 'rotZ']:
-        if not math.isnan(left_hand.get(key, 0)):
-            return False
-
-    # Check virtuals count is 0
-    virtuals = transform.get('virtuals', [])
-    if len(virtuals) != 0:
-        return False
-
-    return True
 
 def _is_stealth_client(data: Dict[str, Any]) -> bool:
-    """Check if client data indicates stealth mode (NaN handshake)"""
-    return _is_nan_transform(data)
+    return (
+        _is_nan_transform(data.get("physical"))
+        and _is_nan_transform(data.get("head"))
+        and _is_nan_transform(data.get("rightHand"))
+        and _is_nan_transform(data.get("leftHand"))
+        and len(data.get("virtuals", [])) == 0
+    )
+
 
 # Helper functions for common operations
 def _pack_string(buffer: bytearray, string: str, use_ushort: bool = False) -> None:
     """Pack a string with length prefix into buffer"""
-    string_bytes = string.encode('utf-8')
+    string_bytes = string.encode("utf-8")
     if use_ushort:
-        buffer.extend(struct.pack('<H', len(string_bytes)))
+        buffer.extend(struct.pack("<H", len(string_bytes)))
     else:
         buffer.append(len(string_bytes))
     buffer.extend(string_bytes)
 
+
 def _unpack_string(data: bytes, offset: int, use_ushort: bool = False) -> Tuple[str, int]:
     """Unpack a length-prefixed string from data"""
     if use_ushort:
-        length = struct.unpack('<H', data[offset:offset+2])[0]
+        length = struct.unpack("<H", data[offset:offset+2])[0]
         offset += 2
     else:
         length = data[offset]
         offset += 1
-    string = data[offset:offset+length].decode('utf-8')
+    string = data[offset:offset+length].decode("utf-8")
     return string, offset + length
 
-def _pack_transform(buffer: bytearray, transform: Dict[str, Any], keys: List[str]) -> None:
-    """Pack a transform with specified keys"""
-    for key in keys:
-        buffer.extend(struct.pack('<f', transform.get(key, 0)))
 
-def _unpack_transform(data: bytes, offset: int, keys: List[str], is_local_space: bool = False) -> Tuple[Dict[str, Any], int]:
-    """Unpack a transform with specified keys"""
-    transform = {'isLocalSpace': is_local_space}
-    for key in keys:
-        value = struct.unpack('<f', data[offset:offset+4])[0]
-        transform[key] = value
-        offset += 4
-    return transform, offset
+def serialize_transform_data(buffer: bytearray, data: TransformData) -> None:
+    buffer.extend(struct.pack("<f", data.position.x))
+    buffer.extend(struct.pack("<f", data.position.y))
+    buffer.extend(struct.pack("<f", data.position.z))
+    buffer.extend(struct.pack("<f", data.rotation.x))
+    buffer.extend(struct.pack("<f", data.rotation.y))
+    buffer.extend(struct.pack("<f", data.rotation.z))
 
-def _pack_full_transform(buffer: bytearray, transform: Dict[str, Any]) -> None:
-    """Pack a full 6-float transform"""
-    _pack_transform(buffer, transform, ['posX', 'posY', 'posZ', 'rotX', 'rotY', 'rotZ'])
 
-def _unpack_full_transform(data: bytes, offset: int, is_local_space: bool = False) -> Tuple[Dict[str, Any], int]:
-    """Unpack a full 6-float transform"""
-    return _unpack_transform(data, offset, ['posX', 'posY', 'posZ', 'rotX', 'rotY', 'rotZ'], is_local_space)
+def deserialize_transform_data(data: bytes, offset: int) -> Tuple[TransformData, int]:
+    px, py, pz, rx, ry, rz = struct.unpack_from("<6f", data, offset)
+    offset += 24
+    return TransformData(Vector3(px, py, pz), Vector3(rx, ry, rz)), offset
 
 def _serialize_client_data(buffer: bytearray, client: Dict[str, Any]) -> None:
     """Serialize a single client's data (shared by room transform and client transform)"""
-    # Device ID
-    _pack_string(buffer, client.get('deviceId', ''))
+    _pack_string(buffer, client.get("deviceId", ""))
+    serialize_transform_data(buffer, client.get("physical", TransformData()))
+    serialize_transform_data(buffer, client.get("head", TransformData()))
+    serialize_transform_data(buffer, client.get("rightHand", TransformData()))
+    serialize_transform_data(buffer, client.get("leftHand", TransformData()))
 
-    # Physical transform (special case: only 3 values)
-    physical = client.get('physical', {})
-    _pack_transform(buffer, physical, ['posX', 'posZ', 'rotY'])
-
-    # Head, Right hand, Left hand transforms
-    for transform_key in ['head', 'rightHand', 'leftHand']:
-        _pack_full_transform(buffer, client.get(transform_key, {}))
-
-    # Virtual transforms
-    virtuals = client.get('virtuals', [])
+    virtuals = client.get("virtuals", [])
     virtual_count = min(len(virtuals), MAX_VIRTUAL_TRANSFORMS)
-    # Limit virtual transforms to maximum allowed
     buffer.append(virtual_count)
-
     for i in range(virtual_count):
-        _pack_full_transform(buffer, virtuals[i])
+        serialize_transform_data(buffer, virtuals[i])
 
 def serialize_client_transform(data: Dict[str, Any]) -> bytes:
     """Serialize client transform data to binary format"""
@@ -173,26 +146,18 @@ def serialize_room_transform(data: Dict[str, Any]) -> bytes:
 
 def _serialize_client_data_short(buffer: bytearray, client: Dict[str, Any]) -> None:
     """Serialize a single client's data with client number only (2 bytes)"""
-    # Client number (2 bytes)
-    client_no = client.get('clientNo', 0)
-    buffer.extend(struct.pack('<H', client_no))
+    client_no = client.get("clientNo", 0)
+    buffer.extend(struct.pack("<H", client_no))
+    serialize_transform_data(buffer, client.get("physical", TransformData()))
+    serialize_transform_data(buffer, client.get("head", TransformData()))
+    serialize_transform_data(buffer, client.get("rightHand", TransformData()))
+    serialize_transform_data(buffer, client.get("leftHand", TransformData()))
 
-    # Physical transform (special case: only 3 values)
-    physical = client.get('physical', {})
-    _pack_transform(buffer, physical, ['posX', 'posZ', 'rotY'])
-
-    # Head, Right hand, Left hand transforms
-    for transform_key in ['head', 'rightHand', 'leftHand']:
-        _pack_full_transform(buffer, client.get(transform_key, {}))
-
-    # Virtual transforms
-    virtuals = client.get('virtuals', [])
+    virtuals = client.get("virtuals", [])
     virtual_count = min(len(virtuals), MAX_VIRTUAL_TRANSFORMS)
-    # Limit virtual transforms to maximum allowed
     buffer.append(virtual_count)
-
     for i in range(virtual_count):
-        _pack_full_transform(buffer, virtuals[i])
+        serialize_transform_data(buffer, virtuals[i])
 
 
 def _serialize_rpc_base(buffer: bytearray, data: Dict[str, Any], msg_type: int) -> None:
@@ -413,41 +378,23 @@ def deserialize(data: bytes) -> Tuple[int, Union[Dict[str, Any], None], bytes]:
 
 def _deserialize_client_transform(data: bytes, offset: int) -> Dict[str, Any]:
     """Deserialize client transform from binary data"""
-    result = {}
+    result: Dict[str, Any] = {}
 
-    # Device ID
-    result['deviceId'], offset = _unpack_string(data, offset)
+    result["deviceId"], offset = _unpack_string(data, offset)
+    result["physical"], offset = deserialize_transform_data(data, offset)
+    result["head"], offset = deserialize_transform_data(data, offset)
+    result["rightHand"], offset = deserialize_transform_data(data, offset)
+    result["leftHand"], offset = deserialize_transform_data(data, offset)
 
-    # Physical transform (special case with default values)
-    physical_values, offset = _unpack_transform(data, offset, ['posX', 'posZ', 'rotY'], is_local_space=True)
-    result['physical'] = {
-        'posX': physical_values['posX'],
-        'posY': 0,
-        'posZ': physical_values['posZ'],
-        'rotX': 0,
-        'rotY': physical_values['rotY'],
-        'rotZ': 0,
-        'isLocalSpace': True
-    }
-
-    # Head, Right hand, Left hand transforms
-    result['head'], offset = _unpack_full_transform(data, offset)
-    result['rightHand'], offset = _unpack_full_transform(data, offset)
-    result['leftHand'], offset = _unpack_full_transform(data, offset)
-
-    # Virtual transforms
     virtual_count = data[offset]
     offset += 1
-
-    # Validate virtual count to prevent memory issues
     if virtual_count > MAX_VIRTUAL_TRANSFORMS:
         virtual_count = MAX_VIRTUAL_TRANSFORMS
 
-    if virtual_count > 0:
-        result['virtuals'] = []
-        for _ in range(virtual_count):
-            vt, offset = _unpack_full_transform(data, offset)
-            result['virtuals'].append(vt)
+    result["virtuals"] = []
+    for _ in range(virtual_count):
+        vt, offset = deserialize_transform_data(data, offset)
+        result["virtuals"].append(vt)
 
     return result
 
@@ -481,56 +428,35 @@ def _deserialize_rpc_client_message(data: bytes, offset: int) -> Dict[str, Any]:
 
 def _deserialize_room_transform(data: bytes, offset: int) -> Dict[str, Any]:
     """Deserialize room transform with client numbers only"""
-    result = {}
+    result: Dict[str, Any] = {}
 
-    # Room ID
-    result['roomId'], offset = _unpack_string(data, offset)
-
-    # Number of clients
-    client_count = struct.unpack('<H', data[offset:offset+2])[0]
+    result["roomId"], offset = _unpack_string(data, offset)
+    client_count = struct.unpack("<H", data[offset:offset+2])[0]
     offset += 2
 
-    result['clients'] = []
+    result["clients"] = []
     for _ in range(client_count):
-        client = {}
-
-        # Client number (2 bytes)
-        client_no = struct.unpack('<H', data[offset:offset+2])[0]
+        client: Dict[str, Any] = {}
+        client_no = struct.unpack("<H", data[offset:offset+2])[0]
         offset += 2
-        client['clientNo'] = client_no
+        client["clientNo"] = client_no
 
-        # Physical transform
-        physical_values, offset = _unpack_transform(data, offset, ['posX', 'posZ', 'rotY'], is_local_space=True)
-        client['physical'] = {
-            'posX': physical_values['posX'],
-            'posY': 0,
-            'posZ': physical_values['posZ'],
-            'rotX': 0,
-            'rotY': physical_values['rotY'],
-            'rotZ': 0,
-            'isLocalSpace': True
-        }
+        client["physical"], offset = deserialize_transform_data(data, offset)
+        client["head"], offset = deserialize_transform_data(data, offset)
+        client["rightHand"], offset = deserialize_transform_data(data, offset)
+        client["leftHand"], offset = deserialize_transform_data(data, offset)
 
-        # Head, Right hand, Left hand transforms
-        client['head'], offset = _unpack_full_transform(data, offset)
-        client['rightHand'], offset = _unpack_full_transform(data, offset)
-        client['leftHand'], offset = _unpack_full_transform(data, offset)
-
-        # Virtual transforms
         virtual_count = data[offset]
         offset += 1
-
-        # Validate virtual count to prevent memory issues
         if virtual_count > MAX_VIRTUAL_TRANSFORMS:
             virtual_count = MAX_VIRTUAL_TRANSFORMS
 
-        if virtual_count > 0:
-            client['virtuals'] = []
-            for _ in range(virtual_count):
-                vt, offset = _unpack_full_transform(data, offset)
-                client['virtuals'].append(vt)
+        client["virtuals"] = []
+        for _ in range(virtual_count):
+            vt, offset = deserialize_transform_data(data, offset)
+            client["virtuals"].append(vt)
 
-        result['clients'].append(client)
+        result["clients"].append(client)
 
     return result
 

--- a/STYLY-NetSync-Server/src/styly_netsync/client_simulator.py
+++ b/STYLY-NetSync-Server/src/styly_netsync/client_simulator.py
@@ -18,10 +18,10 @@ import zmq
 
 # Import the binary serializer from the same package
 try:
-    from .binary_serializer import serialize_client_transform
+    from .binary_serializer import serialize_client_transform, TransformData, Vector3
 except ImportError:
     # Fallback for direct script execution
-    from binary_serializer import serialize_client_transform
+    from binary_serializer import serialize_client_transform, TransformData, Vector3
 
 class MovementPattern(Enum):
     """Movement patterns matching DebugMoveAvatar.cs"""
@@ -107,43 +107,29 @@ class SimulatedClient:
         # Build transform data matching the expected format
         transform_data = {
             "deviceId": self.device_id,
-            "physical": {
-                "posX": new_position[0],
-                "posY": 0,  # Y is always 0 for physical transform
-                "posZ": new_position[2],
-                "rotX": 0,
-                "rotY": 0,  # For simplicity, no rotation in simulation
-                "rotZ": 0,
-                "isLocalSpace": True,
-            },
-            "head": {
-                "posX": head_pos[0],
-                "posY": head_pos[1],
-                "posZ": head_pos[2],
-                "rotX": 0,
-                "rotY": 0,
-                "rotZ": 0,
-                "isLocalSpace": False,
-            },
-            "rightHand": {
-                "posX": right_hand_pos[0],
-                "posY": right_hand_pos[1],
-                "posZ": right_hand_pos[2],
-                "rotX": 0,
-                "rotY": 0,
-                "rotZ": 0,
-                "isLocalSpace": False,
-            },
-            "leftHand": {
-                "posX": left_hand_pos[0],
-                "posY": left_hand_pos[1],
-                "posZ": left_hand_pos[2],
-                "rotX": 0,
-                "rotY": 0,
-                "rotZ": 0,
-                "isLocalSpace": False,
-            },
-            "virtuals": virtuals,
+            "physical": TransformData(
+                position=Vector3(new_position[0], 0, new_position[2]),
+                rotation=Vector3(0, 0, 0),
+            ),
+            "head": TransformData(
+                position=Vector3(head_pos[0], head_pos[1], head_pos[2]),
+                rotation=Vector3(0, 0, 0),
+            ),
+            "rightHand": TransformData(
+                position=Vector3(right_hand_pos[0], right_hand_pos[1], right_hand_pos[2]),
+                rotation=Vector3(0, 0, 0),
+            ),
+            "leftHand": TransformData(
+                position=Vector3(left_hand_pos[0], left_hand_pos[1], left_hand_pos[2]),
+                rotation=Vector3(0, 0, 0),
+            ),
+            "virtuals": [
+                TransformData(
+                    position=Vector3(v["posX"], v["posY"], v["posZ"]),
+                    rotation=Vector3(v.get("rotX", 0), v.get("rotY", 0), v.get("rotZ", 0)),
+                )
+                for v in virtuals
+            ],
         }
 
         return transform_data

--- a/STYLY-NetSync-Server/tests/integration/test_client.py
+++ b/STYLY-NetSync-Server/tests/integration/test_client.py
@@ -58,6 +58,8 @@ from styly_netsync.binary_serializer import (
     MSG_DEVICE_ID_MAPPING,
     MSG_GLOBAL_VAR_SYNC,
     MSG_ROOM_TRANSFORM,
+    TransformData,
+    Vector3,
     deserialize,
     serialize_client_transform,
     serialize_client_var_set,
@@ -143,44 +145,24 @@ class TestClient:
 
         # Build transform data
         transform_data = {
-            'deviceId': self.device_id,
-            'physical': {
-                'posX': self.position_x,
-                'posY': 0,
-                'posZ': self.position_z,
-                'rotX': 0,
-                'rotY': self.rotation_y,
-                'rotZ': 0,
-                'isLocalSpace': True
-            },
-            'head': {
-                'posX': self.position_x,
-                'posY': 1.6,  # Head height
-                'posZ': self.position_z,
-                'rotX': 0,
-                'rotY': self.rotation_y,
-                'rotZ': 0,
-                'isLocalSpace': False
-            },
-            'rightHand': {
-                'posX': self.position_x + 0.3,
-                'posY': 1.2,
-                'posZ': self.position_z,
-                'rotX': 0,
-                'rotY': 0,
-                'rotZ': 0,
-                'isLocalSpace': False
-            },
-            'leftHand': {
-                'posX': self.position_x - 0.3,
-                'posY': 1.2,
-                'posZ': self.position_z,
-                'rotX': 0,
-                'rotY': 0,
-                'rotZ': 0,
-                'isLocalSpace': False
-            },
-            'virtuals': []  # No virtual objects for this test
+            "deviceId": self.device_id,
+            "physical": TransformData(
+                position=Vector3(self.position_x, 0, self.position_z),
+                rotation=Vector3(0, self.rotation_y, 0),
+            ),
+            "head": TransformData(
+                position=Vector3(self.position_x, 1.6, self.position_z),
+                rotation=Vector3(0, self.rotation_y, 0),
+            ),
+            "rightHand": TransformData(
+                position=Vector3(self.position_x + 0.3, 1.2, self.position_z),
+                rotation=Vector3(0, 0, 0),
+            ),
+            "leftHand": TransformData(
+                position=Vector3(self.position_x - 0.3, 1.2, self.position_z),
+                rotation=Vector3(0, 0, 0),
+            ),
+            "virtuals": [],
         }
 
         # Serialize and send

--- a/STYLY-NetSync-Server/tests/integration/test_stealth_mode.py
+++ b/STYLY-NetSync-Server/tests/integration/test_stealth_mode.py
@@ -19,10 +19,9 @@ def create_stealth_handshake(device_id: str) -> bytes:
     buffer.append(len(device_id_bytes))
     buffer.extend(device_id_bytes)
 
-    # Physical transform with NaN values (3 floats)
-    buffer.extend(struct.pack('<f', float('nan')))  # posX
-    buffer.extend(struct.pack('<f', float('nan')))  # posZ
-    buffer.extend(struct.pack('<f', float('nan')))  # rotY
+    # Physical transform with NaN values (6 floats)
+    for _ in range(6):
+        buffer.extend(struct.pack('<f', float('nan')))
 
     # Head transform with NaN values (6 floats)
     for _ in range(6):

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal/BinarySerializer.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal/BinarySerializer.cs
@@ -19,89 +19,57 @@ namespace Styly.NetSync
         public const byte MSG_CLIENT_VAR_SET = 9;  // Set client variable
         public const byte MSG_CLIENT_VAR_SYNC = 10;  // Sync client variables
 
-        // Transform data type identifiers
-        private const byte TRANSFORM_PHYSICAL = 1;  // 3 floats: posX, posZ, rotY
-        private const byte TRANSFORM_VIRTUAL = 2;   // 6 floats: full transform
-
         #region === Serialization ===
+
+        private static void WriteTransformData(BinaryWriter writer, TransformData data)
+        {
+            data ??= new TransformData();
+            writer.Write(data.position.x);
+            writer.Write(data.position.y);
+            writer.Write(data.position.z);
+            writer.Write(data.rotation.x);
+            writer.Write(data.rotation.y);
+            writer.Write(data.rotation.z);
+        }
 
         public static byte[] SerializeClientTransform(ClientTransformData data)
         {
-            using (var ms = new MemoryStream())
-            using (var writer = new BinaryWriter(ms))
+            using var ms = new MemoryStream();
+            using var writer = new BinaryWriter(ms);
+
+            // Message type
+            writer.Write(MSG_CLIENT_TRANSFORM);
+
+            // Device ID (as UTF8 bytes with length prefix)
+            var deviceIdBytes = System.Text.Encoding.UTF8.GetBytes(data.deviceId ?? string.Empty);
+            writer.Write((byte)deviceIdBytes.Length);
+            writer.Write(deviceIdBytes);
+
+            // Physical transform (full 6 floats)
+            WriteTransformData(writer, data.physical);
+
+            // Head transform
+            WriteTransformData(writer, data.head);
+
+            // Right hand transform
+            WriteTransformData(writer, data.rightHand);
+
+            // Left hand transform
+            WriteTransformData(writer, data.leftHand);
+
+            // Virtual transforms
+            var virtualCount = data.virtuals?.Count ?? 0;
+            if (virtualCount > MAX_VIRTUAL_TRANSFORMS)
             {
-                // Message type
-                writer.Write(MSG_CLIENT_TRANSFORM);
-
-                // Device ID (as UTF8 bytes with length prefix)
-                var deviceIdBytes = System.Text.Encoding.UTF8.GetBytes(data.deviceId);
-                writer.Write((byte)deviceIdBytes.Length);
-                writer.Write(deviceIdBytes);
-
-                // Note: Client number is not sent by client, only assigned by server
-
-                // Physical transform (optimized: 3 floats only)
-                {
-                    writer.Write(data.physical.posX);
-                    writer.Write(data.physical.posZ);
-                    writer.Write(data.physical.rotY);
-                }
-
-                // Head transform
-                {
-                    writer.Write(data.head.posX);
-                    writer.Write(data.head.posY);
-                    writer.Write(data.head.posZ);
-                    writer.Write(data.head.rotX);
-                    writer.Write(data.head.rotY);
-                    writer.Write(data.head.rotZ);
-                }
-
-                // Right hand transform
-                {
-                    writer.Write(data.rightHand.posX);
-                    writer.Write(data.rightHand.posY);
-                    writer.Write(data.rightHand.posZ);
-                    writer.Write(data.rightHand.rotX);
-                    writer.Write(data.rightHand.rotY);
-                    writer.Write(data.rightHand.rotZ);
-                }
-
-                // Left hand transform
-                {
-                    writer.Write(data.leftHand.posX);
-                    writer.Write(data.leftHand.posY);
-                    writer.Write(data.leftHand.posZ);
-                    writer.Write(data.leftHand.rotX);
-                    writer.Write(data.leftHand.rotY);
-                    writer.Write(data.leftHand.rotZ);
-                }
-
-                // Virtual transforms count
-                var virtualCount = data.virtuals?.Count ?? 0;
-                if (virtualCount > MAX_VIRTUAL_TRANSFORMS)
-                {
-                    virtualCount = MAX_VIRTUAL_TRANSFORMS;
-                }
-                writer.Write((byte)virtualCount);
-
-                // Virtual transforms (always full 6DOF)
-                if (data.virtuals != null && virtualCount > 0)
-                {
-                    for (int i = 0; i < virtualCount; i++)
-                    {
-                        var vt = data.virtuals[i];
-                        writer.Write(vt.posX);
-                        writer.Write(vt.posY);
-                        writer.Write(vt.posZ);
-                        writer.Write(vt.rotX);
-                        writer.Write(vt.rotY);
-                        writer.Write(vt.rotZ);
-                    }
-                }
-
-                return ms.ToArray();
+                virtualCount = MAX_VIRTUAL_TRANSFORMS;
             }
+            writer.Write((byte)virtualCount);
+            for (int i = 0; i < virtualCount; i++)
+            {
+                WriteTransformData(writer, data.virtuals[i]);
+            }
+
+            return ms.ToArray();
         }
 
         public static byte[] SerializeStealthHandshake(string deviceId)
@@ -118,12 +86,13 @@ namespace Styly.NetSync
                 writer.Write(deviceIdBytes);
 
                 // Physical transform with NaN values (stealth mode indicator)
-                writer.Write(float.NaN); // posX
-                writer.Write(float.NaN); // posZ
-                writer.Write(float.NaN); // rotY
+                for (int i = 0; i < 6; i++)
+                {
+                    writer.Write(float.NaN);
+                }
 
                 // Head transform (NaN values)
-                for (int i = 0; i < 6; i++) // posX, posY, posZ, rotX, rotY, rotZ
+                for (int i = 0; i < 6; i++)
                 {
                     writer.Write(float.NaN);
                 }
@@ -204,6 +173,15 @@ namespace Styly.NetSync
         }
 
 
+        private static TransformData ReadTransformData(BinaryReader reader)
+        {
+            return new TransformData
+            {
+                position = new Vector3(reader.ReadSingle(), reader.ReadSingle(), reader.ReadSingle()),
+                rotation = new Vector3(reader.ReadSingle(), reader.ReadSingle(), reader.ReadSingle())
+            };
+        }
+
         private static RoomTransformData DeserializeRoomTransform(BinaryReader reader)
         {
             var data = new RoomTransformData();
@@ -225,71 +203,31 @@ namespace Styly.NetSync
                 client.clientNo = reader.ReadUInt16();
 
                 // Note: Device ID is no longer sent in MSG_ROOM_TRANSFORM
-                // Device ID will be resolved from client number using mapping table
 
-                // Physical transform
-                {
-                    var posX = reader.ReadSingle();
-                    var posZ = reader.ReadSingle();
-                    var rotY = reader.ReadSingle();
-                    client.physical = new Transform3D(posX, 0, posZ, 0, rotY, 0, true);
-                }
+                // Physical transform (local space)
+                client.physical = ReadTransformData(reader);
 
                 // Head transform
-                {
-                    var posX = reader.ReadSingle();
-                    var posY = reader.ReadSingle();
-                    var posZ = reader.ReadSingle();
-                    var rotX = reader.ReadSingle();
-                    var rotY = reader.ReadSingle();
-                    var rotZ = reader.ReadSingle();
-                    client.head = new Transform3D(posX, posY, posZ, rotX, rotY, rotZ, false);
-                }
+                client.head = ReadTransformData(reader);
 
                 // Right hand transform
-                {
-                    var posX = reader.ReadSingle();
-                    var posY = reader.ReadSingle();
-                    var posZ = reader.ReadSingle();
-                    var rotX = reader.ReadSingle();
-                    var rotY = reader.ReadSingle();
-                    var rotZ = reader.ReadSingle();
-                    client.rightHand = new Transform3D(posX, posY, posZ, rotX, rotY, rotZ, false);
-                }
+                client.rightHand = ReadTransformData(reader);
 
                 // Left hand transform
-                {
-                    var posX = reader.ReadSingle();
-                    var posY = reader.ReadSingle();
-                    var posZ = reader.ReadSingle();
-                    var rotX = reader.ReadSingle();
-                    var rotY = reader.ReadSingle();
-                    var rotZ = reader.ReadSingle();
-                    client.leftHand = new Transform3D(posX, posY, posZ, rotX, rotY, rotZ, false);
-                }
+                client.leftHand = ReadTransformData(reader);
 
                 // Virtual transforms
                 var virtualCount = reader.ReadByte();
 
-                // Validate virtual count to prevent memory issues
                 if (virtualCount > MAX_VIRTUAL_TRANSFORMS)
                 {
                     virtualCount = MAX_VIRTUAL_TRANSFORMS;
                 }
 
-                if (virtualCount > 0)
+                client.virtuals = new List<TransformData>();
+                for (int j = 0; j < virtualCount; j++)
                 {
-                    client.virtuals = new List<Transform3D>(virtualCount);
-                    for (int j = 0; j < virtualCount; j++)
-                    {
-                        var posX = reader.ReadSingle();
-                        var posY = reader.ReadSingle();
-                        var posZ = reader.ReadSingle();
-                        var rotX = reader.ReadSingle();
-                        var rotY = reader.ReadSingle();
-                        var rotZ = reader.ReadSingle();
-                        client.virtuals.Add(new Transform3D(posX, posY, posZ, rotX, rotY, rotZ, false));
-                    }
+                    client.virtuals.Add(ReadTransformData(reader));
                 }
 
                 data.clients.Add(client);
@@ -305,28 +243,14 @@ namespace Styly.NetSync
         public static int CalculateClientTransformSize(ClientTransformData data)
         {
             int size = 1; // Message type
-            size += 1 + System.Text.Encoding.UTF8.GetByteCount(data.deviceId); // Device ID
+            size += 1 + System.Text.Encoding.UTF8.GetByteCount(data.deviceId ?? string.Empty); // Device ID
 
-            // Physical transform
-            if (data.physical != null && data.physical.isLocalSpace)
-            {
-                size += 1 + 12; // Type + 3 floats
-            }
-            else if (data.physical != null)
-            {
-                size += 1 + 24; // Type + 6 floats
-            }
-            else
-            {
-                size += 1; // Just type (0)
-            }
+            // Four transforms: physical + head + right hand + left hand (each 6 floats)
+            size += 24 * 4;
 
             // Virtual transforms
-            size += 1; // Count
-            if (data.virtuals != null)
-            {
-                size += data.virtuals.Count * 24; // 6 floats each
-            }
+            int virtualCount = data.virtuals?.Count ?? 0;
+            size += 1 + virtualCount * 24;
 
             return size;
         }

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal/DataStructure.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal/DataStructure.cs
@@ -5,31 +5,12 @@ using UnityEngine;
 
 namespace Styly.NetSync
 {
-    // Unified transform data structure (supports both local and world coordinates)
+    // Simple transform data using Vector3 for position and rotation (Euler angles)
     [Serializable]
-    public class Transform3D
+    public class TransformData
     {
-        public float posX;
-        public float posY;
-        public float posZ;
-        public float rotX;
-        public float rotY;
-        public float rotZ;
-        public bool isLocalSpace; // true for local/physical, false for world/virtual
-
-        public Transform3D() { }
-
-        // Constructor for virtual/world transforms (full 6DOF)
-        public Transform3D(float x, float y, float z, float rotX, float rotY, float rotZ, bool local = false)
-        {
-            posX = x;
-            posY = y;
-            posZ = z;
-            this.rotX = rotX;
-            this.rotY = rotY;
-            this.rotZ = rotZ;
-            isLocalSpace = local;
-        }
+        public Vector3 position;
+        public Vector3 rotation;
     }
 
     // Client transform data using unified structure
@@ -38,11 +19,11 @@ namespace Styly.NetSync
     {
         public string deviceId;
         public int clientNo;  // Client number assigned by server (0 if not assigned)
-        public Transform3D physical;
-        public Transform3D head;
-        public Transform3D rightHand;
-        public Transform3D leftHand;
-        public List<Transform3D> virtuals;
+        public TransformData physical;
+        public TransformData head;
+        public TransformData rightHand;
+        public TransformData leftHand;
+        public List<TransformData> virtuals;
     }
 
     // Room data from server

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/NetSyncAvatar.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/NetSyncAvatar.cs
@@ -38,11 +38,10 @@ namespace Styly.NetSync
         public bool IsLocalAvatar { get; private set; }
 
         // Variables for interpolation
-        private Transform3D _targetPhysical;
-        private Transform3D _targetHead;
-        private Transform3D _targetRightHand;
-        private Transform3D _targetLeftHand;
-        private List<Transform3D> _targetVirtuals = new List<Transform3D>();
+        private TransformData _targetHead;
+        private TransformData _targetRightHand;
+        private TransformData _targetLeftHand;
+        private List<TransformData> _targetVirtuals = new List<TransformData>();
         private bool _hasTargetData = false;
 
         // Reference to NetSyncManager
@@ -95,14 +94,13 @@ namespace Styly.NetSync
             if (!isLocalAvatar)
             {
                 // For remote players, set initial data for interpolation
-                _targetPhysical = new Transform3D();
-                _targetHead = new Transform3D();
-                _targetRightHand = new Transform3D();
-                _targetLeftHand = new Transform3D();
+                _targetHead = new TransformData();
+                _targetRightHand = new TransformData();
+                _targetLeftHand = new TransformData();
                 _targetVirtuals.Clear();
                 for (int i = 0; i < _virtualTransforms.Length; i++)
                 {
-                    _targetVirtuals.Add(new Transform3D());
+                    _targetVirtuals.Add(new TransformData());
                 }
             }
         }
@@ -116,14 +114,13 @@ namespace Styly.NetSync
             _netSyncManager = manager;
 
             // For remote players, set initial data for interpolation
-            _targetPhysical = new Transform3D();
-            _targetHead = new Transform3D();
-            _targetRightHand = new Transform3D();
-            _targetLeftHand = new Transform3D();
+            _targetHead = new TransformData();
+            _targetRightHand = new TransformData();
+            _targetLeftHand = new TransformData();
             _targetVirtuals.Clear();
             for (int i = 0; i < _virtualTransforms.Length; i++)
             {
-                _targetVirtuals.Add(new Transform3D());
+                _targetVirtuals.Add(new TransformData());
             }
         }
 
@@ -160,11 +157,11 @@ namespace Styly.NetSync
             {
                 deviceId = _deviceId,
                 clientNo = _clientNo,
-                physical = ConvertToTransform3D(_physicalTransform, true),
-                head = ConvertToTransform3D(_head, false),
-                rightHand = ConvertToTransform3D(_rightHand, false),
-                leftHand = ConvertToTransform3D(_leftHand, false),
-                virtuals = ConvertToTransform3DList(_virtualTransforms, false)
+                physical = ConvertToTransformData(_physicalTransform, true),
+                head = ConvertToTransformData(_head, false),
+                rightHand = ConvertToTransformData(_rightHand, false),
+                leftHand = ConvertToTransformData(_leftHand, false),
+                virtuals = ConvertToTransformDataList(_virtualTransforms, false)
             };
         }
 
@@ -182,44 +179,33 @@ namespace Styly.NetSync
         {
             if (IsLocalAvatar) { return; }
 
+            // Physical transform (local space)
+            if (_physicalTransform != null && data.physical != null)
+            {
+                _physicalPosition = data.physical.position;
+                _physicalRotation = data.physical.rotation;
+                _physicalTransform.localPosition = _physicalPosition;
+                _physicalTransform.localRotation = Quaternion.Euler(_physicalRotation);
+            }
+
             // If this is the first data received, immediately set position to avoid interpolation from origin
             if (!_hasTargetData)
             {
-                // Set physical transform immediately
-                if (_physicalTransform != null && data.physical != null)
-                {
-                    _physicalPosition = new Vector3(data.physical.posX, data.physical.posY, data.physical.posZ);
-                    Vector3 newPhysicalPosition = new Vector3(data.physical.posX, data.physical.posY, data.physical.posZ);
-                    Vector3 newPhysicalRotation = new Vector3(data.physical.rotX, data.physical.rotY, data.physical.rotZ);
-                    _physicalPosition = newPhysicalPosition;
-                    _physicalRotation = newPhysicalRotation;
-                    _physicalTransform.localPosition = newPhysicalPosition;
-                    _physicalTransform.localEulerAngles = newPhysicalRotation;
-                    _physicalTransform.localPosition = _physicalPosition;
-                    _physicalTransform.localEulerAngles = _physicalRotation;
-                }
-
-                // Set head transform immediately
                 if (_head != null && data.head != null)
                 {
-                    _head.position = new Vector3(data.head.posX, data.head.posY, data.head.posZ);
-                    _head.rotation = Quaternion.Euler(data.head.rotX, data.head.rotY, data.head.rotZ);
+                    _head.position = data.head.position;
+                    _head.rotation = Quaternion.Euler(data.head.rotation);
                 }
-
-                // Set hand transforms immediately
                 if (_rightHand != null && data.rightHand != null)
                 {
-                    _rightHand.position = new Vector3(data.rightHand.posX, data.rightHand.posY, data.rightHand.posZ);
-                    _rightHand.rotation = Quaternion.Euler(data.rightHand.rotX, data.rightHand.rotY, data.rightHand.rotZ);
+                    _rightHand.position = data.rightHand.position;
+                    _rightHand.rotation = Quaternion.Euler(data.rightHand.rotation);
                 }
-
                 if (_leftHand != null && data.leftHand != null)
                 {
-                    _leftHand.position = new Vector3(data.leftHand.posX, data.leftHand.posY, data.leftHand.posZ);
-                    _leftHand.rotation = Quaternion.Euler(data.leftHand.rotX, data.leftHand.rotY, data.leftHand.rotZ);
+                    _leftHand.position = data.leftHand.position;
+                    _leftHand.rotation = Quaternion.Euler(data.leftHand.rotation);
                 }
-
-                // Set virtual transforms immediately
                 if (_virtualTransforms != null && data.virtuals != null)
                 {
                     int count = Mathf.Min(_virtualTransforms.Length, data.virtuals.Count);
@@ -227,9 +213,8 @@ namespace Styly.NetSync
                     {
                         if (_virtualTransforms[i] != null && data.virtuals[i] != null)
                         {
-                            var vt = data.virtuals[i];
-                            _virtualTransforms[i].position = new Vector3(vt.posX, vt.posY, vt.posZ);
-                            _virtualTransforms[i].rotation = Quaternion.Euler(vt.rotX, vt.rotY, vt.rotZ);
+                            _virtualTransforms[i].position = data.virtuals[i].position;
+                            _virtualTransforms[i].rotation = Quaternion.Euler(data.virtuals[i].rotation);
                         }
                     }
                 }
@@ -240,85 +225,55 @@ namespace Styly.NetSync
             _targetLeftHand = data.leftHand;
             _targetVirtuals = data.virtuals;
             _hasTargetData = true;
-            _physicalPosition = new Vector3(data.physical.posX, data.physical.posY, data.physical.posZ);
-            _physicalRotation = new Vector3(data.physical.rotX, data.physical.rotY, data.physical.rotZ);
 
             // Update client number for remote players
             _clientNo = data.clientNo;
         }
 
-        // Unified transform conversion method
-        // isLocalSpace: whether to read from local space (physical) vs world space (virtual)
-        private Transform3D ConvertToTransform3D(Transform transform, bool isLocalSpace)
+        // Convert Transform to TransformData
+        private TransformData ConvertToTransformData(Transform transform, bool isLocal)
         {
-            if (transform == null) { return new Transform3D(); }
-
-            if (isLocalSpace)
+            if (transform == null) return new TransformData();
+            return new TransformData
             {
-                // Physical/local transform (XZ position, Y rotation only)
-                return new Transform3D(
-                    transform.localPosition.x,
-                    0,
-                    transform.localPosition.z,
-                    0,
-                    transform.localEulerAngles.y,
-                    0,
-                    true
-                );
-            }
-            else
-            {
-                // Virtual/world transform (full 6DOF)
-                return new Transform3D(
-                    transform.position.x,
-                    transform.position.y,
-                    transform.position.z,
-                    transform.eulerAngles.x,
-                    transform.eulerAngles.y,
-                    transform.eulerAngles.z,
-                    false
-                );
-            }
+                position = isLocal ? transform.localPosition : transform.position,
+                rotation = isLocal ? transform.localEulerAngles : transform.eulerAngles
+            };
         }
 
-        // Convert transform array to Transform3D list
-        private List<Transform3D> ConvertToTransform3DList(Transform[] transforms, bool isLocalSpace)
+        // Convert transform array to TransformData list
+        private List<TransformData> ConvertToTransformDataList(Transform[] transforms, bool isLocal)
         {
-            var result = new List<Transform3D>();
+            var result = new List<TransformData>();
             if (transforms != null)
             {
                 foreach (var t in transforms)
                 {
                     if (t != null)
                     {
-                        result.Add(ConvertToTransform3D(t, isLocalSpace));
+                        result.Add(ConvertToTransformData(t, isLocal));
                     }
                 }
             }
             return result;
         }
 
-        // Simplified transform interpolation
+        // Simplified transform interpolation (world space)
         private void InterpolateTransforms()
         {
             float deltaTime = Time.deltaTime * _interpolationSpeed;
-            // Head Transform interpolation (world space)
             if (_head != null && _targetHead != null)
             {
-                InterpolateSingleTransform(_head, _targetHead, deltaTime, false);
+                InterpolateSingleTransform(_head, _targetHead, deltaTime);
             }
-            // Right Hand Transform interpolation (world space)
             if (_rightHand != null && _targetRightHand != null)
             {
-                InterpolateSingleTransform(_rightHand, _targetRightHand, deltaTime, false);
+                InterpolateSingleTransform(_rightHand, _targetRightHand, deltaTime);
             }
-            // Left Hand Transform interpolation (world space)
             if (_leftHand != null && _targetLeftHand != null)
             {
-                InterpolateSingleTransform(_leftHand, _targetLeftHand, deltaTime, false);
+                InterpolateSingleTransform(_leftHand, _targetLeftHand, deltaTime);
             }
-
-            // Virtual Transforms interpolation (world space)
             if (_virtualTransforms != null && _targetVirtuals != null)
             {
                 int count = Mathf.Min(_virtualTransforms.Length, _targetVirtuals.Count);
@@ -326,31 +281,19 @@ namespace Styly.NetSync
                 {
                     if (_virtualTransforms[i] != null)
                     {
-                        InterpolateSingleTransform(_virtualTransforms[i], _targetVirtuals[i], deltaTime, false);
+                        InterpolateSingleTransform(_virtualTransforms[i], _targetVirtuals[i], deltaTime);
                     }
                 }
             }
         }
 
-        // Unified interpolation method for any transform
-        // isLocalSpace: interpolate using localPosition/localRotation vs world position/rotation
-        private void InterpolateSingleTransform(Transform transform, Transform3D target, float deltaTime, bool isLocalSpace)
+        // Unified interpolation method for any transform (world space)
+        private void InterpolateSingleTransform(Transform transform, TransformData target, float deltaTime)
         {
-            Vector3 targetPos = isLocalSpace
-                ? new Vector3(target.posX, transform.localPosition.y, target.posZ)
-                : new Vector3(target.posX, target.posY, target.posZ);
-            Quaternion targetRot = Quaternion.Euler(target.rotX, target.rotY, target.rotZ);
-
-            if (isLocalSpace)
-            {
-                transform.localPosition = Vector3.Lerp(transform.localPosition, targetPos, deltaTime);
-                transform.localRotation = Quaternion.Lerp(transform.localRotation, targetRot, deltaTime);
-            }
-            else
-            {
-                transform.position = Vector3.Lerp(transform.position, targetPos, deltaTime);
-                transform.rotation = Quaternion.Lerp(transform.rotation, targetRot, deltaTime);
-            }
+            Vector3 targetPos = target.position;
+            Quaternion targetRot = Quaternion.Euler(target.rotation);
+            transform.position = Vector3.Lerp(transform.position, targetPos, deltaTime);
+            transform.rotation = Quaternion.Lerp(transform.rotation, targetRot, deltaTime);
         }
 
         // Handle client variable changes from NetSyncManager


### PR DESCRIPTION
## Summary
- replace Transform3D with TransformData using Vector3 for position and rotation
- serialize all transforms as 6 floats and remove isLocalSpace flag
- update Python serializer, client simulator, and tests for new format

## Testing
- `pytest -q` *(fails: KeyboardInterrupt)*
- `pytest tests/test_all_run_methods.py::TestAllRunMethods::test_server_cli_entry_point_help -q` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689d5fd4314c83288a86755e1e4c58bd