### PR TITLE
feat: make battery level sync configurable as advanced option

### DIFF
--- a/STYLY-NetSync-Server/src/styly_netsync/client_simulator.py
+++ b/STYLY-NetSync-Server/src/styly_netsync/client_simulator.py
@@ -1393,9 +1393,9 @@ Examples:
         help="Delay in seconds between batches (requires --spawn-batch-size > 0)",
     )
     parser.add_argument(
-        "--no-battery",
+        "--no-sync-battery",
         action="store_true",
-        help="Disable battery level simulation",
+        help="Disable battery level synchronization",
     )
 
     args = parser.parse_args()
@@ -1422,7 +1422,7 @@ Examples:
         num_clients=args.clients,
         spawn_batch_size=args.spawn_batch_size,
         spawn_batch_interval=args.spawn_batch_interval,
-        simulate_battery=not args.no_battery,
+        simulate_battery=not args.no_sync_battery,
     )
 
     try:

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Editor/NetSyncManagerEditor.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Editor/NetSyncManagerEditor.cs
@@ -72,11 +72,9 @@ namespace Styly.NetSync.Editor
             EditorGUILayout.Space();
             using (new EditorGUILayout.VerticalScope(EditorStyles.helpBox))
             {
-                showAdvanced = EditorGUILayout.BeginFoldoutHeaderGroup(showAdvanced, "Advanced");
+                showAdvanced = EditorGUILayout.BeginFoldoutHeaderGroup(showAdvanced, "Advanced Options");
                 if (showAdvanced)
                 {
-                    EditorGUI.indentLevel++;
-                    EditorGUILayout.LabelField("Server Discovery Settings", EditorStyles.boldLabel);
                     EditorGUI.indentLevel++;
 
                     foreach (var propertyName in AdvancedPropertyOrder)
@@ -93,7 +91,7 @@ namespace Styly.NetSync.Editor
                         }
                     }
 
-                    EditorGUI.indentLevel -= 2;
+                    EditorGUI.indentLevel--;
                 }
                 EditorGUILayout.EndFoldoutHeaderGroup();
             }

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Editor/NetSyncManagerEditor.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Editor/NetSyncManagerEditor.cs
@@ -11,7 +11,8 @@ namespace Styly.NetSync.Editor
         private static bool showAdvanced;
         private static readonly string[] AdvancedPropertyOrder =
         {
-            "BeaconPort"
+            "BeaconPort",
+            "_syncBatteryLevel"
         };
         private static readonly HashSet<string> AdvancedProperties = new HashSet<string>(AdvancedPropertyOrder);
 

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/NetSyncManager.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/NetSyncManager.cs
@@ -44,8 +44,11 @@ namespace Styly.NetSync
         public UnityEvent OnReady;
 
         // Advanced options
+        [Header("Advanced Options")]
         [Tooltip("UDP port used for server discovery beacons.")]
         [Min(1)] public int BeaconPort = 9999;
+        [Tooltip("Enable synchronization of battery levels across devices.")]
+        [SerializeField] private bool _syncBatteryLevel = true;
         private bool _enableDiscovery = true;
         private float _discoveryTimeout = 5f;
 
@@ -582,8 +585,11 @@ namespace Styly.NetSync
                 DebugLog("Connection established during room switch - handshake deferred to main thread");
             }
 
-            // Initialize battery level immediately on connection
-            _lastBatteryUpdate = -_batteryUpdateInterval; // Force immediate update on next Update()
+            // Initialize battery level immediately on connection if sync is enabled
+            if (_syncBatteryLevel)
+            {
+                _lastBatteryUpdate = -_batteryUpdateInterval; // Force immediate update on next Update()
+            }
         }
 
         /// <summary>
@@ -909,6 +915,12 @@ namespace Styly.NetSync
         /// </summary>
         private void UpdateBatteryLevel()
         {
+            // Check if battery sync is enabled
+            if (!_syncBatteryLevel)
+            {
+                return;
+            }
+
             float currentTime = Time.time;
             if (currentTime - _lastBatteryUpdate >= _batteryUpdateInterval)
             {

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/NetSyncManager.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/NetSyncManager.cs
@@ -44,7 +44,6 @@ namespace Styly.NetSync
         public UnityEvent OnReady;
 
         // Advanced options
-        [Header("Advanced Options")]
         [Tooltip("UDP port used for server discovery beacons.")]
         [Min(1)] public int BeaconPort = 9999;
         [Tooltip("Enable synchronization of battery levels across devices.")]


### PR DESCRIPTION
Closes #172

## Summary

Made battery level synchronization configurable as an advanced option in NetSyncManager.

## Changes

- Added `_syncBatteryLevel` boolean field in Advanced Options section with Unity Inspector support
- Modified `UpdateBatteryLevel()` method to respect the sync option
- Updated initialization logic to only force immediate update when enabled
- Default value is `true` to maintain backward compatibility

## Testing

- Verify the option appears in Unity Inspector under Advanced Options
- Test that battery sync works when enabled
- Test that battery sync is disabled when unchecked

Generated with [Claude Code](https://claude.ai/code)