### PR TITLE
refactor: unify transform data protocol

### DIFF
--- a/STYLY-NetSync-Server/src/styly_netsync/binary_serializer.py
+++ b/STYLY-NetSync-Server/src/styly_netsync/binary_serializer.py
@@ -14,50 +14,28 @@ MSG_GLOBAL_VAR_SYNC = 8  # Sync global variables
 MSG_CLIENT_VAR_SET = 9  # Set client variable
 MSG_CLIENT_VAR_SYNC = 10  # Sync client variables
 
-# Transform data type identifiers
-TRANSFORM_PHYSICAL = 1  # 3 floats: posX, posZ, rotY
-TRANSFORM_VIRTUAL = 2   # 6 floats: full transform
-
 # Maximum allowed virtual transforms to prevent memory issues
 MAX_VIRTUAL_TRANSFORMS = 50
 
 # Stealth mode detection utilities
 def _is_nan_transform(transform: Dict[str, Any]) -> bool:
     """Check if a transform contains all NaN values (stealth mode indicator)"""
-    # Check physical transform (posX, posZ, rotY)
     physical = transform.get('physical', {})
     if not physical:
         return False
+    for key in ['posX', 'posY', 'posZ', 'rotX', 'rotY', 'rotZ']:
+        if not math.isnan(physical.get(key, 0)):
+            return False
 
-    # All physical values must be NaN
-    if not (math.isnan(physical.get('posX', 0)) and
-            math.isnan(physical.get('posZ', 0)) and
-            math.isnan(physical.get('rotY', 0))):
-        return False
-
-    # Check head transform (all 6 values must be NaN)
     head = transform.get('head', {})
-    if not head:
-        return False
-    for key in ['posX', 'posY', 'posZ', 'rotX', 'rotY', 'rotZ']:
-        if not math.isnan(head.get(key, 0)):
-            return False
-
-    # Check right hand transform (all 6 values must be NaN)
     right_hand = transform.get('rightHand', {})
-    if not right_hand:
-        return False
-    for key in ['posX', 'posY', 'posZ', 'rotX', 'rotY', 'rotZ']:
-        if not math.isnan(right_hand.get(key, 0)):
-            return False
-
-    # Check left hand transform (all 6 values must be NaN)
     left_hand = transform.get('leftHand', {})
-    if not left_hand:
+    if not head or not right_hand or not left_hand:
         return False
-    for key in ['posX', 'posY', 'posZ', 'rotX', 'rotY', 'rotZ']:
-        if not math.isnan(left_hand.get(key, 0)):
-            return False
+    for part in [head, right_hand, left_hand]:
+        for key in ['posX', 'posY', 'posZ', 'rotX', 'rotY', 'rotZ']:
+            if not math.isnan(part.get(key, 0)):
+                return False
 
     # Check virtuals count is 0
     virtuals = transform.get('virtuals', [])
