### PR TITLE
Unify transform protocol with full 6-DOF data

### DIFF
--- a/STYLY-NetSync-Server/src/styly_netsync/binary_serializer.py
+++ b/STYLY-NetSync-Server/src/styly_netsync/binary_serializer.py
@@ -14,47 +14,32 @@ MSG_GLOBAL_VAR_SYNC = 8  # Sync global variables
 MSG_CLIENT_VAR_SET = 9  # Set client variable
 MSG_CLIENT_VAR_SYNC = 10  # Sync client variables
 
-# Transform data type identifiers
-TRANSFORM_PHYSICAL = 1  # 3 floats: posX, posZ, rotY
-TRANSFORM_VIRTUAL = 2   # 6 floats: full transform
-
 # Maximum allowed virtual transforms to prevent memory issues
 MAX_VIRTUAL_TRANSFORMS = 50
 
 # Stealth mode detection utilities
 def _is_nan_transform(transform: Dict[str, Any]) -> bool:
     """Check if a transform contains all NaN values (stealth mode indicator)"""
-    # Check physical transform (posX, posZ, rotY)
+    # Check physical transform (all 6 values must be NaN)
     physical = transform.get('physical', {})
-    if not physical:
-        return False
-
-    # All physical values must be NaN
-    if not (math.isnan(physical.get('posX', 0)) and
-            math.isnan(physical.get('posZ', 0)) and
-            math.isnan(physical.get('rotY', 0))):
-        return False
+    for key in ['posX', 'posY', 'posZ', 'rotX', 'rotY', 'rotZ']:
+        if not math.isnan(physical.get(key, 0)):
+            return False
 
     # Check head transform (all 6 values must be NaN)
     head = transform.get('head', {})
-    if not head:
-        return False
     for key in ['posX', 'posY', 'posZ', 'rotX', 'rotY', 'rotZ']:
         if not math.isnan(head.get(key, 0)):
             return False
 
     # Check right hand transform (all 6 values must be NaN)
     right_hand = transform.get('rightHand', {})
-    if not right_hand:
-        return False
     for key in ['posX', 'posY', 'posZ', 'rotX', 'rotY', 'rotZ']:
         if not math.isnan(right_hand.get(key, 0)):
             return False
 
     # Check left hand transform (all 6 values must be NaN)
     left_hand = transform.get('leftHand', {})
-    if not left_hand:
-        return False
     for key in ['posX', 'posY', 'posZ', 'rotX', 'rotY', 'rotZ']:
         if not math.isnan(left_hand.get(key, 0)):
             return False
