### PR TITLE
feat: add drain NV flush policy

### DIFF
--- a/STYLY-NetSync-Server/src/styly_netsync/server.py
+++ b/STYLY-NetSync-Server/src/styly_netsync/server.py
@@ -497,7 +497,7 @@ class NetSyncServer:
                 if self.router:
                     self.router.close()
                 self.context.term()
-                raise SystemExit(1) from None
+                raise SystemExit(1) from e
             else:
                 logger.error(f"ZMQ Error: {e}")
                 raise

--- a/STYLY-NetSync-Server/src/styly_netsync/server.py
+++ b/STYLY-NetSync-Server/src/styly_netsync/server.py
@@ -1041,7 +1041,10 @@ class NetSyncServer:
             self._enqueue_pub(topic, msg)
 
         elapsed_ms = (time.perf_counter() - start) * 1000.0
-        logger.info(f"NV flush took {elapsed_ms:.2f} ms (room={room_id})")
+        if elapsed_ms > 10.0:
+            logger.info(f"NV flush took {elapsed_ms:.2f} ms (room={room_id})")
+        else:
+            logger.debug(f"NV flush took {elapsed_ms:.2f} ms (room={room_id})")
 
     def _flush_nv_rate_limited(self, room_id: str) -> None:
         """Flush NV updates using existing rate-limited fairness logic."""


### PR DESCRIPTION
## Summary
- introduce `nv_flush_policy` with default `drain`
- add `_flush_nv_drain` and `_flush_nv_rate_limited` implementations
- flush NV queues every cycle according to policy and CLI option `--nv-flush-policy`

## Testing
- `ruff check src/styly_netsync/server.py`
- `black src/styly_netsync/server.py`
- `mypy src` *(fails: many missing annotations in existing modules)*
- `pytest -q` *(terminated after long runtime)*

------
https://chatgpt.com/codex/tasks/task_e_68bc44f37a4c8328b3b27a7d99b7258a