### PR TITLE
fix: add serializedObject.Update() to NetSyncAvatarEditor for periodic inspector updates

### DIFF
--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Editor/NetSyncAvatarEditor.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Editor/NetSyncAvatarEditor.cs
@@ -18,15 +18,18 @@ namespace Styly.NetSync.Editor
         
         public override void OnInspectorGUI()
         {
+            // Update serialized object to reflect runtime changes
+            serializedObject.Update();
+
             // Draw default inspector
             DrawDefaultInspector();
-            
+
             // Only show network variables during play mode
             if (!Application.isPlaying)
             {
                 return;
             }
-            
+
             EditorGUILayout.Space();
             
             // Client Network Variables section


### PR DESCRIPTION
The NetSyncAvatarEditor was missing the serializedObject.Update() call at the start of OnInspectorGUI(), which prevented the inspector from reflecting runtime changes to client variables. This fix matches the pattern used in NetSyncManagerEditor, ensuring that client variables are properly updated in the inspector during play mode.

Fixes #185

Generated with [Claude Code](https://claude.ai/code)