@@ -96,9 +74,9 @@ def _pack_transform(buffer: bytearray, transform: Dict[str, Any], keys: List[str
     for key in keys:
         buffer.extend(struct.pack('<f', transform.get(key, 0)))
 
-def _unpack_transform(data: bytes, offset: int, keys: List[str], is_local_space: bool = False) -> Tuple[Dict[str, Any], int]:
+def _unpack_transform(data: bytes, offset: int, keys: List[str]) -> Tuple[Dict[str, Any], int]:
     """Unpack a transform with specified keys"""
-    transform = {'isLocalSpace': is_local_space}
+    transform: Dict[str, Any] = {}
     for key in keys:
         value = struct.unpack('<f', data[offset:offset+4])[0]
         transform[key] = value
@@ -109,18 +87,16 @@ def _pack_full_transform(buffer: bytearray, transform: Dict[str, Any]) -> None:
     """Pack a full 6-float transform"""
     _pack_transform(buffer, transform, ['posX', 'posY', 'posZ', 'rotX', 'rotY', 'rotZ'])
 
-def _unpack_full_transform(data: bytes, offset: int, is_local_space: bool = False) -> Tuple[Dict[str, Any], int]:
+def _unpack_full_transform(data: bytes, offset: int) -> Tuple[Dict[str, Any], int]:
     """Unpack a full 6-float transform"""
-    return _unpack_transform(data, offset, ['posX', 'posY', 'posZ', 'rotX', 'rotY', 'rotZ'], is_local_space)
+    return _unpack_transform(data, offset, ['posX', 'posY', 'posZ', 'rotX', 'rotY', 'rotZ'])
 
 def _serialize_client_data(buffer: bytearray, client: Dict[str, Any]) -> None:
     """Serialize a single client's data (shared by room transform and client transform)"""
     # Device ID
     _pack_string(buffer, client.get('deviceId', ''))
 
-    # Physical transform (special case: only 3 values)
-    physical = client.get('physical', {})
-    _pack_transform(buffer, physical, ['posX', 'posZ', 'rotY'])
+    _pack_full_transform(buffer, client.get('physical', {}))
 
     # Head, Right hand, Left hand transforms
     for transform_key in ['head', 'rightHand', 'leftHand']:
@@ -177,9 +153,7 @@ def _serialize_client_data_short(buffer: bytearray, client: Dict[str, Any]) -> N
     client_no = client.get('clientNo', 0)
     buffer.extend(struct.pack('<H', client_no))
 
-    # Physical transform (special case: only 3 values)
-    physical = client.get('physical', {})
-    _pack_transform(buffer, physical, ['posX', 'posZ', 'rotY'])
+    _pack_full_transform(buffer, client.get('physical', {}))
 
     # Head, Right hand, Left hand transforms
     for transform_key in ['head', 'rightHand', 'leftHand']:
@@ -418,17 +392,7 @@ def _deserialize_client_transform(data: bytes, offset: int) -> Dict[str, Any]:
     # Device ID
     result['deviceId'], offset = _unpack_string(data, offset)
 
-    # Physical transform (special case with default values)
-    physical_values, offset = _unpack_transform(data, offset, ['posX', 'posZ', 'rotY'], is_local_space=True)
-    result['physical'] = {
-        'posX': physical_values['posX'],
-        'posY': 0,
-        'posZ': physical_values['posZ'],
-        'rotX': 0,
-        'rotY': physical_values['rotY'],
-        'rotZ': 0,
-        'isLocalSpace': True
-    }
+    result['physical'], offset = _unpack_full_transform(data, offset)
 
     # Head, Right hand, Left hand transforms
     result['head'], offset = _unpack_full_transform(data, offset)
@@ -499,19 +463,8 @@ def _deserialize_room_transform(data: bytes, offset: int) -> Dict[str, Any]:
         offset += 2
         client['clientNo'] = client_no
 
-        # Physical transform
-        physical_values, offset = _unpack_transform(data, offset, ['posX', 'posZ', 'rotY'], is_local_space=True)
-        client['physical'] = {
-            'posX': physical_values['posX'],
-            'posY': 0,
-            'posZ': physical_values['posZ'],
-            'rotX': 0,
-            'rotY': physical_values['rotY'],
-            'rotZ': 0,
-            'isLocalSpace': True
-        }
+        client['physical'], offset = _unpack_full_transform(data, offset)
 
-        # Head, Right hand, Left hand transforms
         client['head'], offset = _unpack_full_transform(data, offset)
         client['rightHand'], offset = _unpack_full_transform(data, offset)
         client['leftHand'], offset = _unpack_full_transform(data, offset)

--- a/STYLY-NetSync-Server/src/styly_netsync/client_simulator.py
+++ b/STYLY-NetSync-Server/src/styly_netsync/client_simulator.py
@@ -112,9 +112,8 @@ class SimulatedClient:
                 "posY": 0,  # Y is always 0 for physical transform
                 "posZ": new_position[2],
                 "rotX": 0,
-                "rotY": 0,  # For simplicity, no rotation in simulation
+                "rotY": 0,
                 "rotZ": 0,
-                "isLocalSpace": True,
             },
             "head": {
                 "posX": head_pos[0],
@@ -123,7 +122,6 @@ class SimulatedClient:
                 "rotX": 0,
                 "rotY": 0,
                 "rotZ": 0,
-                "isLocalSpace": False,
             },
             "rightHand": {
                 "posX": right_hand_pos[0],
@@ -132,7 +130,6 @@ class SimulatedClient:
                 "rotX": 0,
                 "rotY": 0,
                 "rotZ": 0,
-                "isLocalSpace": False,
             },
             "leftHand": {
                 "posX": left_hand_pos[0],
@@ -141,7 +138,6 @@ class SimulatedClient:
                 "rotX": 0,
                 "rotY": 0,
                 "rotZ": 0,
-                "isLocalSpace": False,
             },
             "virtuals": virtuals,
         }
@@ -302,7 +298,6 @@ class SimulatedClient:
                 "rotX": 0,
                 "rotY": current_phase,  # Rotate around Y axis
                 "rotZ": 0,
-                "isLocalSpace": False,
             }
             virtuals.append(virtual_pos)
 

--- a/STYLY-NetSync-Server/tests/integration/test_client.py
+++ b/STYLY-NetSync-Server/tests/integration/test_client.py
@@ -150,8 +150,7 @@ class TestClient:
                 'posZ': self.position_z,
                 'rotX': 0,
                 'rotY': self.rotation_y,
