### PR TITLE
feat: Beacon port setting

### DIFF
--- a/STYLY-NetSync-Server/src/styly_netsync/server.py
+++ b/STYLY-NetSync-Server/src/styly_netsync/server.py
@@ -82,6 +82,19 @@ DEFAULT_SERVER_NAME = "STYLY-NetSync-Server"
 DEFAULT_NV_FLUSH_POLICY = "drain"
 
 
+def valid_port(value: str) -> int:
+    """Return a validated TCP/UDP port number."""
+    try:
+        port = int(value)
+    except ValueError as exc:  # pragma: no cover - argparse handles messaging
+        raise argparse.ArgumentTypeError("Port must be an integer") from exc
+
+    if not 1 <= port <= 65535:
+        raise argparse.ArgumentTypeError("Port must be between 1 and 65535")
+
+    return port
+
+
 @lru_cache(maxsize=1)
 def get_version() -> str:
     """
@@ -1514,6 +1527,12 @@ def main():
         "--no-beacon", action="store_true", help="Disable beacon discovery"
     )
     parser.add_argument(
+        "--beacon-port",
+        type=valid_port,
+        metavar="PORT",
+        help=f"UDP port used for server discovery beacons (default: {DEFAULT_BEACON_PORT})",
+    )
+    parser.add_argument(
         "-V",
         "--version",
         action="version",
@@ -1539,6 +1558,8 @@ def main():
     logger.info(f"  DEALER port: {dealer_port}")
     logger.info(f"  PUB port: {pub_port}")
     if not args.no_beacon:
+        if args.beacon_port is not None:
+            beacon_port = args.beacon_port
         logger.info(f"  Beacon port: {beacon_port}")
         logger.info(f"  Server name: {server_name}")
     else:

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/ServerDiscoveryManager.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/ServerDiscoveryManager.cs
@@ -18,7 +18,12 @@ namespace Styly.NetSync
 
         public bool EnableDiscovery { get; set; } = true;
         public float DiscoveryTimeout { get; set; } = 5f;
-        public int BeaconPort { get; set; } = 9999;
+        private int _beaconPort = 9999;
+        public int BeaconPort
+        {
+            get => Volatile.Read(ref _beaconPort);
+            private set => Volatile.Write(ref _beaconPort, value);
+        }
         public bool IsDiscovering => _isDiscovering;
         public float DiscoveryInterval { get; set; } = 0.5f; // Send discovery request every 0.5 seconds
 
@@ -27,6 +32,11 @@ namespace Styly.NetSync
         public ServerDiscoveryManager(bool enableDebugLogs)
         {
             _enableDebugLogs = enableDebugLogs;
+        }
+
+        public void SetBeaconPort(int port)
+        {
+            BeaconPort = port;
         }
 
         public void StartDiscovery()


### PR DESCRIPTION
This pull request introduces configurable server discovery beacon ports and improves the handling of advanced network settings in both the Unity client and Python server. The main changes include adding a `BeaconPort` property to allow customization of the UDP port used for server discovery, updating the Unity editor to expose advanced options in a collapsible section, and ensuring consistent usage of discovery-related settings throughout the codebase.

**Server Discovery Configuration**

* Added a `BeaconPort` property to `NetSyncManager` in Unity, making the UDP port for server discovery beacons configurable via the inspector and script. Also added `EnableDiscovery` as a public property for easier access and control. (F420bc85L42R42, F420bc85L681R681)
* Updated `ServerDiscoveryManager` to use a thread-safe backing field for `BeaconPort` and provided a `SetBeaconPort(int port)` method for runtime configuration. [[1]](diffhunk://#diff-58f9324bccdb7b3a8c21a06e9bf8fd87b55fef7fcf17af3229ca245fc96b4fc4L21-R26) [[2]](diffhunk://#diff-58f9324bccdb7b3a8c21a06e9bf8fd87b55fef7fcf17af3229ca245fc96b4fc4R37-R41)
* Ensured `NetSyncManager` sets the `BeaconPort` on the discovery manager during initialization and before starting discovery, so the correct port is always used. [[1]](diffhunk://#diff-85fbaac67340cd0e7530de3718988af88b85f2a51179892204c6e280b6d8506dR458) [[2]](diffhunk://#diff-85fbaac67340cd0e7530de3718988af88b85f2a51179892204c6e280b6d8506dR647)

**Unity Editor Improvements**

* Refactored `NetSyncManagerEditor` to display advanced properties (`EnableDiscovery`, `BeaconPort`) in a dedicated, collapsible "Advanced" section for better usability and organization. [[1]](diffhunk://#diff-e4c9c20a4fde9a7f949afaf096dee68dd4e5cbaf55d67c2b4a8ec8a67c09775dR11-R46) [[2]](diffhunk://#diff-e4c9c20a4fde9a7f949afaf096dee68dd4e5cbaf55d67c2b4a8ec8a67c09775dR55-R97)

**Python Server Enhancements**

* Added a `valid_port` function and a `--beacon-port` CLI argument to the Python server, allowing users to specify and validate the UDP port for beacon discovery. The selected port is logged and used if provided. [[1]](diffhunk://#diff-e88eea98ef9a164151fc1fdd4bf5ed9a273abbfd449f658a8d82ff1b636df45dR85-R97) [[2]](diffhunk://#diff-e88eea98ef9a164151fc1fdd4bf5ed9a273abbfd449f658a8d82ff1b636df45dR1529-R1534) [[3]](diffhunk://#diff-e88eea98ef9a164151fc1fdd4bf5ed9a273abbfd449f658a8d82ff1b636df45dR1561-R1562)