### PR TITLE
Improve/on ready event

### DIFF
--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/NetSyncManager.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/NetSyncManager.cs
@@ -7,6 +7,7 @@ using UnityEngine.Events;
 
 namespace Styly.NetSync
 {
+    [DefaultExecutionOrder(-1000)]
     public class NetSyncManager : MonoBehaviour
     {
         #region === Inspector ===
@@ -258,18 +259,18 @@ namespace Styly.NetSync
                 _shouldCheckReady = false;
                 CheckAndFireReady();
             }
-            
+
             HandleDiscovery();
             HandleReconnection();
             ProcessMessages();
             SendTransformUpdates();
-            
+
             // Process Network Variables debounced updates
             _networkVariableManager?.Tick(DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() / 1000.0, _roomId);
-            
+
             // Flush pending RPCs
             _rpcManager?.FlushPendingIfReady(_roomId);
-            
+
             LogStatistics();
         }
         #endregion ------------------------------------------------------------------------
@@ -381,14 +382,14 @@ namespace Styly.NetSync
         {
             _clientNo = clientNo;
             DebugLog($"Local client number assigned: {clientNo}");
-            
+
             // Flush pending self client NV
             foreach (var (name, value) in _pendingSelfClientNV)
             {
                 _networkVariableManager?.SetClientVariable(_clientNo, name, value, _roomId);
             }
             _pendingSelfClientNV.Clear();
-            
+
             // Set flag to check ready state on main thread
             _shouldCheckReady = true;
         }
@@ -400,7 +401,7 @@ namespace Styly.NetSync
                 _hasInvokedReady = true;
                 DebugLog("NetSyncManager is now Ready (connected and handshaken)");
                 OnReady?.Invoke();
-                
+
                 // Don't flush immediately - let Update() handle it on next frame
                 // This avoids potential socket state issues
             }

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/NetSyncManager.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/NetSyncManager.cs
@@ -43,7 +43,6 @@ namespace Styly.NetSync
         public UnityEvent<int, string, string[]> OnRPCReceived;
         public UnityEvent<string, string, string> OnGlobalVariableChanged;
         public UnityEvent<int, string, string, string> OnClientVariableChanged;
-        [HideInInspector]
         public UnityEvent OnReady;
         #endregion ------------------------------------------------------------------------
 


### PR DESCRIPTION
This pull request introduces a minor update to the `NetSyncManager` class to improve its behavior in Unity's execution order and modifies the visibility of the `OnReady` event in the inspector.

Unity execution order:

* Added the `[DefaultExecutionOrder(-1000)]` attribute to the `NetSyncManager` class to ensure it initializes earlier in the Unity lifecycle.

Inspector visibility:

* Removed the `[HideInInspector]` attribute from the `OnReady` event, making it visible in the Unity Inspector for easier assignment of event handlers.

Close #54