### PR TITLE
Refactor transform sync to full position/rotation

### DIFF
--- a/STYLY-NetSync-Server/src/styly_netsync/binary_serializer.py
+++ b/STYLY-NetSync-Server/src/styly_netsync/binary_serializer.py
@@ -1,5 +1,6 @@
 import math
 import struct
+from dataclasses import dataclass, field
 from typing import Any, Dict, List, Tuple, Union
 
 # Message type identifiers
@@ -14,57 +15,50 @@ MSG_GLOBAL_VAR_SYNC = 8  # Sync global variables
 MSG_CLIENT_VAR_SET = 9  # Set client variable
 MSG_CLIENT_VAR_SYNC = 10  # Sync client variables
 
-# Transform data type identifiers
-TRANSFORM_PHYSICAL = 1  # 3 floats: posX, posZ, rotY
-TRANSFORM_VIRTUAL = 2   # 6 floats: full transform
-
 # Maximum allowed virtual transforms to prevent memory issues
 MAX_VIRTUAL_TRANSFORMS = 50
 
+
+@dataclass
+class Vector3:
+    x: float = 0.0
+    y: float = 0.0
+    z: float = 0.0
+
+
+@dataclass
+class TransformData:
+    position: Vector3 = field(default_factory=Vector3)
+    rotation: Vector3 = field(default_factory=Vector3)
+
 # Stealth mode detection utilities
+def _all_nan(data: TransformData) -> bool:
+    return all(
+        math.isnan(v)
+        for v in [
+            data.position.x,
+            data.position.y,
+            data.position.z,
+            data.rotation.x,
+            data.rotation.y,
+            data.rotation.z,
+        ]
+    )
+
+
 def _is_nan_transform(transform: Dict[str, Any]) -> bool:
     """Check if a transform contains all NaN values (stealth mode indicator)"""
-    # Check physical transform (posX, posZ, rotY)
-    physical = transform.get('physical', {})
-    if not physical:
+    physical = transform.get("physical")
+    if not isinstance(physical, TransformData) or not _all_nan(physical):
         return False
 
-    # All physical values must be NaN
-    if not (math.isnan(physical.get('posX', 0)) and
-            math.isnan(physical.get('posZ', 0)) and
-            math.isnan(physical.get('rotY', 0))):
-        return False
-
-    # Check head transform (all 6 values must be NaN)
-    head = transform.get('head', {})
-    if not head:
-        return False
-    for key in ['posX', 'posY', 'posZ', 'rotX', 'rotY', 'rotZ']:
-        if not math.isnan(head.get(key, 0)):
+    for key in ["head", "rightHand", "leftHand"]:
+        t = transform.get(key)
+        if not isinstance(t, TransformData) or not _all_nan(t):
             return False
 
-    # Check right hand transform (all 6 values must be NaN)
-    right_hand = transform.get('rightHand', {})
-    if not right_hand:
-        return False
-    for key in ['posX', 'posY', 'posZ', 'rotX', 'rotY', 'rotZ']:
-        if not math.isnan(right_hand.get(key, 0)):
-            return False
-
-    # Check left hand transform (all 6 values must be NaN)
-    left_hand = transform.get('leftHand', {})
-    if not left_hand:
-        return False
-    for key in ['posX', 'posY', 'posZ', 'rotX', 'rotY', 'rotZ']:
-        if not math.isnan(left_hand.get(key, 0)):
-            return False
-
-    # Check virtuals count is 0
-    virtuals = transform.get('virtuals', [])
-    if len(virtuals) != 0:
-        return False
-
-    return True
+    virtuals = transform.get("virtuals", [])
+    return len(virtuals) == 0
 
 def _is_stealth_client(data: Dict[str, Any]) -> bool:
     """Check if client data indicates stealth mode (NaN handshake)"""