@@ -91,36 +76,27 @@ def _unpack_string(data: bytes, offset: int, use_ushort: bool = False) -> Tuple[
     string = data[offset:offset+length].decode('utf-8')
     return string, offset + length
 
-def _pack_transform(buffer: bytearray, transform: Dict[str, Any], keys: List[str]) -> None:
-    """Pack a transform with specified keys"""
-    for key in keys:
-        buffer.extend(struct.pack('<f', transform.get(key, 0)))
-
-def _unpack_transform(data: bytes, offset: int, keys: List[str], is_local_space: bool = False) -> Tuple[Dict[str, Any], int]:
-    """Unpack a transform with specified keys"""
-    transform = {'isLocalSpace': is_local_space}
-    for key in keys:
-        value = struct.unpack('<f', data[offset:offset+4])[0]
-        transform[key] = value
-        offset += 4
-    return transform, offset
-
 def _pack_full_transform(buffer: bytearray, transform: Dict[str, Any]) -> None:
     """Pack a full 6-float transform"""
-    _pack_transform(buffer, transform, ['posX', 'posY', 'posZ', 'rotX', 'rotY', 'rotZ'])
+    for key in ['posX', 'posY', 'posZ', 'rotX', 'rotY', 'rotZ']:
+        buffer.extend(struct.pack('<f', transform.get(key, 0.0)))
 
-def _unpack_full_transform(data: bytes, offset: int, is_local_space: bool = False) -> Tuple[Dict[str, Any], int]:
+def _unpack_full_transform(data: bytes, offset: int) -> Tuple[Dict[str, Any], int]:
     """Unpack a full 6-float transform"""
-    return _unpack_transform(data, offset, ['posX', 'posY', 'posZ', 'rotX', 'rotY', 'rotZ'], is_local_space)
+    keys = ['posX', 'posY', 'posZ', 'rotX', 'rotY', 'rotZ']
+    transform: Dict[str, Any] = {}
+    for key in keys:
+        transform[key] = struct.unpack('<f', data[offset:offset+4])[0]
+        offset += 4
+    return transform, offset
 
 def _serialize_client_data(buffer: bytearray, client: Dict[str, Any]) -> None:
     """Serialize a single client's data (shared by room transform and client transform)"""
     # Device ID
     _pack_string(buffer, client.get('deviceId', ''))
 
-    # Physical transform (special case: only 3 values)
-    physical = client.get('physical', {})
-    _pack_transform(buffer, physical, ['posX', 'posZ', 'rotY'])
+    # Physical transform (full 6 values)
+    _pack_full_transform(buffer, client.get('physical', {}))
 
     # Head, Right hand, Left hand transforms
     for transform_key in ['head', 'rightHand', 'leftHand']:
@@ -177,9 +153,8 @@ def _serialize_client_data_short(buffer: bytearray, client: Dict[str, Any]) -> N
     client_no = client.get('clientNo', 0)
     buffer.extend(struct.pack('<H', client_no))
 
-    # Physical transform (special case: only 3 values)
-    physical = client.get('physical', {})
-    _pack_transform(buffer, physical, ['posX', 'posZ', 'rotY'])
+    # Physical transform (full 6 values)
+    _pack_full_transform(buffer, client.get('physical', {}))
 
     # Head, Right hand, Left hand transforms
     for transform_key in ['head', 'rightHand', 'leftHand']:
@@ -418,17 +393,8 @@ def _deserialize_client_transform(data: bytes, offset: int) -> Dict[str, Any]:
     # Device ID
     result['deviceId'], offset = _unpack_string(data, offset)
 
-    # Physical transform (special case with default values)
-    physical_values, offset = _unpack_transform(data, offset, ['posX', 'posZ', 'rotY'], is_local_space=True)
-    result['physical'] = {
-        'posX': physical_values['posX'],
-        'posY': 0,
-        'posZ': physical_values['posZ'],
-        'rotX': 0,
-        'rotY': physical_values['rotY'],
-        'rotZ': 0,
-        'isLocalSpace': True
-    }
+    # Physical transform (full 6 values)
+    result['physical'], offset = _unpack_full_transform(data, offset)
 
     # Head, Right hand, Left hand transforms
     result['head'], offset = _unpack_full_transform(data, offset)
@@ -500,16 +466,7 @@ def _deserialize_room_transform(data: bytes, offset: int) -> Dict[str, Any]:
         client['clientNo'] = client_no
 
         # Physical transform
-        physical_values, offset = _unpack_transform(data, offset, ['posX', 'posZ', 'rotY'], is_local_space=True)
-        client['physical'] = {
-            'posX': physical_values['posX'],
-            'posY': 0,
-            'posZ': physical_values['posZ'],
-            'rotX': 0,
-            'rotY': physical_values['rotY'],
-            'rotZ': 0,
-            'isLocalSpace': True
-        }
+        client['physical'], offset = _unpack_full_transform(data, offset)
 
         # Head, Right hand, Left hand transforms
         client['head'], offset = _unpack_full_transform(data, offset)

--- a/STYLY-NetSync-Server/src/styly_netsync/client_simulator.py
+++ b/STYLY-NetSync-Server/src/styly_netsync/client_simulator.py
@@ -114,7 +114,6 @@ class SimulatedClient:
                 "rotX": 0,
                 "rotY": 0,  # For simplicity, no rotation in simulation
                 "rotZ": 0,
-                "isLocalSpace": True,
             },
             "head": {
                 "posX": head_pos[0],
@@ -123,7 +122,6 @@ class SimulatedClient:
                 "rotX": 0,
                 "rotY": 0,
                 "rotZ": 0,
-                "isLocalSpace": False,
             },
             "rightHand": {
                 "posX": right_hand_pos[0],
@@ -132,7 +130,6 @@ class SimulatedClient:
                 "rotX": 0,
                 "rotY": 0,
                 "rotZ": 0,
-                "isLocalSpace": False,
             },
             "leftHand": {
                 "posX": left_hand_pos[0],
@@ -141,7 +138,6 @@ class SimulatedClient:
                 "rotX": 0,
                 "rotY": 0,
                 "rotZ": 0,
-                "isLocalSpace": False,
             },
             "virtuals": virtuals,
         }
