### PR TITLE
fix: add workaround to ignore initial pause for Android devices

### DIFF
--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/NetSyncManager.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/NetSyncManager.cs
@@ -328,6 +328,9 @@ namespace Styly.NetSync
 
         private void OnApplicationPause(bool paused)
         {
+            // This is a wourkaround to ignore initial pause for ANdroid devices
+            if (Time.time < 1) { return; }
+
             if (paused)
             {
                 DebugLog("Application paused - stopping network");
@@ -836,7 +839,7 @@ namespace Styly.NetSync
             {
                 // Full local->world for position
                 worldPos = parent.TransformPoint(position);
-                
+
                 // Yaw-only in local space, then compose with parent's rotation to get world yaw
                 var localYaw = Quaternion.Euler(0f, eulerRotation.y, 0f);
                 var worldYaw = parent.rotation * localYaw;


### PR DESCRIPTION
This pull request introduces a workaround in the `NetSyncManager` to address an issue with initial application pause events on Android devices. The change ensures that the network is not stopped during the initial pause, which can occur shortly after the app starts.

Platform-specific workaround:

* [`NetSyncManager.cs`](diffhunk://#diff-85fbaac67340cd0e7530de3718988af88b85f2a51179892204c6e280b6d8506dR331-R333): Added a conditional check in `OnApplicationPause` to ignore pause events if `Time.time` is less than 1, preventing unintended network stops during app startup on Android devices.

Close https://github.com/styly-dev/STYLY-NetSync/issues/138