@@ -91,49 +85,35 @@ def _unpack_string(data: bytes, offset: int, use_ushort: bool = False) -> Tuple[
     string = data[offset:offset+length].decode('utf-8')
     return string, offset + length
 
-def _pack_transform(buffer: bytearray, transform: Dict[str, Any], keys: List[str]) -> None:
-    """Pack a transform with specified keys"""
-    for key in keys:
-        buffer.extend(struct.pack('<f', transform.get(key, 0)))
 
-def _unpack_transform(data: bytes, offset: int, keys: List[str], is_local_space: bool = False) -> Tuple[Dict[str, Any], int]:
-    """Unpack a transform with specified keys"""
-    transform = {'isLocalSpace': is_local_space}
-    for key in keys:
-        value = struct.unpack('<f', data[offset:offset+4])[0]
-        transform[key] = value
-        offset += 4
-    return transform, offset
+def serialize_transform_data(buffer: bytearray, data: TransformData) -> None:
+    buffer.extend(struct.pack('<f', data.position.x))
+    buffer.extend(struct.pack('<f', data.position.y))
+    buffer.extend(struct.pack('<f', data.position.z))
+    buffer.extend(struct.pack('<f', data.rotation.x))
+    buffer.extend(struct.pack('<f', data.rotation.y))
+    buffer.extend(struct.pack('<f', data.rotation.z))
 
-def _pack_full_transform(buffer: bytearray, transform: Dict[str, Any]) -> None:
-    """Pack a full 6-float transform"""
-    _pack_transform(buffer, transform, ['posX', 'posY', 'posZ', 'rotX', 'rotY', 'rotZ'])
 
-def _unpack_full_transform(data: bytes, offset: int, is_local_space: bool = False) -> Tuple[Dict[str, Any], int]:
-    """Unpack a full 6-float transform"""
-    return _unpack_transform(data, offset, ['posX', 'posY', 'posZ', 'rotX', 'rotY', 'rotZ'], is_local_space)
+def deserialize_transform_data(data: bytes, offset: int) -> Tuple[TransformData, int]:
+    px, py, pz, rx, ry, rz = struct.unpack_from('<ffffff', data, offset)
+    offset += 24
+    return TransformData(Vector3(px, py, pz), Vector3(rx, ry, rz)), offset
 
 def _serialize_client_data(buffer: bytearray, client: Dict[str, Any]) -> None:
     """Serialize a single client's data (shared by room transform and client transform)"""
-    # Device ID
-    _pack_string(buffer, client.get('deviceId', ''))
+    _pack_string(buffer, client.get("deviceId", ""))
 
-    # Physical transform (special case: only 3 values)
-    physical = client.get('physical', {})
-    _pack_transform(buffer, physical, ['posX', 'posZ', 'rotY'])
+    serialize_transform_data(buffer, client.get("physical", TransformData()))
+    serialize_transform_data(buffer, client.get("head", TransformData()))
+    serialize_transform_data(buffer, client.get("rightHand", TransformData()))
+    serialize_transform_data(buffer, client.get("leftHand", TransformData()))
 
-    # Head, Right hand, Left hand transforms
-    for transform_key in ['head', 'rightHand', 'leftHand']:
-        _pack_full_transform(buffer, client.get(transform_key, {}))
-
-    # Virtual transforms
-    virtuals = client.get('virtuals', [])
+    virtuals = client.get("virtuals", [])
     virtual_count = min(len(virtuals), MAX_VIRTUAL_TRANSFORMS)
-    # Limit virtual transforms to maximum allowed
     buffer.append(virtual_count)
-
     for i in range(virtual_count):
-        _pack_full_transform(buffer, virtuals[i])
+        serialize_transform_data(buffer, virtuals[i])
 
 def serialize_client_transform(data: Dict[str, Any]) -> bytes:
     """Serialize client transform data to binary format"""
@@ -173,26 +153,19 @@ def serialize_room_transform(data: Dict[str, Any]) -> bytes:
 
 def _serialize_client_data_short(buffer: bytearray, client: Dict[str, Any]) -> None:
     """Serialize a single client's data with client number only (2 bytes)"""
-    # Client number (2 bytes)
-    client_no = client.get('clientNo', 0)
+    client_no = client.get("clientNo", 0)
     buffer.extend(struct.pack('<H', client_no))
 
-    # Physical transform (special case: only 3 values)
-    physical = client.get('physical', {})
-    _pack_transform(buffer, physical, ['posX', 'posZ', 'rotY'])
+    serialize_transform_data(buffer, client.get("physical", TransformData()))
+    serialize_transform_data(buffer, client.get("head", TransformData()))
+    serialize_transform_data(buffer, client.get("rightHand", TransformData()))
+    serialize_transform_data(buffer, client.get("leftHand", TransformData()))
 
-    # Head, Right hand, Left hand transforms
-    for transform_key in ['head', 'rightHand', 'leftHand']:
-        _pack_full_transform(buffer, client.get(transform_key, {}))
-
-    # Virtual transforms
-    virtuals = client.get('virtuals', [])
+    virtuals = client.get("virtuals", [])
     virtual_count = min(len(virtuals), MAX_VIRTUAL_TRANSFORMS)
-    # Limit virtual transforms to maximum allowed
     buffer.append(virtual_count)
-
     for i in range(virtual_count):
-        _pack_full_transform(buffer, virtuals[i])
+        serialize_transform_data(buffer, virtuals[i])
 
 
 def _serialize_rpc_base(buffer: bytearray, data: Dict[str, Any], msg_type: int) -> None:
@@ -413,42 +386,21 @@ def deserialize(data: bytes) -> Tuple[int, Union[Dict[str, Any], None], bytes]:
 
 def _deserialize_client_transform(data: bytes, offset: int) -> Dict[str, Any]:
     """Deserialize client transform from binary data"""
-    result = {}
+    result: Dict[str, Any] = {}
+    result["deviceId"], offset = _unpack_string(data, offset)
+    result["physical"], offset = deserialize_transform_data(data, offset)
+    result["head"], offset = deserialize_transform_data(data, offset)
+    result["rightHand"], offset = deserialize_transform_data(data, offset)
+    result["leftHand"], offset = deserialize_transform_data(data, offset)
 
-    # Device ID
-    result['deviceId'], offset = _unpack_string(data, offset)
-
-    # Physical transform (special case with default values)
-    physical_values, offset = _unpack_transform(data, offset, ['posX', 'posZ', 'rotY'], is_local_space=True)
-    result['physical'] = {
-        'posX': physical_values['posX'],
-        'posY': 0,
-        'posZ': physical_values['posZ'],
-        'rotX': 0,
-        'rotY': physical_values['rotY'],
-        'rotZ': 0,
-        'isLocalSpace': True
-    }
-
-    # Head, Right hand, Left hand transforms
-    result['head'], offset = _unpack_full_transform(data, offset)
-    result['rightHand'], offset = _unpack_full_transform(data, offset)
-    result['leftHand'], offset = _unpack_full_transform(data, offset)
-
-    # Virtual transforms
     virtual_count = data[offset]
     offset += 1
-
-    # Validate virtual count to prevent memory issues
     if virtual_count > MAX_VIRTUAL_TRANSFORMS:
         virtual_count = MAX_VIRTUAL_TRANSFORMS
-
-    if virtual_count > 0:
-        result['virtuals'] = []
-        for _ in range(virtual_count):
-            vt, offset = _unpack_full_transform(data, offset)
-            result['virtuals'].append(vt)
-
+    result["virtuals"] = []
+    for _ in range(virtual_count):
+        vt, offset = deserialize_transform_data(data, offset)
+        result["virtuals"].append(vt)
     return result
 
 def _deserialize_rpc_message(data: bytes, offset: int) -> Dict[str, Any]:
@@ -499,36 +451,19 @@ def _deserialize_room_transform(data: bytes, offset: int) -> Dict[str, Any]:
         offset += 2
         client['clientNo'] = client_no
 
-        # Physical transform
-        physical_values, offset = _unpack_transform(data, offset, ['posX', 'posZ', 'rotY'], is_local_space=True)
-        client['physical'] = {
-            'posX': physical_values['posX'],
-            'posY': 0,
-            'posZ': physical_values['posZ'],
-            'rotX': 0,
-            'rotY': physical_values['rotY'],
-            'rotZ': 0,
-            'isLocalSpace': True
-        }
+        client['physical'], offset = deserialize_transform_data(data, offset)
+        client['head'], offset = deserialize_transform_data(data, offset)
+        client['rightHand'], offset = deserialize_transform_data(data, offset)
+        client['leftHand'], offset = deserialize_transform_data(data, offset)
 
-        # Head, Right hand, Left hand transforms
-        client['head'], offset = _unpack_full_transform(data, offset)
-        client['rightHand'], offset = _unpack_full_transform(data, offset)
-        client['leftHand'], offset = _unpack_full_transform(data, offset)
-
-        # Virtual transforms
         virtual_count = data[offset]
         offset += 1
-
-        # Validate virtual count to prevent memory issues
         if virtual_count > MAX_VIRTUAL_TRANSFORMS:
             virtual_count = MAX_VIRTUAL_TRANSFORMS
-
-        if virtual_count > 0:
-            client['virtuals'] = []
-            for _ in range(virtual_count):
-                vt, offset = _unpack_full_transform(data, offset)
-                client['virtuals'].append(vt)
+        client['virtuals'] = []
+        for _ in range(virtual_count):
+            vt, offset = deserialize_transform_data(data, offset)
+            client['virtuals'].append(vt)
 
         result['clients'].append(client)
 

--- a/STYLY-NetSync-Server/tests/integration/test_client.py
+++ b/STYLY-NetSync-Server/tests/integration/test_client.py
@@ -65,6 +65,8 @@ from styly_netsync.binary_serializer import (
     serialize_rpc_client_message,
     serialize_rpc_message,
     serialize_rpc_request,
+    TransformData,
+    Vector3,
 )
 
 # Configure logging
@@ -144,43 +146,11 @@ class TestClient:
         # Build transform data
         transform_data = {
             'deviceId': self.device_id,
-            'physical': {
-                'posX': self.position_x,
-                'posY': 0,
-                'posZ': self.position_z,
-                'rotX': 0,
-                'rotY': self.rotation_y,
-                'rotZ': 0,
-                'isLocalSpace': True
-            },
-            'head': {
-                'posX': self.position_x,
-                'posY': 1.6,  # Head height
-                'posZ': self.position_z,
-                'rotX': 0,
-                'rotY': self.rotation_y,
-                'rotZ': 0,
-                'isLocalSpace': False
-            },
-            'rightHand': {
-                'posX': self.position_x + 0.3,
-                'posY': 1.2,
-                'posZ': self.position_z,
-                'rotX': 0,
-                'rotY': 0,
-                'rotZ': 0,
-                'isLocalSpace': False
-            },
-            'leftHand': {
-                'posX': self.position_x - 0.3,
-                'posY': 1.2,
-                'posZ': self.position_z,
-                'rotX': 0,
-                'rotY': 0,
-                'rotZ': 0,
-                'isLocalSpace': False
-            },
-            'virtuals': []  # No virtual objects for this test
+            'physical': TransformData(position=Vector3(self.position_x, 0, self.position_z), rotation=Vector3(0, self.rotation_y, 0)),
+            'head': TransformData(position=Vector3(self.position_x, 1.6, self.position_z), rotation=Vector3(0, self.rotation_y, 0)),
+            'rightHand': TransformData(position=Vector3(self.position_x + 0.3, 1.2, self.position_z), rotation=Vector3(0, 0, 0)),
+            'leftHand': TransformData(position=Vector3(self.position_x - 0.3, 1.2, self.position_z), rotation=Vector3(0, 0, 0)),
+            'virtuals': []
         }
 
         # Serialize and send

--- a/STYLY-NetSync-Server/tests/integration/test_stealth_mode.py
+++ b/STYLY-NetSync-Server/tests/integration/test_stealth_mode.py
@@ -19,10 +19,9 @@ def create_stealth_handshake(device_id: str) -> bytes:
     buffer.append(len(device_id_bytes))
     buffer.extend(device_id_bytes)
 
-    # Physical transform with NaN values (3 floats)
-    buffer.extend(struct.pack('<f', float('nan')))  # posX
-    buffer.extend(struct.pack('<f', float('nan')))  # posZ
-    buffer.extend(struct.pack('<f', float('nan')))  # rotY
+    # Physical transform with NaN values (6 floats)
+    for _ in range(6):
+        buffer.extend(struct.pack('<f', float('nan')))
 
     # Head transform with NaN values (6 floats)
     for _ in range(6):

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal/BinarySerializer.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal/BinarySerializer.cs
@@ -19,89 +19,57 @@ namespace Styly.NetSync
         public const byte MSG_CLIENT_VAR_SET = 9;  // Set client variable
         public const byte MSG_CLIENT_VAR_SYNC = 10;  // Sync client variables
 
-        // Transform data type identifiers
-        private const byte TRANSFORM_PHYSICAL = 1;  // 3 floats: posX, posZ, rotY
-        private const byte TRANSFORM_VIRTUAL = 2;   // 6 floats: full transform
-
         #region === Serialization ===
+
+        private static void WriteTransformData(BinaryWriter writer, TransformData data)
+        {
+            var pos = data?.position ?? Vector3.zero;
+            var rot = data?.rotation ?? Vector3.zero;
+            writer.Write(pos.x);
+            writer.Write(pos.y);
+            writer.Write(pos.z);
+            writer.Write(rot.x);
+            writer.Write(rot.y);
+            writer.Write(rot.z);
+        }
 
         public static byte[] SerializeClientTransform(ClientTransformData data)
         {
-            using (var ms = new MemoryStream())
-            using (var writer = new BinaryWriter(ms))
+            using var ms = new MemoryStream();
+            using var writer = new BinaryWriter(ms);
+
+            // Message type
+            writer.Write(MSG_CLIENT_TRANSFORM);
+
+            // Device ID (as UTF8 bytes with length prefix)
+            var deviceIdBytes = System.Text.Encoding.UTF8.GetBytes(data.deviceId ?? "");
+            writer.Write((byte)deviceIdBytes.Length);
+            writer.Write(deviceIdBytes);
+
+            // Physical transform
+            WriteTransformData(writer, data.physical ?? new TransformData());
+
+            // Head transform
+            WriteTransformData(writer, data.head ?? new TransformData());
+
+            // Right hand transform
+            WriteTransformData(writer, data.rightHand ?? new TransformData());
+
+            // Left hand transform
+            WriteTransformData(writer, data.leftHand ?? new TransformData());
+
+            // Virtual transforms
+            var virtualCount = data.virtuals?.Count ?? 0;
+            writer.Write((byte)virtualCount);
+            if (virtualCount > 0)
             {
-                // Message type
-                writer.Write(MSG_CLIENT_TRANSFORM);
-
-                // Device ID (as UTF8 bytes with length prefix)
-                var deviceIdBytes = System.Text.Encoding.UTF8.GetBytes(data.deviceId);
-                writer.Write((byte)deviceIdBytes.Length);
-                writer.Write(deviceIdBytes);
-
-                // Note: Client number is not sent by client, only assigned by server
-
-                // Physical transform (optimized: 3 floats only)
+                for (int i = 0; i < virtualCount; i++)
                 {
-                    writer.Write(data.physical.posX);
-                    writer.Write(data.physical.posZ);
-                    writer.Write(data.physical.rotY);
+                    WriteTransformData(writer, data.virtuals[i] ?? new TransformData());
                 }
-
-                // Head transform
-                {
-                    writer.Write(data.head.posX);
-                    writer.Write(data.head.posY);
-                    writer.Write(data.head.posZ);
-                    writer.Write(data.head.rotX);
-                    writer.Write(data.head.rotY);
-                    writer.Write(data.head.rotZ);
-                }
-
-                // Right hand transform
-                {
-                    writer.Write(data.rightHand.posX);
-                    writer.Write(data.rightHand.posY);
-                    writer.Write(data.rightHand.posZ);
-                    writer.Write(data.rightHand.rotX);
-                    writer.Write(data.rightHand.rotY);
-                    writer.Write(data.rightHand.rotZ);
-                }
-
-                // Left hand transform
-                {
-                    writer.Write(data.leftHand.posX);
-                    writer.Write(data.leftHand.posY);
-                    writer.Write(data.leftHand.posZ);
-                    writer.Write(data.leftHand.rotX);
-                    writer.Write(data.leftHand.rotY);
-                    writer.Write(data.leftHand.rotZ);
-                }
-
-                // Virtual transforms count
-                var virtualCount = data.virtuals?.Count ?? 0;
-                if (virtualCount > MAX_VIRTUAL_TRANSFORMS)
-                {
-                    virtualCount = MAX_VIRTUAL_TRANSFORMS;
-                }
-                writer.Write((byte)virtualCount);
-
-                // Virtual transforms (always full 6DOF)
-                if (data.virtuals != null && virtualCount > 0)
-                {
-                    for (int i = 0; i < virtualCount; i++)
-                    {
-                        var vt = data.virtuals[i];
-                        writer.Write(vt.posX);
-                        writer.Write(vt.posY);
-                        writer.Write(vt.posZ);
-                        writer.Write(vt.rotX);
-                        writer.Write(vt.rotY);
-                        writer.Write(vt.rotZ);
-                    }
-                }
-
-                return ms.ToArray();
             }
+
+            return ms.ToArray();
         }
 
         public static byte[] SerializeStealthHandshake(string deviceId)
@@ -118,12 +86,13 @@ namespace Styly.NetSync
                 writer.Write(deviceIdBytes);
 
                 // Physical transform with NaN values (stealth mode indicator)
-                writer.Write(float.NaN); // posX
-                writer.Write(float.NaN); // posZ
-                writer.Write(float.NaN); // rotY
+                for (int i = 0; i < 6; i++)
+                {
+                    writer.Write(float.NaN);
+                }
 
                 // Head transform (NaN values)
-                for (int i = 0; i < 6; i++) // posX, posY, posZ, rotX, rotY, rotZ
+                for (int i = 0; i < 6; i++)
                 {
                     writer.Write(float.NaN);
                 }
@@ -204,6 +173,15 @@ namespace Styly.NetSync
         }
 
 
