### PR TITLE
feat: enhance version retrieval to support development mode detection

### DIFF
--- a/STYLY-NetSync-Server/src/styly_netsync/server.py
+++ b/STYLY-NetSync-Server/src/styly_netsync/server.py
@@ -102,7 +102,7 @@ def get_version() -> str:
                         return True
             return False
         except im.PackageNotFoundError:
-            return True  # If not found in metadata, likely development mode
+            return False  # If not found in metadata, not development mode
 
     # 1) For development mode, prioritize pyproject.toml
     if is_development_mode():
@@ -114,7 +114,7 @@ def get_version() -> str:
                     v = (data.get("project") or {}).get("version")
                     if v:
                         return v
-                except Exception:
+                except (tomllib.TOMLDecodeError, OSError, UnicodeDecodeError):
                     # Continue to next fallback if TOML parsing fails
                     pass
                 break
@@ -139,7 +139,7 @@ def get_version() -> str:
                 v = (data.get("project") or {}).get("version")
                 if v:
                     return v
-            except Exception:
+            except (tomllib.TOMLDecodeError, OSError, UnicodeDecodeError):
                 pass
             break
 


### PR DESCRIPTION
Fix version detection in development mode installations

Problem

When styly-netsync-server is installed in development mode using pip install -e . , the --version command returns an outdated version number instead of the current version from pyproject.toml.

Before this fix:
- styly-netsync-server --version returned 0.5.4 (cached metadata from install time)
- Current pyproject.toml shows version = "0.5.8"

Root Cause

Development mode installations (pip install -e .) cache package metadata at installation time. The importlib.metadata.version() function returns the version that was in pyproject.toml when the package was first installed, not the current filesystem version.

Solution

Modified the get_version() function in server.py to:

1. Detect development mode installations by examining package file paths via importlib.metadata
2. Prioritize pyproject.toml parsing for development mode installations
3. Fall back to importlib.metadata for normal PyPI installations
4. Improve error handling with multiple fallback strategies

Changes Made

- Updated get_version() function priority order
- Added is_development_mode() helper function
- Enhanced TOML parsing with better error handling
- Maintains backward compatibility with production installations

Testing

After this fix:
- styly-netsync-server --version correctly returns 0.5.8 in
development mode
- Production installations via PyPI will continue to work as
expected
- uvx styly-netsync-server --version will work correctly after
PyPI publication

Impact

- ✅ Development workflow: Developers see current version numbers
- ✅ Production compatibility: No breaking changes for PyPI installations
- ✅ CI/CD reliability: Version commands return accurate information

---
Type: Bug FixBreaking Change: NoRequires Documentation Update:
No