-                'rotZ': 0,
-                'isLocalSpace': True
+                'rotZ': 0
             },
             'head': {
                 'posX': self.position_x,
@@ -159,8 +158,7 @@ class TestClient:
                 'posZ': self.position_z,
                 'rotX': 0,
                 'rotY': self.rotation_y,
-                'rotZ': 0,
-                'isLocalSpace': False
+                'rotZ': 0
             },
             'rightHand': {
                 'posX': self.position_x + 0.3,
@@ -168,8 +166,7 @@ class TestClient:
                 'posZ': self.position_z,
                 'rotX': 0,
                 'rotY': 0,
-                'rotZ': 0,
-                'isLocalSpace': False
+                'rotZ': 0
             },
             'leftHand': {
                 'posX': self.position_x - 0.3,
@@ -177,8 +174,7 @@ class TestClient:
                 'posZ': self.position_z,
                 'rotX': 0,
                 'rotY': 0,
-                'rotZ': 0,
-                'isLocalSpace': False
+                'rotZ': 0
             },
             'virtuals': []  # No virtual objects for this test
         }

--- a/STYLY-NetSync-Server/tests/integration/test_stealth_mode.py
+++ b/STYLY-NetSync-Server/tests/integration/test_stealth_mode.py
@@ -19,10 +19,9 @@ def create_stealth_handshake(device_id: str) -> bytes:
     buffer.append(len(device_id_bytes))
     buffer.extend(device_id_bytes)
 
-    # Physical transform with NaN values (3 floats)
-    buffer.extend(struct.pack('<f', float('nan')))  # posX
-    buffer.extend(struct.pack('<f', float('nan')))  # posZ
-    buffer.extend(struct.pack('<f', float('nan')))  # rotY
+    # Physical transform with NaN values (6 floats)
+    for _ in range(6):
+        buffer.extend(struct.pack('<f', float('nan')))
 
     # Head transform with NaN values (6 floats)
     for _ in range(6):

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal/BinarySerializer.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal/BinarySerializer.cs
@@ -19,133 +19,71 @@ namespace Styly.NetSync
         public const byte MSG_CLIENT_VAR_SET = 9;  // Set client variable
         public const byte MSG_CLIENT_VAR_SYNC = 10;  // Sync client variables
 