@@ -302,7 +298,6 @@ class SimulatedClient:
                 "rotX": 0,
                 "rotY": current_phase,  # Rotate around Y axis
                 "rotZ": 0,
-                "isLocalSpace": False,
             }
             virtuals.append(virtual_pos)
 

--- a/STYLY-NetSync-Server/tests/integration/test_client.py
+++ b/STYLY-NetSync-Server/tests/integration/test_client.py
@@ -151,7 +151,6 @@ class TestClient:
                 'rotX': 0,
                 'rotY': self.rotation_y,
                 'rotZ': 0,
-                'isLocalSpace': True
             },
             'head': {
                 'posX': self.position_x,
@@ -160,7 +159,6 @@ class TestClient:
                 'rotX': 0,
                 'rotY': self.rotation_y,
                 'rotZ': 0,
-                'isLocalSpace': False
             },
             'rightHand': {
                 'posX': self.position_x + 0.3,
@@ -169,7 +167,6 @@ class TestClient:
                 'rotX': 0,
                 'rotY': 0,
                 'rotZ': 0,
-                'isLocalSpace': False
             },
             'leftHand': {
                 'posX': self.position_x - 0.3,
@@ -178,7 +175,6 @@ class TestClient:
                 'rotX': 0,
                 'rotY': 0,
                 'rotZ': 0,
-                'isLocalSpace': False
             },
             'virtuals': []  # No virtual objects for this test
         }

--- a/STYLY-NetSync-Server/tests/integration/test_stealth_mode.py
+++ b/STYLY-NetSync-Server/tests/integration/test_stealth_mode.py
@@ -19,10 +19,9 @@ def create_stealth_handshake(device_id: str) -> bytes:
     buffer.append(len(device_id_bytes))
     buffer.extend(device_id_bytes)
 
-    # Physical transform with NaN values (3 floats)
-    buffer.extend(struct.pack('<f', float('nan')))  # posX
-    buffer.extend(struct.pack('<f', float('nan')))  # posZ
-    buffer.extend(struct.pack('<f', float('nan')))  # rotY
+    # Physical transform with NaN values (6 floats)
+    for _ in range(6):
+        buffer.extend(struct.pack('<f', float('nan')))
 
     # Head transform with NaN values (6 floats)
     for _ in range(6):

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal/DataStructure.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal/DataStructure.cs
@@ -5,31 +5,12 @@ using UnityEngine;
 
 namespace Styly.NetSync
 {
-    // Unified transform data structure (supports both local and world coordinates)
+    // Simple transform data structure using Unity's Vector3
     [Serializable]
-    public class Transform3D
+    public class TransformData
     {
-        public float posX;
-        public float posY;
-        public float posZ;
-        public float rotX;
-        public float rotY;
-        public float rotZ;
-        public bool isLocalSpace; // true for local/physical, false for world/virtual
-
-        public Transform3D() { }
-
-        // Constructor for virtual/world transforms (full 6DOF)
-        public Transform3D(float x, float y, float z, float rotX, float rotY, float rotZ, bool local = false)
-        {
-            posX = x;
-            posY = y;
-            posZ = z;
-            this.rotX = rotX;
-            this.rotY = rotY;
-            this.rotZ = rotZ;
-            isLocalSpace = local;
-        }
+        public Vector3 position;
+        public Vector3 rotation; // Euler angles (x, y, z)
     }
 
     // Client transform data using unified structure
@@ -38,11 +19,11 @@ namespace Styly.NetSync
     {
         public string deviceId;
         public int clientNo;  // Client number assigned by server (0 if not assigned)
-        public Transform3D physical;
-        public Transform3D head;
-        public Transform3D rightHand;
-        public Transform3D leftHand;
-        public List<Transform3D> virtuals;
+        public TransformData physical;
+        public TransformData head;
+        public TransformData rightHand;
+        public TransformData leftHand;
+        public List<TransformData> virtuals;
     }
 
     // Room data from server

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/NetSyncAvatar.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/NetSyncAvatar.cs
@@ -38,11 +38,10 @@ namespace Styly.NetSync
         public bool IsLocalAvatar { get; private set; }
 
         // Variables for interpolation
-        private Transform3D _targetPhysical;
-        private Transform3D _targetHead;
-        private Transform3D _targetRightHand;
-        private Transform3D _targetLeftHand;
-        private List<Transform3D> _targetVirtuals = new List<Transform3D>();
+        private TransformData _targetHead;
+        private TransformData _targetRightHand;
+        private TransformData _targetLeftHand;
+        private List<TransformData> _targetVirtuals = new List<TransformData>();
         private bool _hasTargetData = false;
 
         // Reference to NetSyncManager
@@ -95,14 +94,13 @@ namespace Styly.NetSync
             if (!isLocalAvatar)
             {
                 // For remote players, set initial data for interpolation
-                _targetPhysical = new Transform3D();
-                _targetHead = new Transform3D();
-                _targetRightHand = new Transform3D();
-                _targetLeftHand = new Transform3D();
+                _targetHead = new TransformData();
+                _targetRightHand = new TransformData();
+                _targetLeftHand = new TransformData();
                 _targetVirtuals.Clear();
                 for (int i = 0; i < _virtualTransforms.Length; i++)
                 {
-                    _targetVirtuals.Add(new Transform3D());
+                    _targetVirtuals.Add(new TransformData());
                 }
             }
         }
