### PR TITLE
fix: improve handling of updated markdown files in release workflow

### DIFF
--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -146,7 +146,12 @@ jobs:
 
             AFTER=$(sha256sum "$file" | cut -d' ' -f1)
             if [ "$BEFORE" != "$AFTER" ]; then
-              UPDATED_FILES="$UPDATED_FILES\n$file"
+              # Append without introducing a leading empty line
+              if [ -z "$UPDATED_FILES" ]; then
+                UPDATED_FILES="$file"
+              else
+                UPDATED_FILES="$UPDATED_FILES"$'\n'"$file"
+              fi
             fi
           done
 
@@ -154,7 +159,8 @@ jobs:
             echo "ℹ️ No version strings found in .md files (this is normal if none exist yet)"
             echo "UPDATED_MD_FILES=" >> $GITHUB_ENV
           else
-            UNIQUE_FILES=$(echo -e "$UPDATED_FILES" | sort -u)
+            # Normalize, drop blank lines, and de-duplicate
+            UNIQUE_FILES=$(echo -e "$UPDATED_FILES" | sed '/^[[:space:]]*$/d' | sort -u)
             COUNT=$(echo "$UNIQUE_FILES" | wc -l)
             echo "✅ Updated version in $COUNT file(s)"
             {
@@ -173,9 +179,11 @@ jobs:
           git add STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Resources/com.styly.styly-netsync.version.txt
           git add STYLY-NetSync-Server/pyproject.toml
 
-          # Add updated .md files if any
+          # Add updated .md files if any (filter blank lines to avoid empty pathspec)
           if [ -n "${UPDATED_MD_FILES}" ]; then
-            echo "${UPDATED_MD_FILES}" | tr '\n' '\0' | xargs -0 -I{} git add "{}"
+            echo "${UPDATED_MD_FILES}" | while IFS= read -r file; do
+              [ -n "$file" ] && git add "$file"
+            done
           fi
 
           # Check if there are changes to commit


### PR DESCRIPTION
This PR is intended to fix the following error.
```
fatal: empty string is not a valid pathspec. please use . instead if you meant to match all paths
Error: Process completed with exit code 123.
```

This pull request improves the handling of updated Markdown files in the release workflow by ensuring that blank lines are filtered out and that file lists are properly deduplicated and normalized. These changes help prevent issues with empty pathspecs and ensure only valid files are processed.

**Improvements to file list handling in the release workflow:**

* Updated the logic for building the `UPDATED_FILES` list to avoid introducing leading empty lines and to ensure correct formatting when appending file names.
* Added normalization and blank line filtering when deduplicating the list of updated Markdown files to ensure only valid file names are considered.

**Improvements to Git add step:**

* Changed the method for adding updated Markdown files to the Git staging area by filtering out blank lines, preventing errors from empty file paths.