+        private static TransformData ReadTransformData(BinaryReader reader)
+        {
+            return new TransformData
+            {
+                position = new Vector3(reader.ReadSingle(), reader.ReadSingle(), reader.ReadSingle()),
+                rotation = new Vector3(reader.ReadSingle(), reader.ReadSingle(), reader.ReadSingle())
+            };
+        }
+
         private static RoomTransformData DeserializeRoomTransform(BinaryReader reader)
         {
             var data = new RoomTransformData();
@@ -224,72 +202,29 @@ namespace Styly.NetSync
                 // Client number (2 bytes)
                 client.clientNo = reader.ReadUInt16();
 
-                // Note: Device ID is no longer sent in MSG_ROOM_TRANSFORM
-                // Device ID will be resolved from client number using mapping table
-
                 // Physical transform
-                {
-                    var posX = reader.ReadSingle();
-                    var posZ = reader.ReadSingle();
-                    var rotY = reader.ReadSingle();
-                    client.physical = new Transform3D(posX, 0, posZ, 0, rotY, 0, true);
-                }
+                client.physical = ReadTransformData(reader);
 
                 // Head transform
-                {
-                    var posX = reader.ReadSingle();
-                    var posY = reader.ReadSingle();
-                    var posZ = reader.ReadSingle();
-                    var rotX = reader.ReadSingle();
-                    var rotY = reader.ReadSingle();
-                    var rotZ = reader.ReadSingle();
-                    client.head = new Transform3D(posX, posY, posZ, rotX, rotY, rotZ, false);
-                }
+                client.head = ReadTransformData(reader);
 
                 // Right hand transform
-                {
-                    var posX = reader.ReadSingle();
-                    var posY = reader.ReadSingle();
-                    var posZ = reader.ReadSingle();
-                    var rotX = reader.ReadSingle();
-                    var rotY = reader.ReadSingle();
-                    var rotZ = reader.ReadSingle();
-                    client.rightHand = new Transform3D(posX, posY, posZ, rotX, rotY, rotZ, false);
-                }
+                client.rightHand = ReadTransformData(reader);
 
                 // Left hand transform
-                {
-                    var posX = reader.ReadSingle();
-                    var posY = reader.ReadSingle();
-                    var posZ = reader.ReadSingle();
-                    var rotX = reader.ReadSingle();
-                    var rotY = reader.ReadSingle();
-                    var rotZ = reader.ReadSingle();
-                    client.leftHand = new Transform3D(posX, posY, posZ, rotX, rotY, rotZ, false);
-                }
+                client.leftHand = ReadTransformData(reader);
 
                 // Virtual transforms
                 var virtualCount = reader.ReadByte();
-
-                // Validate virtual count to prevent memory issues
                 if (virtualCount > MAX_VIRTUAL_TRANSFORMS)
                 {
                     virtualCount = MAX_VIRTUAL_TRANSFORMS;
                 }
 
-                if (virtualCount > 0)
+                client.virtuals = new List<TransformData>(virtualCount);
+                for (int j = 0; j < virtualCount; j++)
                 {
-                    client.virtuals = new List<Transform3D>(virtualCount);
-                    for (int j = 0; j < virtualCount; j++)
-                    {
-                        var posX = reader.ReadSingle();
-                        var posY = reader.ReadSingle();
-                        var posZ = reader.ReadSingle();
-                        var rotX = reader.ReadSingle();
-                        var rotY = reader.ReadSingle();
-                        var rotZ = reader.ReadSingle();
-                        client.virtuals.Add(new Transform3D(posX, posY, posZ, rotX, rotY, rotZ, false));
-                    }
+                    client.virtuals.Add(ReadTransformData(reader));
                 }
 
                 data.clients.Add(client);
@@ -305,29 +240,10 @@ namespace Styly.NetSync
         public static int CalculateClientTransformSize(ClientTransformData data)
         {
             int size = 1; // Message type
-            size += 1 + System.Text.Encoding.UTF8.GetByteCount(data.deviceId); // Device ID
-
-            // Physical transform
-            if (data.physical != null && data.physical.isLocalSpace)
-            {
-                size += 1 + 12; // Type + 3 floats
-            }
-            else if (data.physical != null)
-            {
-                size += 1 + 24; // Type + 6 floats
-            }
-            else
-            {
-                size += 1; // Just type (0)
-            }
-
-            // Virtual transforms
-            size += 1; // Count
-            if (data.virtuals != null)
-            {
-                size += data.virtuals.Count * 24; // 6 floats each
-            }
-
+            size += 1 + System.Text.Encoding.UTF8.GetByteCount(data.deviceId ?? "");
+            size += 24 * 4; // physical + head + right + left
+            size += 1; // virtual count
+            size += (data.virtuals?.Count ?? 0) * 24;
             return size;
         }
 

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal/DataStructure.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal/DataStructure.cs
@@ -5,31 +5,11 @@ using UnityEngine;
 
 namespace Styly.NetSync
 {
-    // Unified transform data structure (supports both local and world coordinates)
     [Serializable]
-    public class Transform3D
+    public class TransformData
     {
-        public float posX;
-        public float posY;
-        public float posZ;
-        public float rotX;
-        public float rotY;
-        public float rotZ;
-        public bool isLocalSpace; // true for local/physical, false for world/virtual
-
-        public Transform3D() { }
-
-        // Constructor for virtual/world transforms (full 6DOF)
-        public Transform3D(float x, float y, float z, float rotX, float rotY, float rotZ, bool local = false)
-        {
-            posX = x;
-            posY = y;
-            posZ = z;
-            this.rotX = rotX;
-            this.rotY = rotY;
-            this.rotZ = rotZ;
-            isLocalSpace = local;
-        }
+        public Vector3 position;
+        public Vector3 rotation; // Euler angles (x, y, z)
     }
 
     // Client transform data using unified structure
@@ -38,11 +18,11 @@ namespace Styly.NetSync
     {
         public string deviceId;
         public int clientNo;  // Client number assigned by server (0 if not assigned)
-        public Transform3D physical;
-        public Transform3D head;
-        public Transform3D rightHand;
-        public Transform3D leftHand;
-        public List<Transform3D> virtuals;
+        public TransformData physical;
+        public TransformData head;
+        public TransformData rightHand;
+        public TransformData leftHand;
+        public List<TransformData> virtuals;
     }
 
     // Room data from server

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/NetSyncAvatar.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/NetSyncAvatar.cs
@@ -1,6 +1,7 @@
 // NetSyncAvatar.cs
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using UnityEngine;
 using UnityEngine.Events;
 using UnityEngine.XR;
@@ -38,11 +39,11 @@ namespace Styly.NetSync
         public bool IsLocalAvatar { get; private set; }
 
         // Variables for interpolation
-        private Transform3D _targetPhysical;
-        private Transform3D _targetHead;
-        private Transform3D _targetRightHand;
-        private Transform3D _targetLeftHand;
-        private List<Transform3D> _targetVirtuals = new List<Transform3D>();
+        private TransformData _targetPhysical;
+        private TransformData _targetHead;
+        private TransformData _targetRightHand;
+        private TransformData _targetLeftHand;
+        private List<TransformData> _targetVirtuals = new List<TransformData>();
         private bool _hasTargetData = false;
 
         // Reference to NetSyncManager
@@ -95,14 +96,14 @@ namespace Styly.NetSync
             if (!isLocalAvatar)
             {
                 // For remote players, set initial data for interpolation
-                _targetPhysical = new Transform3D();
-                _targetHead = new Transform3D();
-                _targetRightHand = new Transform3D();
-                _targetLeftHand = new Transform3D();
+                _targetPhysical = new TransformData();
+                _targetHead = new TransformData();
+                _targetRightHand = new TransformData();
+                _targetLeftHand = new TransformData();
                 _targetVirtuals.Clear();
                 for (int i = 0; i < _virtualTransforms.Length; i++)
                 {
-                    _targetVirtuals.Add(new Transform3D());
+                    _targetVirtuals.Add(new TransformData());
                 }
             }
         }
@@ -116,14 +117,14 @@ namespace Styly.NetSync
             _netSyncManager = manager;
 
             // For remote players, set initial data for interpolation
-            _targetPhysical = new Transform3D();
-            _targetHead = new Transform3D();
-            _targetRightHand = new Transform3D();
-            _targetLeftHand = new Transform3D();
+            _targetPhysical = new TransformData();
+            _targetHead = new TransformData();
+            _targetRightHand = new TransformData();
+            _targetLeftHand = new TransformData();
             _targetVirtuals.Clear();
             for (int i = 0; i < _virtualTransforms.Length; i++)
             {
-                _targetVirtuals.Add(new Transform3D());
+                _targetVirtuals.Add(new TransformData());
             }
         }
 
@@ -160,11 +161,11 @@ namespace Styly.NetSync
             {
                 deviceId = _deviceId,
                 clientNo = _clientNo,
-                physical = ConvertToTransform3D(_physicalTransform, true),
-                head = ConvertToTransform3D(_head, false),
-                rightHand = ConvertToTransform3D(_rightHand, false),
-                leftHand = ConvertToTransform3D(_leftHand, false),
-                virtuals = ConvertToTransform3DList(_virtualTransforms, false)
+                physical = ConvertToTransformData(_physicalTransform, true),
+                head = ConvertToTransformData(_head, false),
+                rightHand = ConvertToTransformData(_rightHand, false),
+                leftHand = ConvertToTransformData(_leftHand, false),
+                virtuals = _virtualTransforms?.Select(v => ConvertToTransformData(v, false)).ToList() ?? new List<TransformData>()
             };
         }
 
@@ -185,41 +186,32 @@ namespace Styly.NetSync
             // If this is the first data received, immediately set position to avoid interpolation from origin
             if (!_hasTargetData)
             {
-                // Set physical transform immediately
                 if (_physicalTransform != null && data.physical != null)
                 {
-                    _physicalPosition = new Vector3(data.physical.posX, data.physical.posY, data.physical.posZ);
-                    Vector3 newPhysicalPosition = new Vector3(data.physical.posX, data.physical.posY, data.physical.posZ);
-                    Vector3 newPhysicalRotation = new Vector3(data.physical.rotX, data.physical.rotY, data.physical.rotZ);
-                    _physicalPosition = newPhysicalPosition;
-                    _physicalRotation = newPhysicalRotation;
-                    _physicalTransform.localPosition = newPhysicalPosition;
-                    _physicalTransform.localEulerAngles = newPhysicalRotation;
-                    _physicalTransform.localPosition = _physicalPosition;
-                    _physicalTransform.localEulerAngles = _physicalRotation;
+                    _physicalTransform.localPosition = data.physical.position;
+                    _physicalTransform.localRotation = Quaternion.Euler(data.physical.rotation);
+                    _physicalPosition = data.physical.position;
+                    _physicalRotation = data.physical.rotation;
                 }
 
-                // Set head transform immediately
                 if (_head != null && data.head != null)
                 {
-                    _head.position = new Vector3(data.head.posX, data.head.posY, data.head.posZ);
-                    _head.rotation = Quaternion.Euler(data.head.rotX, data.head.rotY, data.head.rotZ);
+                    _head.position = data.head.position;
+                    _head.rotation = Quaternion.Euler(data.head.rotation);
                 }
 
-                // Set hand transforms immediately
                 if (_rightHand != null && data.rightHand != null)
                 {
-                    _rightHand.position = new Vector3(data.rightHand.posX, data.rightHand.posY, data.rightHand.posZ);
-                    _rightHand.rotation = Quaternion.Euler(data.rightHand.rotX, data.rightHand.rotY, data.rightHand.rotZ);
+                    _rightHand.position = data.rightHand.position;
+                    _rightHand.rotation = Quaternion.Euler(data.rightHand.rotation);
                 }
 
                 if (_leftHand != null && data.leftHand != null)
                 {
-                    _leftHand.position = new Vector3(data.leftHand.posX, data.leftHand.posY, data.leftHand.posZ);
-                    _leftHand.rotation = Quaternion.Euler(data.leftHand.rotX, data.leftHand.rotY, data.leftHand.rotZ);
+                    _leftHand.position = data.leftHand.position;
+                    _leftHand.rotation = Quaternion.Euler(data.leftHand.rotation);
                 }
 
-                // Set virtual transforms immediately
                 if (_virtualTransforms != null && data.virtuals != null)
                 {
                     int count = Mathf.Min(_virtualTransforms.Length, data.virtuals.Count);
@@ -227,130 +219,73 @@ namespace Styly.NetSync
                     {
                         if (_virtualTransforms[i] != null && data.virtuals[i] != null)
                         {
-                            var vt = data.virtuals[i];
-                            _virtualTransforms[i].position = new Vector3(vt.posX, vt.posY, vt.posZ);
-                            _virtualTransforms[i].rotation = Quaternion.Euler(vt.rotX, vt.rotY, vt.rotZ);
+                            _virtualTransforms[i].position = data.virtuals[i].position;
+                            _virtualTransforms[i].rotation = Quaternion.Euler(data.virtuals[i].rotation);
                         }
                     }
                 }
             }
 
-            _targetHead = data.head;
-            _targetRightHand = data.rightHand;
-            _targetLeftHand = data.leftHand;
-            _targetVirtuals = data.virtuals;
+            _targetPhysical = data.physical ?? new TransformData();
+            _targetHead = data.head ?? new TransformData();
+            _targetRightHand = data.rightHand ?? new TransformData();
+            _targetLeftHand = data.leftHand ?? new TransformData();
+            _targetVirtuals = data.virtuals ?? new List<TransformData>();
             _hasTargetData = true;
-            _physicalPosition = new Vector3(data.physical.posX, data.physical.posY, data.physical.posZ);
-            _physicalRotation = new Vector3(data.physical.rotX, data.physical.rotY, data.physical.rotZ);
+            _physicalPosition = data.physical.position;
+            _physicalRotation = data.physical.rotation;
 
-            // Update client number for remote players
             _clientNo = data.clientNo;
         }
 
-        // Unified transform conversion method
-        // isLocalSpace: whether to read from local space (physical) vs world space (virtual)
-        private Transform3D ConvertToTransform3D(Transform transform, bool isLocalSpace)
-        {
-            if (transform == null) { return new Transform3D(); }
 
-            if (isLocalSpace)
-            {
-                // Physical/local transform (XZ position, Y rotation only)
-                return new Transform3D(
-                    transform.localPosition.x,
-                    0,
-                    transform.localPosition.z,
-                    0,
-                    transform.localEulerAngles.y,
-                    0,
-                    true
-                );
-            }
-            else
-            {
-                // Virtual/world transform (full 6DOF)
-                return new Transform3D(
-                    transform.position.x,
-                    transform.position.y,
-                    transform.position.z,
-                    transform.eulerAngles.x,
-                    transform.eulerAngles.y,
-                    transform.eulerAngles.z,
-                    false
-                );
-            }
-        }
-
-        // Convert transform array to Transform3D list
-        private List<Transform3D> ConvertToTransform3DList(Transform[] transforms, bool isLocalSpace)
-        {
-            var result = new List<Transform3D>();
-            if (transforms != null)
-            {
-                foreach (var t in transforms)
-                {
-                    if (t != null)
-                    {
-                        result.Add(ConvertToTransform3D(t, isLocalSpace));
-                    }
-                }
-            }
-            return result;
-        }
-
-        // Simplified transform interpolation
         private void InterpolateTransforms()
         {
-            float deltaTime = Time.deltaTime * _interpolationSpeed;
-            // Head Transform interpolation (world space)
-            if (_head != null && _targetHead != null)
+            float deltaTime = Time.deltaTime;
+            if (_physicalTransform != null)
             {
-                InterpolateSingleTransform(_head, _targetHead, deltaTime, false);
+                float t = deltaTime * _interpolationSpeed;
+                _physicalTransform.localPosition = Vector3.Lerp(_physicalTransform.localPosition, _targetPhysical.position, t);
+                _physicalTransform.localRotation = Quaternion.Lerp(_physicalTransform.localRotation, Quaternion.Euler(_targetPhysical.rotation), t);
             }
-            // Right Hand Transform interpolation (world space)
-            if (_rightHand != null && _targetRightHand != null)
+            if (_head != null)
             {
-                InterpolateSingleTransform(_rightHand, _targetRightHand, deltaTime, false);
+                InterpolateSingleTransform(_head, _targetHead, deltaTime);
             }
-            // Left Hand Transform interpolation (world space)
-            if (_leftHand != null && _targetLeftHand != null)
+            if (_rightHand != null)
             {
-                InterpolateSingleTransform(_leftHand, _targetLeftHand, deltaTime, false);
+                InterpolateSingleTransform(_rightHand, _targetRightHand, deltaTime);
             }
-
-            // Virtual Transforms interpolation (world space)
-            if (_virtualTransforms != null && _targetVirtuals != null)
+            if (_leftHand != null)
+            {
+                InterpolateSingleTransform(_leftHand, _targetLeftHand, deltaTime);
+            }
+            if (_virtualTransforms != null)
             {
                 int count = Mathf.Min(_virtualTransforms.Length, _targetVirtuals.Count);
                 for (int i = 0; i < count; i++)
                 {
-                    if (_virtualTransforms[i] != null)
-                    {
-                        InterpolateSingleTransform(_virtualTransforms[i], _targetVirtuals[i], deltaTime, false);
-                    }
+                    InterpolateSingleTransform(_virtualTransforms[i], _targetVirtuals[i], deltaTime);
                 }
             }
         }
 
