### PR TITLE
Update styly xr rig 0.4.5

### DIFF
--- a/STYLY-NetSync-Unity/Assets/Samples_Dev/Demo-01/Demo-01.unity
+++ b/STYLY-NetSync-Unity/Assets/Samples_Dev/Demo-01/Demo-01.unity
@@ -119,63 +119,6 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
---- !u!1001 &99100142
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 4062051036038346442, guid: 2f952482bf1d64a0a9fab4329f7e11b2, type: 3}
-      propertyPath: m_Name
-      value: STYLY XR Rig
-      objectReference: {fileID: 0}
-    - target: {fileID: 5778849293402468298, guid: 2f952482bf1d64a0a9fab4329f7e11b2, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5778849293402468298, guid: 2f952482bf1d64a0a9fab4329f7e11b2, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5778849293402468298, guid: 2f952482bf1d64a0a9fab4329f7e11b2, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: -1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5778849293402468298, guid: 2f952482bf1d64a0a9fab4329f7e11b2, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5778849293402468298, guid: 2f952482bf1d64a0a9fab4329f7e11b2, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5778849293402468298, guid: 2f952482bf1d64a0a9fab4329f7e11b2, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5778849293402468298, guid: 2f952482bf1d64a0a9fab4329f7e11b2, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5778849293402468298, guid: 2f952482bf1d64a0a9fab4329f7e11b2, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5778849293402468298, guid: 2f952482bf1d64a0a9fab4329f7e11b2, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5778849293402468298, guid: 2f952482bf1d64a0a9fab4329f7e11b2, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 2f952482bf1d64a0a9fab4329f7e11b2, type: 3}
 --- !u!1 &128240247
 GameObject:
   m_ObjectHideFlags: 0
@@ -902,6 +845,63 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 65e15cd9d8379c449a0cee7e4d444a7a, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1001 &1345725595
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 932545197216251793, guid: 8ea6960e82d7c419c93a7f4f18e7b06e, type: 3}
+      propertyPath: m_Name
+      value: STYLY XR Rig
+      objectReference: {fileID: 0}
+    - target: {fileID: 932545197216251794, guid: 8ea6960e82d7c419c93a7f4f18e7b06e, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 932545197216251794, guid: 8ea6960e82d7c419c93a7f4f18e7b06e, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 932545197216251794, guid: 8ea6960e82d7c419c93a7f4f18e7b06e, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 932545197216251794, guid: 8ea6960e82d7c419c93a7f4f18e7b06e, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 932545197216251794, guid: 8ea6960e82d7c419c93a7f4f18e7b06e, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 932545197216251794, guid: 8ea6960e82d7c419c93a7f4f18e7b06e, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 932545197216251794, guid: 8ea6960e82d7c419c93a7f4f18e7b06e, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 932545197216251794, guid: 8ea6960e82d7c419c93a7f4f18e7b06e, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 932545197216251794, guid: 8ea6960e82d7c419c93a7f4f18e7b06e, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 932545197216251794, guid: 8ea6960e82d7c419c93a7f4f18e7b06e, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 8ea6960e82d7c419c93a7f4f18e7b06e, type: 3}
 --- !u!1 &1379146743
 GameObject:
   m_ObjectHideFlags: 0
@@ -1235,7 +1235,7 @@ MonoBehaviour:
   _roomId: default_room
   _localAvatarPrefab: {fileID: 5433920805635859656, guid: 533c4bfc8e64a634c991381ba7791b99, type: 3}
   _remoteAvatarPrefab: {fileID: 4943129801574805003, guid: ab3b1ca71deaa734dabad80f2cbbe3f6, type: 3}
-  OnClientConnected:
+  OnAvatarConnected:
     m_PersistentCalls:
       m_Calls: []
   OnClientDisconnected:
@@ -1262,6 +1262,9 @@ MonoBehaviour:
   OnClientVariableChanged:
     m_PersistentCalls:
       m_Calls: []
+  OnReady:
+    m_PersistentCalls:
+      m_Calls: []
 --- !u!4 &1846318900
 Transform:
   m_ObjectHideFlags: 0
@@ -1283,6 +1286,6 @@ SceneRoots:
   m_Roots:
   - {fileID: 519411593}
   - {fileID: 128240249}
-  - {fileID: 99100142}
   - {fileID: 1846318900}
   - {fileID: 690301447}
+  - {fileID: 1345725595}

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/package.json
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/package.json
@@ -8,7 +8,7 @@
     "org.nuget.netmq": "4.0.2",
     "com.unity.xr.core-utils": "2.1.1",
     "com.unity.nuget.newtonsoft-json": "3.2.1",
-    "com.styly.styly-xr-rig": "0.4.4"
+    "com.styly.styly-xr-rig": "0.4.5"
   },
   "author": {
     "name": "STYLY, Inc.",

--- a/STYLY-NetSync-Unity/Packages/packages-lock.json
+++ b/STYLY-NetSync-Unity/Packages/packages-lock.json
@@ -8,11 +8,11 @@
         "org.nuget.netmq": "4.0.2",
         "com.unity.xr.core-utils": "2.1.1",
         "com.unity.nuget.newtonsoft-json": "3.2.1",
-        "com.styly.styly-xr-rig": "0.4.4"
+        "com.styly.styly-xr-rig": "0.4.5"
       }
     },
     "com.styly.styly-xr-rig": {
-      "version": "0.4.4",
+      "version": "0.4.5",
       "depth": 1,
       "source": "registry",
       "dependencies": {


### PR DESCRIPTION
This pull request updates the `STYLY XR Rig` prefab in the Demo-01 Unity scene to use a newer version and updates the package dependencies accordingly. It also introduces minor event renaming and adds a new event to improve clarity and functionality in the scene's network synchronization logic.

Prefab and Scene Updates:

* Replaced the old `STYLY XR Rig` prefab instance (GUID: `2f952482bf1d64a0a9fab4329f7e11b2`) with a new instance (GUID: `8ea6960e82d7c419c93a7f4f18e7b06e`) in `Demo-01.unity`, updating all relevant references and root objects. [[1]](diffhunk://#diff-29051a84aa2db6146ccf1b2ece223e1d0f8ed14add89d32a59ea77e9a5cee298L122-L178) [[2]](diffhunk://#diff-29051a84aa2db6146ccf1b2ece223e1d0f8ed14add89d32a59ea77e9a5cee298R848-R904) [[3]](diffhunk://#diff-29051a84aa2db6146ccf1b2ece223e1d0f8ed14add89d32a59ea77e9a5cee298L1286-R1291)

Dependency Updates:

* Updated the `com.styly.styly-xr-rig` package from version `0.4.4` to `0.4.5` in both `package.json` and `packages-lock.json` to ensure the project uses the latest prefab and features. [[1]](diffhunk://#diff-c048c88725c85d2f28e120b10b054559ed59a262cb4c7c021c751f21fe49d35bL11-R11) [[2]](diffhunk://#diff-066d9509e08bf27d90a446f2479f944fa9fa16c0c14011a83ebb8fce1f5224e9L11-R15)