-        // Transform data type identifiers
-        private const byte TRANSFORM_PHYSICAL = 1;  // 3 floats: posX, posZ, rotY
-        private const byte TRANSFORM_VIRTUAL = 2;   // 6 floats: full transform
+        private static void WriteTransformData(BinaryWriter writer, TransformData d)
+        {
+            var p = d?.position ?? Vector3.zero;
+            var r = d?.rotation ?? Vector3.zero;
+            writer.Write(p.x); writer.Write(p.y); writer.Write(p.z);
+            writer.Write(r.x); writer.Write(r.y); writer.Write(r.z);
+        }
+
+        private static TransformData ReadTransformData(BinaryReader reader)
+        {
+            return new TransformData
+            {
+                position = new Vector3(reader.ReadSingle(), reader.ReadSingle(), reader.ReadSingle()),
+                rotation = new Vector3(reader.ReadSingle(), reader.ReadSingle(), reader.ReadSingle())
+            };
+        }
 
         #region === Serialization ===
 
         public static byte[] SerializeClientTransform(ClientTransformData data)
         {
-            using (var ms = new MemoryStream())
-            using (var writer = new BinaryWriter(ms))
+            using var ms = new MemoryStream();
+            using var writer = new BinaryWriter(ms);
+
+            writer.Write(MSG_CLIENT_TRANSFORM);
+
+            var deviceIdBytes = System.Text.Encoding.UTF8.GetBytes(data.deviceId ?? "");
+            writer.Write((byte)deviceIdBytes.Length);
+            writer.Write(deviceIdBytes);
+
+            WriteTransformData(writer, data.physical);
+            WriteTransformData(writer, data.head);
+            WriteTransformData(writer, data.rightHand);
+            WriteTransformData(writer, data.leftHand);
+
+            var virtualCount = data.virtuals?.Count ?? 0;
+            if (virtualCount > MAX_VIRTUAL_TRANSFORMS) virtualCount = MAX_VIRTUAL_TRANSFORMS;
+            writer.Write((byte)virtualCount);
+            for (int i = 0; i < virtualCount; i++)
             {
-                // Message type
-                writer.Write(MSG_CLIENT_TRANSFORM);
-
-                // Device ID (as UTF8 bytes with length prefix)
-                var deviceIdBytes = System.Text.Encoding.UTF8.GetBytes(data.deviceId);
-                writer.Write((byte)deviceIdBytes.Length);
-                writer.Write(deviceIdBytes);
-
-                // Note: Client number is not sent by client, only assigned by server
-
-                // Physical transform (optimized: 3 floats only)
-                {
-                    writer.Write(data.physical.posX);
-                    writer.Write(data.physical.posZ);
-                    writer.Write(data.physical.rotY);
-                }
-
-                // Head transform
-                {
-                    writer.Write(data.head.posX);
-                    writer.Write(data.head.posY);
-                    writer.Write(data.head.posZ);
-                    writer.Write(data.head.rotX);
-                    writer.Write(data.head.rotY);
-                    writer.Write(data.head.rotZ);
-                }
-
-                // Right hand transform
-                {
-                    writer.Write(data.rightHand.posX);
-                    writer.Write(data.rightHand.posY);
-                    writer.Write(data.rightHand.posZ);
-                    writer.Write(data.rightHand.rotX);
-                    writer.Write(data.rightHand.rotY);
-                    writer.Write(data.rightHand.rotZ);
-                }
-
-                // Left hand transform
-                {
-                    writer.Write(data.leftHand.posX);
-                    writer.Write(data.leftHand.posY);
-                    writer.Write(data.leftHand.posZ);
-                    writer.Write(data.leftHand.rotX);
-                    writer.Write(data.leftHand.rotY);
-                    writer.Write(data.leftHand.rotZ);
-                }
-
-                // Virtual transforms count
-                var virtualCount = data.virtuals?.Count ?? 0;
-                if (virtualCount > MAX_VIRTUAL_TRANSFORMS)
-                {
-                    virtualCount = MAX_VIRTUAL_TRANSFORMS;
-                }
-                writer.Write((byte)virtualCount);
-
-                // Virtual transforms (always full 6DOF)
-                if (data.virtuals != null && virtualCount > 0)
-                {
-                    for (int i = 0; i < virtualCount; i++)
-                    {
-                        var vt = data.virtuals[i];
-                        writer.Write(vt.posX);
-                        writer.Write(vt.posY);
-                        writer.Write(vt.posZ);
-                        writer.Write(vt.rotX);
-                        writer.Write(vt.rotY);
-                        writer.Write(vt.rotZ);
-                    }
-                }
-
-                return ms.ToArray();
+                WriteTransformData(writer, data.virtuals[i]);
             }
+
+            return ms.ToArray();
         }
 
         public static byte[] SerializeStealthHandshake(string deviceId)
         {
-            using (var ms = new MemoryStream())
-            using (var writer = new BinaryWriter(ms))
-            {
-                // Message type
-                writer.Write(MSG_CLIENT_TRANSFORM);
+            using var ms = new MemoryStream();
+            using var writer = new BinaryWriter(ms);
 
-                // Device ID (as UTF8 bytes with length prefix)
-                var deviceIdBytes = System.Text.Encoding.UTF8.GetBytes(deviceId);
-                writer.Write((byte)deviceIdBytes.Length);
-                writer.Write(deviceIdBytes);
+            writer.Write(MSG_CLIENT_TRANSFORM);
 
-                // Physical transform with NaN values (stealth mode indicator)
-                writer.Write(float.NaN); // posX
-                writer.Write(float.NaN); // posZ
-                writer.Write(float.NaN); // rotY
+            var deviceIdBytes = System.Text.Encoding.UTF8.GetBytes(deviceId ?? "");
+            writer.Write((byte)deviceIdBytes.Length);
+            writer.Write(deviceIdBytes);
 
-                // Head transform (NaN values)
-                for (int i = 0; i < 6; i++) // posX, posY, posZ, rotX, rotY, rotZ
-                {
-                    writer.Write(float.NaN);
-                }
+            for (int i = 0; i < 6; i++) writer.Write(float.NaN); // physical
+            for (int i = 0; i < 3 * 6; i++) writer.Write(float.NaN); // head/right/left
+            writer.Write((byte)0);
 
-                // Right hand transform (NaN values)
-                for (int i = 0; i < 6; i++)
-                {
-                    writer.Write(float.NaN);
-                }
-
-                // Left hand transform (NaN values)
-                for (int i = 0; i < 6; i++)
-                {
-                    writer.Write(float.NaN);
-                }
-
-                // No virtual transforms for stealth handshake
-                writer.Write((byte)0);
-
-                return ms.ToArray();
-            }
+            return ms.ToArray();
         }
+
+        #endregion
 
         #region === Deserialization ===
 
@@ -216,79 +154,25 @@ namespace Styly.NetSync
             var clientCount = reader.ReadUInt16();
             data.clients = new List<ClientTransformData>(clientCount);
 
-            // Each client with short ID
             for (int i = 0; i < clientCount; i++)
             {
                 var client = new ClientTransformData();
 
-                // Client number (2 bytes)
                 client.clientNo = reader.ReadUInt16();
 
-                // Note: Device ID is no longer sent in MSG_ROOM_TRANSFORM
-                // Device ID will be resolved from client number using mapping table
+                client.physical = ReadTransformData(reader);
+                client.head = ReadTransformData(reader);
+                client.rightHand = ReadTransformData(reader);
+                client.leftHand = ReadTransformData(reader);
 
-                // Physical transform
-                {
-                    var posX = reader.ReadSingle();
-                    var posZ = reader.ReadSingle();
-                    var rotY = reader.ReadSingle();
-                    client.physical = new Transform3D(posX, 0, posZ, 0, rotY, 0, true);
-                }
-
-                // Head transform
-                {
-                    var posX = reader.ReadSingle();
-                    var posY = reader.ReadSingle();
-                    var posZ = reader.ReadSingle();
-                    var rotX = reader.ReadSingle();
-                    var rotY = reader.ReadSingle();
-                    var rotZ = reader.ReadSingle();
-                    client.head = new Transform3D(posX, posY, posZ, rotX, rotY, rotZ, false);
-                }
-
-                // Right hand transform
-                {
-                    var posX = reader.ReadSingle();
-                    var posY = reader.ReadSingle();
-                    var posZ = reader.ReadSingle();
-                    var rotX = reader.ReadSingle();
-                    var rotY = reader.ReadSingle();
-                    var rotZ = reader.ReadSingle();
-                    client.rightHand = new Transform3D(posX, posY, posZ, rotX, rotY, rotZ, false);
-                }
-
-                // Left hand transform
-                {
-                    var posX = reader.ReadSingle();
-                    var posY = reader.ReadSingle();
-                    var posZ = reader.ReadSingle();
-                    var rotX = reader.ReadSingle();
-                    var rotY = reader.ReadSingle();
-                    var rotZ = reader.ReadSingle();
-                    client.leftHand = new Transform3D(posX, posY, posZ, rotX, rotY, rotZ, false);
-                }
-
-                // Virtual transforms
                 var virtualCount = reader.ReadByte();
-
-                // Validate virtual count to prevent memory issues
-                if (virtualCount > MAX_VIRTUAL_TRANSFORMS)
-                {
-                    virtualCount = MAX_VIRTUAL_TRANSFORMS;
-                }
-
+                if (virtualCount > MAX_VIRTUAL_TRANSFORMS) virtualCount = MAX_VIRTUAL_TRANSFORMS;
                 if (virtualCount > 0)
                 {
-                    client.virtuals = new List<Transform3D>(virtualCount);
+                    client.virtuals = new List<TransformData>(virtualCount);
                     for (int j = 0; j < virtualCount; j++)
                     {
-                        var posX = reader.ReadSingle();
-                        var posY = reader.ReadSingle();
-                        var posZ = reader.ReadSingle();
-                        var rotX = reader.ReadSingle();
-                        var rotY = reader.ReadSingle();
-                        var rotZ = reader.ReadSingle();
-                        client.virtuals.Add(new Transform3D(posX, posY, posZ, rotX, rotY, rotZ, false));
+                        client.virtuals.Add(ReadTransformData(reader));
                     }
                 }
 
@@ -296,41 +180,6 @@ namespace Styly.NetSync
             }
             return data;
         }
-
-
-        #endregion
-
-        #region === Size Calculation ===
-
-        public static int CalculateClientTransformSize(ClientTransformData data)
-        {
-            int size = 1; // Message type
-            size += 1 + System.Text.Encoding.UTF8.GetByteCount(data.deviceId); // Device ID
-
-            // Physical transform
-            if (data.physical != null && data.physical.isLocalSpace)
-            {
-                size += 1 + 12; // Type + 3 floats
-            }
-            else if (data.physical != null)
-            {
-                size += 1 + 24; // Type + 6 floats
-            }
-            else
-            {
-                size += 1; // Just type (0)
-            }
-
-            // Virtual transforms
-            size += 1; // Count
-            if (data.virtuals != null)
-            {
-                size += data.virtuals.Count * 24; // 6 floats each
-            }
-
-            return size;
-        }
-
         #endregion
 
         /// <summary>

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal/DataStructure.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal/DataStructure.cs
@@ -5,47 +5,25 @@ using UnityEngine;
 
 namespace Styly.NetSync
 {
-    // Unified transform data structure (supports both local and world coordinates)
     [Serializable]
-    public class Transform3D
+    public class TransformData
     {
-        public float posX;
-        public float posY;
-        public float posZ;
-        public float rotX;
-        public float rotY;
-        public float rotZ;
-        public bool isLocalSpace; // true for local/physical, false for world/virtual
-
-        public Transform3D() { }
-
-        // Constructor for virtual/world transforms (full 6DOF)
-        public Transform3D(float x, float y, float z, float rotX, float rotY, float rotZ, bool local = false)
-        {
-            posX = x;
-            posY = y;
-            posZ = z;
-            this.rotX = rotX;
-            this.rotY = rotY;
-            this.rotZ = rotZ;
-            isLocalSpace = local;
-        }
+        public Vector3 position;
+        public Vector3 rotation;
     }
 
-    // Client transform data using unified structure
     [Serializable]
     public class ClientTransformData
     {
         public string deviceId;
         public int clientNo;  // Client number assigned by server (0 if not assigned)
-        public Transform3D physical;
-        public Transform3D head;
-        public Transform3D rightHand;
-        public Transform3D leftHand;
-        public List<Transform3D> virtuals;
+        public TransformData physical;
+        public TransformData head;
+        public TransformData rightHand;
+        public TransformData leftHand;
+        public List<TransformData> virtuals;
     }
 
-    // Room data from server
     [Serializable]
     public class RoomTransformData
     {

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/NetSyncAvatar.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/NetSyncAvatar.cs
@@ -38,11 +38,10 @@ namespace Styly.NetSync
         public bool IsLocalAvatar { get; private set; }
 
         // Variables for interpolation
-        private Transform3D _targetPhysical;
-        private Transform3D _targetHead;
-        private Transform3D _targetRightHand;
-        private Transform3D _targetLeftHand;
-        private List<Transform3D> _targetVirtuals = new List<Transform3D>();
+        private TransformData _targetHead;
+        private TransformData _targetRightHand;
+        private TransformData _targetLeftHand;
+        private List<TransformData> _targetVirtuals = new List<TransformData>();
         private bool _hasTargetData = false;
 
         // Reference to NetSyncManager
@@ -94,15 +93,13 @@ namespace Styly.NetSync
 
             if (!isLocalAvatar)
             {
-                // For remote players, set initial data for interpolation
-                _targetPhysical = new Transform3D();
-                _targetHead = new Transform3D();
-                _targetRightHand = new Transform3D();
-                _targetLeftHand = new Transform3D();
+                _targetHead = new TransformData();
+                _targetRightHand = new TransformData();
+                _targetLeftHand = new TransformData();
                 _targetVirtuals.Clear();
                 for (int i = 0; i < _virtualTransforms.Length; i++)
                 {
-                    _targetVirtuals.Add(new Transform3D());
+                    _targetVirtuals.Add(new TransformData());
                 }
             }
         }
@@ -115,15 +112,13 @@ namespace Styly.NetSync
             IsLocalAvatar = false;
             _netSyncManager = manager;
 
-            // For remote players, set initial data for interpolation
-            _targetPhysical = new Transform3D();
-            _targetHead = new Transform3D();
-            _targetRightHand = new Transform3D();
-            _targetLeftHand = new Transform3D();
+            _targetHead = new TransformData();
+            _targetRightHand = new TransformData();
+            _targetLeftHand = new TransformData();
             _targetVirtuals.Clear();
             for (int i = 0; i < _virtualTransforms.Length; i++)
             {
-                _targetVirtuals.Add(new Transform3D());
+                _targetVirtuals.Add(new TransformData());
             }
         }
 
@@ -153,18 +148,17 @@ namespace Styly.NetSync
 #endif
         }
 
-        // Get current transform data for sending
         public ClientTransformData GetTransformData()
         {
             return new ClientTransformData
             {
                 deviceId = _deviceId,
                 clientNo = _clientNo,
-                physical = ConvertToTransform3D(_physicalTransform, true),
-                head = ConvertToTransform3D(_head, false),
-                rightHand = ConvertToTransform3D(_rightHand, false),
-                leftHand = ConvertToTransform3D(_leftHand, false),
-                virtuals = ConvertToTransform3DList(_virtualTransforms, false)
+                physical = ConvertToTransformData(_physicalTransform, true),
+                head = ConvertToTransformData(_head, false),
+                rightHand = ConvertToTransformData(_rightHand, false),
+                leftHand = ConvertToTransformData(_leftHand, false),
+                virtuals = ConvertToTransformDataList(_virtualTransforms, false)
             };
         }
 
