### PR TITLE
[Breaking change] refactor: standardize parameter order for client variable methods

### DIFF
--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/NetworkVariableManager.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/NetworkVariableManager.cs
@@ -51,15 +51,15 @@ namespace Styly.NetSync
         // Events (using C# events, NOT SendMessage)
         public event Action<string, string, string> OnGlobalVariableChanged;
         public event Action<int, string, string, string> OnClientVariableChanged;
-        
+
         // Flag to track if initial network variables have been received
         private bool _hasReceivedInitialSync = false;
         private DateTime _connectionEstablishedTime = DateTime.MinValue; // Track when connection was established
         // Conservative timeout for initial network variable sync to handle empty rooms
         private const float INITIAL_SYNC_TIMEOUT = 2.0f;
-        
+
         public bool HasReceivedInitialSync => _hasReceivedInitialSync;
-        
+
         /// <summary>
         /// Reset the initial sync flag (called when connection is lost)
         /// </summary>
@@ -68,7 +68,7 @@ namespace Styly.NetSync
             _hasReceivedInitialSync = false;
             _connectionEstablishedTime = DateTime.MinValue;
         }
-        
+
         /// <summary>
         /// Called when connection is established to start tracking sync timeout
         /// </summary>
@@ -76,7 +76,7 @@ namespace Styly.NetSync
         {
             _connectionEstablishedTime = DateTime.UtcNow;
         }
-        
+
         /// <summary>
         /// Check if we should consider initial sync complete based on timeout
         /// This handles cases where server has no variables to send
@@ -209,7 +209,7 @@ namespace Styly.NetSync
         }
 
         // Client Variables API
-        public bool SetClientVariable(int targetClientNo, string name, string value, string roomId)
+        public bool SetClientVariable(string name, string value, int targetClientNo, string roomId)
         {
             if (!ValidateVariableName(name) || !ValidateVariableValue(value))
                 return false;
@@ -313,7 +313,7 @@ namespace Styly.NetSync
             }
         }
 
-        public string GetClientVariable(int clientNo, string name, string defaultValue = null)
+        public string GetClientVariable(string name, int clientNo, string defaultValue = null)
         {
             if (!_hasReceivedInitialSync)
             {
@@ -356,7 +356,7 @@ namespace Styly.NetSync
             {
                 _hasReceivedInitialSync = true;
             }
-            
+
             if (data.TryGetValue("variables", out var variablesObj))
             {
                 object[] variables = ConvertToObjectArray(variablesObj);
@@ -398,7 +398,7 @@ namespace Styly.NetSync
             {
                 _hasReceivedInitialSync = true;
             }
-            
+
             if (data.TryGetValue("clientVariables", out var clientVarsObj))
             {
                 Dictionary<string, object> clientVariables = ConvertToDictionary(clientVarsObj);
@@ -500,7 +500,7 @@ namespace Styly.NetSync
         private static int EstimateGlobalVarSetSize(string name, string value)
         {
             // 1 (type) + 2 (sender) + 1 + nameLen + 2 + valueLen + 8 (timestamp)
-            int nameLen  = ClampedUtf8Length(name, 64);
+            int nameLen = ClampedUtf8Length(name, 64);
             int valueLen = ClampedUtf8Length(value, 1024);
             return 1 + 2 + 1 + nameLen + 2 + valueLen + 8;
         }
@@ -508,7 +508,7 @@ namespace Styly.NetSync
         private static int EstimateClientVarSetSize(string name, string value)
         {
             // 1 (type) + 2 (sender) + 2 (target) + 1 + nameLen + 2 + valueLen + 8 (timestamp)
-            int nameLen  = ClampedUtf8Length(name, 64);
+            int nameLen = ClampedUtf8Length(name, 64);
             int valueLen = ClampedUtf8Length(value, 1024);
             return 1 + 2 + 2 + 1 + nameLen + 2 + valueLen + 8;
         }

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/NetSyncAvatar.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/NetSyncAvatar.cs
@@ -280,7 +280,7 @@ namespace Styly.NetSync
         /// </summary>
         public bool SetClientVariable(string name, string value)
         {
-            return NetSyncManager.Instance != null ? NetSyncManager.Instance.SetClientVariable(_clientNo, name, value) : false;
+            return NetSyncManager.Instance != null ? NetSyncManager.Instance.SetClientVariable(name, value, _clientNo) : false;
         }
 
         /// <summary>
@@ -288,23 +288,23 @@ namespace Styly.NetSync
         /// </summary>
         public string GetClientVariable(string name, string defaultValue = null)
         {
-            return NetSyncManager.Instance != null ? NetSyncManager.Instance.GetClientVariable(_clientNo, name, defaultValue) : defaultValue;
+            return NetSyncManager.Instance != null ? NetSyncManager.Instance.GetClientVariable(name, _clientNo, defaultValue) : defaultValue;
         }
 
         /// <summary>
         /// Set a client variable for a specific client
         /// </summary>
-        public bool SetClientVariable(int targetClientNo, string name, string value)
+        public bool SetClientVariable(string name, string value, int targetClientNo)
         {
-            return NetSyncManager.Instance != null ? NetSyncManager.Instance.SetClientVariable(targetClientNo, name, value) : false;
+            return NetSyncManager.Instance != null ? NetSyncManager.Instance.SetClientVariable(name, value, targetClientNo) : false;
         }
 
         /// <summary>
         /// Get a client variable for a specific client
         /// </summary>
-        public string GetClientVariable(int clientNo, string name, string defaultValue = null)
+        public string GetClientVariable(string name, int clientNo, string defaultValue = null)
         {
-            return NetSyncManager.Instance != null ? NetSyncManager.Instance.GetClientVariable(clientNo, name, defaultValue) : defaultValue;
+            return NetSyncManager.Instance != null ? NetSyncManager.Instance.GetClientVariable(name, clientNo, defaultValue) : defaultValue;
         }
         #endregion
     }

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/NetSyncManager.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/NetSyncManager.cs
@@ -90,7 +90,6 @@ namespace Styly.NetSync
             }
         }
 
-
         // Network Variables API
         public bool SetGlobalVariable(string name, string value)
         {
@@ -109,17 +108,22 @@ namespace Styly.NetSync
                 _pendingSelfClientNV.Add((name, value)); // late-binding until handshake
                 return true; // accepted
             }
-            return _networkVariableManager != null ? _networkVariableManager.SetClientVariable(_clientNo, name, value, _roomId) : false;
+            return _networkVariableManager != null ? _networkVariableManager.SetClientVariable(name, value, _clientNo, _roomId) : false;
         }
 
