### PR TITLE
Cache NetSyncAvatar references to avoid per-frame GetComponent calls

### DIFF
--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/NetSyncManager.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/NetSyncManager.cs
@@ -783,18 +783,9 @@ namespace Styly.NetSync
             Transform parent = null;
             if (_avatarManager != null)
             {
-                var peers = _avatarManager.ConnectedPeers;
-                if (peers != null && peers.TryGetValue(clientNo, out var go) && go)
+                if (_avatarManager.TryGetNetSyncAvatar(clientNo, out var net) && net != null)
                 {
-                    var net = go.GetComponent<NetSyncAvatar>();
-                    if (net != null && net._head != null)
-                    {
-                        parent = net._head.parent;
-                    }
-                    else
-                    {
-                        parent = go.transform; // Fallback to avatar root if head/parent is unavailable
-                    }
+                    parent = net._head != null ? net._head.parent : net.transform;
                 }
             }
 


### PR DESCRIPTION
## Summary
- cache NetSyncAvatar instances per client and reuse them for updates
- simplify human presence transform update by accessing cached avatars instead of GetComponent

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68bb033b0bcc8328a4f6319ab76ba267