### PR TITLE
Throttle editor repaint to reduce CPU

### DIFF
--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Editor/NetSyncAvatarEditor.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Editor/NetSyncAvatarEditor.cs
@@ -8,6 +8,7 @@ namespace Styly.NetSync.Editor
     {
         private NetSyncAvatar _netSyncAvatar;
         private bool _showClientVariables = true;
+        private double _lastRepaint;
         
         private void OnEnable()
         {
@@ -84,7 +85,11 @@ namespace Styly.NetSync.Editor
             // Force repaint to show real-time updates
             if (Application.isPlaying && Event.current.type == EventType.Layout)
             {
-                Repaint();
+                if (EditorApplication.timeSinceStartup - _lastRepaint > 0.2)
+                {
+                    Repaint();
+                    _lastRepaint = EditorApplication.timeSinceStartup;
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
- Throttle NetSyncAvatarEditor repaint calls to once every 0.2s during play mode to prevent excessive CPU use

## Testing
- `pytest -q` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68bb03c6c55c8328b55b68a7af323bb3