-        public bool SetClientVariable(int targetClientNo, string name, string value)
+        public bool SetClientVariable(string name, string value, int targetClientNo)
         {
-            return _networkVariableManager != null ? _networkVariableManager.SetClientVariable(targetClientNo, name, value, _roomId) : false;
+            return _networkVariableManager != null ? _networkVariableManager.SetClientVariable(name, value, targetClientNo, _roomId) : false;
         }
 
-        public string GetClientVariable(int clientNo, string name, string defaultValue = null)
+        public string GetClientVariable(string name, string defaultValue = null)
         {
-            return _networkVariableManager != null ? _networkVariableManager.GetClientVariable(clientNo, name, defaultValue) : defaultValue;
+            return _networkVariableManager != null ? _networkVariableManager.GetClientVariable(name, _clientNo, defaultValue) : defaultValue;
+        }
+
+        public string GetClientVariable(string name, int clientNo, string defaultValue = null)
+        {
+            return _networkVariableManager != null ? _networkVariableManager.GetClientVariable(name, clientNo, defaultValue) : defaultValue;
         }
 
         /// <summary>
@@ -570,7 +574,7 @@ namespace Styly.NetSync
             // Flush pending self client NV
             foreach (var (name, value) in _pendingSelfClientNV)
             {
-                _networkVariableManager?.SetClientVariable(_clientNo, name, value, _roomId);
+                _networkVariableManager?.SetClientVariable(name, value, _clientNo, _roomId);
             }
             _pendingSelfClientNV.Clear();
 

--- a/_README.md
+++ b/_README.md
@@ -167,11 +167,11 @@ NetSyncManager.Instance.SetGlobalVariable("gameState", "playing");
 NetSyncManager.Instance.SetClientVariable("playerScore", "100");
 
 // Set another client's variable (requires their client number)
-NetSyncManager.Instance.SetClientVariable(targetClientNo, "health", "50");
+NetSyncManager.Instance.SetClientVariable("health", "50", targetClientNo);
 
 // Get variables
 string gameState = NetSyncManager.Instance.GetGlobalVariable("gameState");
-string score = NetSyncManager.Instance.GetClientVariable(clientNo, "playerScore");
+string score = NetSyncManager.Instance.GetClientVariable("playerScore", clientNo);
 
 // Get variables with default value
 string gameState = NetSyncManager.Instance.GetGlobalVariable("gameState", "Initial State");


### PR DESCRIPTION
This pull request refactors the client variable API to use a more consistent and intuitive parameter order for methods related to setting and getting client variables. The changes affect the `NetworkVariableManager`, `NetSyncManager`, and `NetSyncAvatar` classes, as well as the usage examples in the documentation. The main goal is to improve code readability and reduce confusion when calling these methods.

### API consistency and refactoring

* Swapped parameter order for all `SetClientVariable` and `GetClientVariable` methods to consistently use `(string name, string value, int targetClientNo)` and `(string name, int clientNo, string defaultValue = null)` respectively, across `NetworkVariableManager`, `NetSyncManager`, and `NetSyncAvatar`. [[1]](diffhunk://#diff-c03db5d91cabfeacbc546ca91599d7d66da128d497f683be57cbbccd45d87459L212-R212) [[2]](diffhunk://#diff-c03db5d91cabfeacbc546ca91599d7d66da128d497f683be57cbbccd45d87459L316-R316) [[3]](diffhunk://#diff-240da6a2ec82adc7416223e594094274f5755fa49745a8a594e432b16c485ac8L283-R307) [[4]](diffhunk://#diff-85fbaac67340cd0e7530de3718988af88b85f2a51179892204c6e280b6d8506dL112-R126) [[5]](diffhunk://#diff-85fbaac67340cd0e7530de3718988af88b85f2a51179892204c6e280b6d8506dL573-R577)
* Updated method calls throughout the codebase to match the new parameter order, ensuring that all usages are consistent and correct. [[1]](diffhunk://#diff-85fbaac67340cd0e7530de3718988af88b85f2a51179892204c6e280b6d8506dL112-R126) [[2]](diffhunk://#diff-85fbaac67340cd0e7530de3718988af88b85f2a51179892204c6e280b6d8506dL573-R577)

### Documentation updates

* Updated usage examples in `_README.md` to reflect the new method signatures and parameter order for setting and getting client variables.

### Minor cleanup

* Removed an unnecessary blank line in `NetSyncManager.cs` for minor code tidiness.

Close https://github.com/styly-dev/STYLY-NetSync/issues/137