@@ -182,44 +176,34 @@ namespace Styly.NetSync
         {
             if (IsLocalAvatar) { return; }
 
-            // If this is the first data received, immediately set position to avoid interpolation from origin
+            if (_physicalTransform != null && data.physical != null)
+            {
+                _physicalTransform.localPosition = data.physical.position;
+                _physicalTransform.localRotation = Quaternion.Euler(data.physical.rotation);
+                _physicalPosition = data.physical.position;
+                _physicalRotation = data.physical.rotation;
+            }
+
             if (!_hasTargetData)
             {
-                // Set physical transform immediately
-                if (_physicalTransform != null && data.physical != null)
-                {
-                    _physicalPosition = new Vector3(data.physical.posX, data.physical.posY, data.physical.posZ);
-                    Vector3 newPhysicalPosition = new Vector3(data.physical.posX, data.physical.posY, data.physical.posZ);
-                    Vector3 newPhysicalRotation = new Vector3(data.physical.rotX, data.physical.rotY, data.physical.rotZ);
-                    _physicalPosition = newPhysicalPosition;
-                    _physicalRotation = newPhysicalRotation;
-                    _physicalTransform.localPosition = newPhysicalPosition;
-                    _physicalTransform.localEulerAngles = newPhysicalRotation;
-                    _physicalTransform.localPosition = _physicalPosition;
-                    _physicalTransform.localEulerAngles = _physicalRotation;
-                }
-
-                // Set head transform immediately
                 if (_head != null && data.head != null)
                 {
-                    _head.position = new Vector3(data.head.posX, data.head.posY, data.head.posZ);
-                    _head.rotation = Quaternion.Euler(data.head.rotX, data.head.rotY, data.head.rotZ);
+                    _head.position = data.head.position;
+                    _head.rotation = Quaternion.Euler(data.head.rotation);
                 }
 
-                // Set hand transforms immediately
                 if (_rightHand != null && data.rightHand != null)
                 {
-                    _rightHand.position = new Vector3(data.rightHand.posX, data.rightHand.posY, data.rightHand.posZ);
-                    _rightHand.rotation = Quaternion.Euler(data.rightHand.rotX, data.rightHand.rotY, data.rightHand.rotZ);
+                    _rightHand.position = data.rightHand.position;
+                    _rightHand.rotation = Quaternion.Euler(data.rightHand.rotation);
                 }
 
                 if (_leftHand != null && data.leftHand != null)
                 {
-                    _leftHand.position = new Vector3(data.leftHand.posX, data.leftHand.posY, data.leftHand.posZ);
-                    _leftHand.rotation = Quaternion.Euler(data.leftHand.rotX, data.leftHand.rotY, data.leftHand.rotZ);
+                    _leftHand.position = data.leftHand.position;
+                    _leftHand.rotation = Quaternion.Euler(data.leftHand.rotation);
                 }
 
-                // Set virtual transforms immediately
                 if (_virtualTransforms != null && data.virtuals != null)
                 {
                     int count = Mathf.Min(_virtualTransforms.Length, data.virtuals.Count);
@@ -227,9 +211,8 @@ namespace Styly.NetSync
                     {
                         if (_virtualTransforms[i] != null && data.virtuals[i] != null)
                         {
-                            var vt = data.virtuals[i];
-                            _virtualTransforms[i].position = new Vector3(vt.posX, vt.posY, vt.posZ);
-                            _virtualTransforms[i].rotation = Quaternion.Euler(vt.rotX, vt.rotY, vt.rotZ);
+                            _virtualTransforms[i].position = data.virtuals[i].position;
+                            _virtualTransforms[i].rotation = Quaternion.Euler(data.virtuals[i].rotation);
                         }
                     }
                 }
@@ -240,58 +223,30 @@ namespace Styly.NetSync
             _targetLeftHand = data.leftHand;
             _targetVirtuals = data.virtuals;
             _hasTargetData = true;
-            _physicalPosition = new Vector3(data.physical.posX, data.physical.posY, data.physical.posZ);
-            _physicalRotation = new Vector3(data.physical.rotX, data.physical.rotY, data.physical.rotZ);
 
-            // Update client number for remote players
             _clientNo = data.clientNo;
         }
 
-        // Unified transform conversion method
-        // isLocalSpace: whether to read from local space (physical) vs world space (virtual)
-        private Transform3D ConvertToTransform3D(Transform transform, bool isLocalSpace)
+        private TransformData ConvertToTransformData(Transform transform, bool useLocal)
         {
-            if (transform == null) { return new Transform3D(); }
-
-            if (isLocalSpace)
+            if (transform == null) return new TransformData();
+            return new TransformData
             {
-                // Physical/local transform (XZ position, Y rotation only)
-                return new Transform3D(
-                    transform.localPosition.x,
-                    0,
-                    transform.localPosition.z,
-                    0,
-                    transform.localEulerAngles.y,
-                    0,
-                    true
-                );
-            }
-            else
-            {
-                // Virtual/world transform (full 6DOF)
-                return new Transform3D(
-                    transform.position.x,
-                    transform.position.y,
-                    transform.position.z,
-                    transform.eulerAngles.x,
-                    transform.eulerAngles.y,
-                    transform.eulerAngles.z,
-                    false
-                );
-            }
+                position = useLocal ? transform.localPosition : transform.position,
+                rotation = useLocal ? transform.localEulerAngles : transform.eulerAngles
+            };
         }
 