@@ -116,14 +114,13 @@ namespace Styly.NetSync
             _netSyncManager = manager;
 
             // For remote players, set initial data for interpolation
-            _targetPhysical = new Transform3D();
-            _targetHead = new Transform3D();
-            _targetRightHand = new Transform3D();
-            _targetLeftHand = new Transform3D();
+            _targetHead = new TransformData();
+            _targetRightHand = new TransformData();
+            _targetLeftHand = new TransformData();
             _targetVirtuals.Clear();
             for (int i = 0; i < _virtualTransforms.Length; i++)
             {
-                _targetVirtuals.Add(new Transform3D());
+                _targetVirtuals.Add(new TransformData());
             }
         }
 
@@ -160,11 +157,11 @@ namespace Styly.NetSync
             {
                 deviceId = _deviceId,
                 clientNo = _clientNo,
-                physical = ConvertToTransform3D(_physicalTransform, true),
-                head = ConvertToTransform3D(_head, false),
-                rightHand = ConvertToTransform3D(_rightHand, false),
-                leftHand = ConvertToTransform3D(_leftHand, false),
-                virtuals = ConvertToTransform3DList(_virtualTransforms, false)
+                physical = ToTransformData(_physicalTransform, true),
+                head = ToTransformData(_head, false),
+                rightHand = ToTransformData(_rightHand, false),
+                leftHand = ToTransformData(_leftHand, false),
+                virtuals = ToTransformDataList(_virtualTransforms, false)
             };
         }
 
@@ -182,44 +179,36 @@ namespace Styly.NetSync
         {
             if (IsLocalAvatar) { return; }
 
-            // If this is the first data received, immediately set position to avoid interpolation from origin
+            // Apply physical transform in local space
+            if (_physicalTransform != null && data.physical != null)
+            {
+                _physicalTransform.localPosition = data.physical.position;
+                _physicalTransform.localRotation = Quaternion.Euler(data.physical.rotation);
+                _physicalPosition = data.physical.position;
+                _physicalRotation = data.physical.rotation;
+            }
+
+            // If this is the first data received, set transforms immediately
             if (!_hasTargetData)
             {
-                // Set physical transform immediately
-                if (_physicalTransform != null && data.physical != null)
-                {
-                    _physicalPosition = new Vector3(data.physical.posX, data.physical.posY, data.physical.posZ);
-                    Vector3 newPhysicalPosition = new Vector3(data.physical.posX, data.physical.posY, data.physical.posZ);
-                    Vector3 newPhysicalRotation = new Vector3(data.physical.rotX, data.physical.rotY, data.physical.rotZ);
-                    _physicalPosition = newPhysicalPosition;
-                    _physicalRotation = newPhysicalRotation;
-                    _physicalTransform.localPosition = newPhysicalPosition;
-                    _physicalTransform.localEulerAngles = newPhysicalRotation;
-                    _physicalTransform.localPosition = _physicalPosition;
-                    _physicalTransform.localEulerAngles = _physicalRotation;
-                }
-
-                // Set head transform immediately
                 if (_head != null && data.head != null)
                 {
-                    _head.position = new Vector3(data.head.posX, data.head.posY, data.head.posZ);
-                    _head.rotation = Quaternion.Euler(data.head.rotX, data.head.rotY, data.head.rotZ);
+                    _head.position = data.head.position;
+                    _head.rotation = Quaternion.Euler(data.head.rotation);
                 }
 
-                // Set hand transforms immediately
                 if (_rightHand != null && data.rightHand != null)
                 {
-                    _rightHand.position = new Vector3(data.rightHand.posX, data.rightHand.posY, data.rightHand.posZ);
-                    _rightHand.rotation = Quaternion.Euler(data.rightHand.rotX, data.rightHand.rotY, data.rightHand.rotZ);
+                    _rightHand.position = data.rightHand.position;
+                    _rightHand.rotation = Quaternion.Euler(data.rightHand.rotation);
                 }
 
                 if (_leftHand != null && data.leftHand != null)
                 {
-                    _leftHand.position = new Vector3(data.leftHand.posX, data.leftHand.posY, data.leftHand.posZ);
-                    _leftHand.rotation = Quaternion.Euler(data.leftHand.rotX, data.leftHand.rotY, data.leftHand.rotZ);
+                    _leftHand.position = data.leftHand.position;
+                    _leftHand.rotation = Quaternion.Euler(data.leftHand.rotation);
                 }
 
-                // Set virtual transforms immediately
                 if (_virtualTransforms != null && data.virtuals != null)
                 {
                     int count = Mathf.Min(_virtualTransforms.Length, data.virtuals.Count);
@@ -227,9 +216,8 @@ namespace Styly.NetSync
                     {
                         if (_virtualTransforms[i] != null && data.virtuals[i] != null)
                         {
-                            var vt = data.virtuals[i];
-                            _virtualTransforms[i].position = new Vector3(vt.posX, vt.posY, vt.posZ);
-                            _virtualTransforms[i].rotation = Quaternion.Euler(vt.rotX, vt.rotY, vt.rotZ);
+                            _virtualTransforms[i].position = data.virtuals[i].position;
+                            _virtualTransforms[i].rotation = Quaternion.Euler(data.virtuals[i].rotation);
                         }
                     }
                 }
@@ -240,58 +228,31 @@ namespace Styly.NetSync
             _targetLeftHand = data.leftHand;
             _targetVirtuals = data.virtuals;
             _hasTargetData = true;
-            _physicalPosition = new Vector3(data.physical.posX, data.physical.posY, data.physical.posZ);
-            _physicalRotation = new Vector3(data.physical.rotX, data.physical.rotY, data.physical.rotZ);
 
             // Update client number for remote players
             _clientNo = data.clientNo;
         }
 
-        // Unified transform conversion method
-        // isLocalSpace: whether to read from local space (physical) vs world space (virtual)
-        private Transform3D ConvertToTransform3D(Transform transform, bool isLocalSpace)
+        private TransformData ToTransformData(Transform transform, bool isLocal)
         {
-            if (transform == null) { return new Transform3D(); }
-
-            if (isLocalSpace)
+            if (transform == null) { return new TransformData(); }
+            return new TransformData
             {
-                // Physical/local transform (XZ position, Y rotation only)
-                return new Transform3D(
-                    transform.localPosition.x,
-                    0,
-                    transform.localPosition.z,
-                    0,
-                    transform.localEulerAngles.y,
-                    0,
-                    true
-                );
-            }
-            else
-            {
-                // Virtual/world transform (full 6DOF)
-                return new Transform3D(
-                    transform.position.x,
-                    transform.position.y,
-                    transform.position.z,
-                    transform.eulerAngles.x,
-                    transform.eulerAngles.y,
-                    transform.eulerAngles.z,
-                    false
-                );
-            }
+                position = isLocal ? transform.localPosition : transform.position,
+                rotation = isLocal ? transform.localEulerAngles : transform.eulerAngles
+            };
         }
 
-        // Convert transform array to Transform3D list
-        private List<Transform3D> ConvertToTransform3DList(Transform[] transforms, bool isLocalSpace)
+        private List<TransformData> ToTransformDataList(Transform[] transforms, bool isLocal)
         {
-            var result = new List<Transform3D>();
+            var result = new List<TransformData>();
             if (transforms != null)
             {
                 foreach (var t in transforms)
                 {
                     if (t != null)
                     {
-                        result.Add(ConvertToTransform3D(t, isLocalSpace));
+                        result.Add(ToTransformData(t, isLocal));
                     }
                 }
             }
@@ -305,17 +266,17 @@ namespace Styly.NetSync
             // Head Transform interpolation (world space)
             if (_head != null && _targetHead != null)
             {
-                InterpolateSingleTransform(_head, _targetHead, deltaTime, false);
+                InterpolateSingleTransform(_head, _targetHead, deltaTime);
             }
             // Right Hand Transform interpolation (world space)
             if (_rightHand != null && _targetRightHand != null)
             {
-                InterpolateSingleTransform(_rightHand, _targetRightHand, deltaTime, false);
+                InterpolateSingleTransform(_rightHand, _targetRightHand, deltaTime);
             }
             // Left Hand Transform interpolation (world space)
             if (_leftHand != null && _targetLeftHand != null)
             {
-                InterpolateSingleTransform(_leftHand, _targetLeftHand, deltaTime, false);
+                InterpolateSingleTransform(_leftHand, _targetLeftHand, deltaTime);
             }
 
             // Virtual Transforms interpolation (world space)
@@ -326,31 +287,19 @@ namespace Styly.NetSync
                 {
                     if (_virtualTransforms[i] != null)
                     {
-                        InterpolateSingleTransform(_virtualTransforms[i], _targetVirtuals[i], deltaTime, false);
+                        InterpolateSingleTransform(_virtualTransforms[i], _targetVirtuals[i], deltaTime);
                     }
                 }
             }
         }
 
-        // Unified interpolation method for any transform
-        // isLocalSpace: interpolate using localPosition/localRotation vs world position/rotation
-        private void InterpolateSingleTransform(Transform transform, Transform3D target, float deltaTime, bool isLocalSpace)
+        // Simplified interpolation method (world space only)
+        private void InterpolateSingleTransform(Transform transform, TransformData target, float deltaTime)
         {
-            Vector3 targetPos = isLocalSpace
-                ? new Vector3(target.posX, transform.localPosition.y, target.posZ)
-                : new Vector3(target.posX, target.posY, target.posZ);
-            Quaternion targetRot = Quaternion.Euler(target.rotX, target.rotY, target.rotZ);
-
-            if (isLocalSpace)
-            {
-                transform.localPosition = Vector3.Lerp(transform.localPosition, targetPos, deltaTime);
-                transform.localRotation = Quaternion.Lerp(transform.localRotation, targetRot, deltaTime);
-            }
-            else
-            {
-                transform.position = Vector3.Lerp(transform.position, targetPos, deltaTime);
-                transform.rotation = Quaternion.Lerp(transform.rotation, targetRot, deltaTime);
-            }
+            Vector3 targetPos = target.position;
+            Quaternion targetRot = Quaternion.Euler(target.rotation);
+            transform.position = Vector3.Lerp(transform.position, targetPos, deltaTime);
+            transform.rotation = Quaternion.Lerp(transform.rotation, targetRot, deltaTime);
         }
 
         // Handle client variable changes from NetSyncManager


### PR DESCRIPTION
## Summary
- Replace legacy Transform3D with Vector3-based TransformData for all avatars
- Streamline binary protocol to always send 6 floats per transform and expand stealth handshake to 6 NaNs
- Align Python server, simulator, and tests with new full-precision transform format

## Testing
- ⚠️ `pytest` *(KeyboardInterrupt: tests did not complete after 78s)*

------
https://chatgpt.com/codex/tasks/task_e_689d6e92d9708328b7b90985e7b6d9d2