-        // Unified interpolation method for any transform
-        // isLocalSpace: interpolate using localPosition/localRotation vs world position/rotation
-        private void InterpolateSingleTransform(Transform transform, Transform3D target, float deltaTime, bool isLocalSpace)
+        private void InterpolateSingleTransform(Transform transform, TransformData target, float deltaTime)
         {
-            Vector3 targetPos = isLocalSpace
-                ? new Vector3(target.posX, transform.localPosition.y, target.posZ)
-                : new Vector3(target.posX, target.posY, target.posZ);
-            Quaternion targetRot = Quaternion.Euler(target.rotX, target.rotY, target.rotZ);
+            if (transform == null || target == null) return;
+            float t = deltaTime * _interpolationSpeed;
+            transform.position = Vector3.Lerp(transform.position, target.position, t);
+            transform.rotation = Quaternion.Lerp(transform.rotation, Quaternion.Euler(target.rotation), t);
+        }
 
-            if (isLocalSpace)
+        private TransformData ConvertToTransformData(Transform t, bool isLocal)
+        {
+            if (t == null) return new TransformData();
+            return new TransformData
             {
-                transform.localPosition = Vector3.Lerp(transform.localPosition, targetPos, deltaTime);
-                transform.localRotation = Quaternion.Lerp(transform.localRotation, targetRot, deltaTime);
-            }
-            else
-            {
-                transform.position = Vector3.Lerp(transform.position, targetPos, deltaTime);
-                transform.rotation = Quaternion.Lerp(transform.rotation, targetRot, deltaTime);
-            }
+                position = isLocal ? t.localPosition : t.position,
+                rotation = isLocal ? t.localEulerAngles : t.eulerAngles
+            };
         }
 
         // Handle client variable changes from NetSyncManager


### PR DESCRIPTION
## Summary
- replace Transform3D with simple TransformData using Vector3 position/rotation
- serialize all transforms as 6 floats for both Unity and Python
- update NetSyncAvatar and test client for full transform sync

## Testing
- `pytest` *(fails: KeyboardInterrupt / server not running)*

------
https://chatgpt.com/codex/tasks/task_e_689d5fd4314c83288a86755e1e4c58bd