-        // Convert transform array to Transform3D list
-        private List<Transform3D> ConvertToTransform3DList(Transform[] transforms, bool isLocalSpace)
+        private List<TransformData> ConvertToTransformDataList(Transform[] transforms, bool useLocal)
         {
-            var result = new List<Transform3D>();
+            var result = new List<TransformData>();
             if (transforms != null)
             {
                 foreach (var t in transforms)
                 {
                     if (t != null)
                     {
-                        result.Add(ConvertToTransform3D(t, isLocalSpace));
+                        result.Add(ConvertToTransformData(t, useLocal));
                     }
                 }
             }
@@ -305,17 +260,17 @@ namespace Styly.NetSync
             // Head Transform interpolation (world space)
             if (_head != null && _targetHead != null)
             {
-                InterpolateSingleTransform(_head, _targetHead, deltaTime, false);
+                InterpolateSingleTransform(_head, _targetHead, deltaTime);
             }
             // Right Hand Transform interpolation (world space)
             if (_rightHand != null && _targetRightHand != null)
             {
-                InterpolateSingleTransform(_rightHand, _targetRightHand, deltaTime, false);
+                InterpolateSingleTransform(_rightHand, _targetRightHand, deltaTime);
             }
             // Left Hand Transform interpolation (world space)
             if (_leftHand != null && _targetLeftHand != null)
             {
-                InterpolateSingleTransform(_leftHand, _targetLeftHand, deltaTime, false);
+                InterpolateSingleTransform(_leftHand, _targetLeftHand, deltaTime);
             }
 
             // Virtual Transforms interpolation (world space)
@@ -326,31 +281,18 @@ namespace Styly.NetSync
                 {
                     if (_virtualTransforms[i] != null)
                     {
-                        InterpolateSingleTransform(_virtualTransforms[i], _targetVirtuals[i], deltaTime, false);
+                        InterpolateSingleTransform(_virtualTransforms[i], _targetVirtuals[i], deltaTime);
                     }
                 }
             }
         }
 
-        // Unified interpolation method for any transform
-        // isLocalSpace: interpolate using localPosition/localRotation vs world position/rotation
-        private void InterpolateSingleTransform(Transform transform, Transform3D target, float deltaTime, bool isLocalSpace)
+        private void InterpolateSingleTransform(Transform transform, TransformData target, float deltaTime)
         {
-            Vector3 targetPos = isLocalSpace
-                ? new Vector3(target.posX, transform.localPosition.y, target.posZ)
-                : new Vector3(target.posX, target.posY, target.posZ);
-            Quaternion targetRot = Quaternion.Euler(target.rotX, target.rotY, target.rotZ);
-
-            if (isLocalSpace)
-            {
-                transform.localPosition = Vector3.Lerp(transform.localPosition, targetPos, deltaTime);
-                transform.localRotation = Quaternion.Lerp(transform.localRotation, targetRot, deltaTime);
-            }
-            else
-            {
-                transform.position = Vector3.Lerp(transform.position, targetPos, deltaTime);
-                transform.rotation = Quaternion.Lerp(transform.rotation, targetRot, deltaTime);
-            }
+            Vector3 targetPos = target.position;
+            Quaternion targetRot = Quaternion.Euler(target.rotation);
+            transform.position = Vector3.Lerp(transform.position, targetPos, deltaTime);
+            transform.rotation = Quaternion.Lerp(transform.rotation, targetRot, deltaTime);
         }
 
         // Handle client variable changes from NetSyncManager


### PR DESCRIPTION
## Summary
- replace Transform3D with Vector3-based TransformData
- serialize all transforms with full 6 floats and update stealth handshake
- adjust NetSyncAvatar and Python server for unified local/world handling

## Testing
- `ruff check`
- `pytest` *(fails: KeyboardInterrupt after long run)*
- `python -m pip install -e .` *(fails: Could not find a version that satisfies the requirement setuptools>=68)*

------
https://chatgpt.com/codex/tasks/task_e_689d6e92d9708328b7b90985e7b6d9d2