### PR TITLE
Queue messages until NetSyncManager finishes handshake

### DIFF
--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal/NetworkVariableManager.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal/NetworkVariableManager.cs
@@ -68,7 +68,7 @@ namespace Styly.NetSync
             if (_lastSentGlobal.TryGetValue(name, out var lastSent) && lastSent == value)
                 return true;
 
-            double now = UnityEngine.Time.realtimeSinceStartupAsDouble;
+            double now = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() / 1000.0;
 
             // Leading-edge attempt if cooldown elapsed (or not set)
             bool allowImmediate = !_nextAllowedGlobal.TryGetValue(name, out var next) || now >= next;
@@ -156,7 +156,7 @@ namespace Styly.NetSync
             if (_lastSentClient.TryGetValue(key, out var lastSent) && lastSent == value)
                 return true;
 
-            double now = UnityEngine.Time.realtimeSinceStartupAsDouble;
+            double now = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() / 1000.0;
 
             // Leading-edge attempt if cooldown elapsed
             bool allowImmediate = !_nextAllowedClient.TryGetValue(key, out var next) || now >= next;

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/NetSyncManager.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/NetSyncManager.cs
@@ -43,6 +43,7 @@ namespace Styly.NetSync
         public UnityEvent<int, string, string[]> OnRPCReceived;
         public UnityEvent<string, string, string> OnGlobalVariableChanged;
         public UnityEvent<int, string, string, string> OnClientVariableChanged;
+        [HideInInspector]
         public UnityEvent OnReady;
         #endregion ------------------------------------------------------------------------
 

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/NetSyncManager.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/NetSyncManager.cs
@@ -43,6 +43,7 @@ namespace Styly.NetSync
         public UnityEvent<int, string, string[]> OnRPCReceived;
         public UnityEvent<string, string, string> OnGlobalVariableChanged;
         public UnityEvent<int, string, string, string> OnClientVariableChanged;
+        public UnityEvent OnReady;
         #endregion ------------------------------------------------------------------------
 
         #region === Singleton & Public API ===
@@ -94,6 +95,11 @@ namespace Styly.NetSync
 
         public bool SetClientVariable(string name, string value)
         {
+            if (_clientNo <= 0)
+            {
+                _pendingSelfClientNV.Add((name, value)); // late-binding until handshake
+                return true; // accepted
+            }
             return _networkVariableManager != null ? _networkVariableManager.SetClientVariable(_clientNo, name, value, _roomId) : false;
         }
 
@@ -156,6 +162,9 @@ namespace Styly.NetSync
         private float _discoveryStartTime;
         private const float ReconnectDelay = 10f;
         private float _reconnectAt;
+        private readonly List<(string name, string value)> _pendingSelfClientNV = new List<(string name, string value)>();
+        private bool _hasInvokedReady = false;
+        private bool _shouldCheckReady = false;
         #endregion ------------------------------------------------------------------------
 
         #region === Public Properties ===
@@ -166,6 +175,9 @@ namespace Styly.NetSync
         public AvatarManager AvatarManager => _avatarManager;
         public RPCManager RPCManager => _rpcManager;
         public TransformSyncManager TransformSyncManager => _transformSyncManager;
+        public bool HasServerConnection => _connectionManager?.IsConnected == true && !_connectionManager.IsConnectionError;
+        public bool HasHandshake => _clientNo > 0;
+        public bool IsReady => HasServerConnection && HasHandshake;
         public MessageProcessor MessageProcessor => _messageProcessor;
 
         public GameObject GetRemoteAvatarPrefab() => _remoteAvatarPrefab;
@@ -240,13 +252,23 @@ namespace Styly.NetSync
 
         private void Update()
         {
+            // Check ready state on main thread
+            if (_shouldCheckReady)
+            {
+                _shouldCheckReady = false;
+                CheckAndFireReady();
+            }
+            
             HandleDiscovery();
             HandleReconnection();
             ProcessMessages();
             SendTransformUpdates();
             
             // Process Network Variables debounced updates
-            _networkVariableManager?.Tick(Time.realtimeSinceStartupAsDouble, _roomId);
+            _networkVariableManager?.Tick(DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() / 1000.0, _roomId);
+            
+            // Flush pending RPCs
+            _rpcManager?.FlushPendingIfReady(_roomId);
             
             LogStatistics();
         }
@@ -316,6 +338,7 @@ namespace Styly.NetSync
         private void OnConnectionEstablished()
         {
             DebugLog("Connection established successfully");
+            _shouldCheckReady = true;
         }
 
         private void OnRemoteAvatarDisconnected(int clientNo)
@@ -358,6 +381,29 @@ namespace Styly.NetSync
         {
             _clientNo = clientNo;
             DebugLog($"Local client number assigned: {clientNo}");
+            
+            // Flush pending self client NV
+            foreach (var (name, value) in _pendingSelfClientNV)
+            {
+                _networkVariableManager?.SetClientVariable(_clientNo, name, value, _roomId);
+            }
+            _pendingSelfClientNV.Clear();
+            
+            // Set flag to check ready state on main thread
+            _shouldCheckReady = true;
+        }
+
+        private void CheckAndFireReady()
+        {
+            if (IsReady && !_hasInvokedReady)
+            {
+                _hasInvokedReady = true;
+                DebugLog("NetSyncManager is now Ready (connected and handshaken)");
+                OnReady?.Invoke();
+                
+                // Don't flush immediately - let Update() handle it on next frame
+                // This avoids potential socket state issues
+            }
         }
 
         private void OnServerDiscovered(string serverAddress, int dealerPort, int subPort)
@@ -498,6 +544,9 @@ namespace Styly.NetSync
             if (_connectionManager.IsConnectionError) { return; }
             Debug.LogError($"[NetSyncManager] {reason}");
             _reconnectAt = Time.time + ReconnectDelay;
+            _clientNo = 0; // Reset client number
+            _hasInvokedReady = false; // Reset ready state
+            _shouldCheckReady = false; // Reset check flag
             StopNetworking();
         }
 


### PR DESCRIPTION
Summary:

* Introduce a clear **Ready** concept in `NetSyncManager` (connected + handshake) and expose `IsReady`, `HasServerConnection`, `HasHandshake`, and `OnReady` event.
* Add **RPC outgoing queueing** in `RPCManager` to buffer RPC calls made before Ready; queue includes TTL, max size, and bounded flush per frame; drains respecting existing client-side rate limiter.
* Implement **late-binding** for self-directed client network variables: `NetSyncManager.SetClientVariable(name,value)` buffers when local clientNo is not yet assigned and forwards to `NetworkVariableManager` once handshake assigns the real client number.
* Preserve existing NetworkVariable internals (debounce/dedupe/retry) — do **not** add a second NV queue; rely on current `Tick()` behavior.
* Wire connection and handshake events: `ConnectionManager.OnConnectionEstablished` and `MessageProcessor.OnLocalClientNoAssigned` trigger Ready evaluation and pending flushes.
* Add configurable parameters (inspector-serializable) for RPC queue: `_maxPendingRpc`, `_rpcTtlSeconds`, `_maxFlushPerFrame`, and logging for queue drops/expiry.
* Ensure disconnect/reset semantics: do not lose pending buffers on transient disconnects; reset `_clientNo` on disconnect so late-binding resumes correctly on next Ready.
* Keep RPC send path refactored into `TrySendNow(...)` to centralize rate-limiter + socket send logic and avoid re-queue loops.
* Bounded per-frame work (`_maxFlushPerFrame`) to avoid large stalls when flushing backlog.
* Update `NetSyncManager.Update()` to call `rpcManager.FlushPendingIfReady(roomId)`.

Files/areas touched (high-level):

* `NetSyncManager.cs` — add Ready properties/event, buffer for self client NV, flush logic, update wiring.
* `RPCManager.cs` — add pending RPC queue, TTL/max size, `TrySendNow`, `FlushPendingIfReady`.
* `MessageProcessor.cs` — ensure `OnLocalClientNoAssigned(int)` is emitted where deviceId→clientNo mapping completes.
* `ConnectionManager.cs` — rely on `OnConnectionEstablished`/disconnect hooks (no API changes).
* `NetworkVariableManager.cs` — no structural change; continued reliance on existing debounce/dedupe/retry behavior.
* Minor: inspector-exposed fields, logs for queue drop/expiry, small refactors to keep main-thread safety and bounded frame work.

Behavioral rationale:

* Prevents silent RPC drops and unintended client-0 targeting for self client NV calls issued before the handshake completes.
* Minimal, backward-compatible internal change to NV pipeline by avoiding double-queuing; only RPCs and self-target binding are newly buffered.
* Keeps server semantics for ID mapping and reassignments intact; buffers survive transient disconnects and are drained only when a true Ready state is reached.

Reference snapshot of repository context for implementers:
