### PR TITLE
feat: Add CORS middleware to FastAPI 

### DIFF
--- a/STYLY-NetSync-Server/src/styly_netsync/rest_bridge.py
+++ b/STYLY-NetSync-Server/src/styly_netsync/rest_bridge.py
@@ -6,6 +6,7 @@ import time
 from typing import Dict
 
 from fastapi import FastAPI, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel, Field, constr
 
 from .client import net_sync_manager
@@ -202,6 +203,16 @@ class BridgeManager:
 def create_app(server_addr: str, dealer_port: int, sub_port: int) -> FastAPI:
     """Create the FastAPI application hosting the REST bridge."""
     app = FastAPI(title="NetSync REST Bridge", version="1.0.0")
+
+    # Add CORS middleware
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=["*"],
+        allow_credentials=True,
+        allow_methods=["GET", "POST", "PUT", "DELETE", "OPTIONS"],
+        allow_headers=["Content-Type", "Authorization"],
+    )
+
     manager = BridgeManager(server_addr, dealer_port, sub_port)
 
     @app.get("/")

--- a/STYLY-NetSync-Unity/Assets/XR/Settings/OpenXR Editor Settings.asset
+++ b/STYLY-NetSync-Unity/Assets/XR/Settings/OpenXR Editor Settings.asset
@@ -1,0 +1,18 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 975057b4fdcfb8142b3080d19a5cc712, type: 3}
+  m_Name: OpenXR Editor Settings
+  m_EditorClassIdentifier: Unity.XR.OpenXR.Editor::UnityEditor.XR.OpenXR.OpenXREditorSettings
+  Keys: 
+  Values: []
+  m_vulkanAdditionalGraphicsQueue: 0
+  m_vulkanOffscreenSwapchainNoMainDisplay: 1

--- a/STYLY-NetSync-Unity/Assets/XR/Settings/OpenXR Editor Settings.asset.meta
+++ b/STYLY-NetSync-Unity/Assets/XR/Settings/OpenXR Editor Settings.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 48ac92f79c09e45c6b3cf9e82a0b3417
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/STYLY-NetSync-Unity/ProjectSettings/PackageManagerSettings.asset
+++ b/STYLY-NetSync-Unity/ProjectSettings/PackageManagerSettings.asset
@@ -27,6 +27,9 @@ MonoBehaviour:
     m_IsDefault: 1
     m_Capabilities: 7
     m_ConfigSource: 0
+    m_Compliance:
+      m_Status: 0
+      m_Violations: []
   - m_Id: scoped:project:package.openupm.com
     m_Name: package.openupm.com
     m_Url: https://package.openupm.com
@@ -45,11 +48,14 @@ MonoBehaviour:
     m_IsDefault: 0
     m_Capabilities: 0
     m_ConfigSource: 4
+    m_Compliance:
+      m_Status: 0
+      m_Violations: []
   m_UserSelectedRegistryName: package.openupm.com
   m_UserAddingNewScopedRegistry: 0
   m_RegistryInfoDraft:
     m_Modified: 0
     m_ErrorMessage: 
-    m_UserModificationsInstanceId: -868
-    m_OriginalInstanceId: -872
+    m_UserModificationsInstanceId: -874
+    m_OriginalInstanceId: -878
   m_LoadAssets: 0

--- a/STYLY-NetSync-Unity/ProjectSettings/ShaderGraphSettings.asset
+++ b/STYLY-NetSync-Unity/ProjectSettings/ShaderGraphSettings.asset
@@ -13,6 +13,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   shaderVariantLimit: 128
+  overrideShaderVariantLimit: 0
   customInterpolatorErrorThreshold: 32
   customInterpolatorWarningThreshold: 16
   customHeatmapValues: {fileID: 0}


### PR DESCRIPTION
This pull request introduces several configuration and compatibility improvements to both the server and Unity project settings, with a focus on enabling cross-origin requests for the REST API and updating Unity project assets for XR/OpenXR support.

**REST API compatibility:**

* Added CORS middleware to the FastAPI application in `rest_bridge.py`, allowing cross-origin requests from any origin and supporting common HTTP methods and headers. [[1]](diffhunk://#diff-f9fcb7afc747fdd287e53429c6493c863087a53af37514301e72d0024b039f80R9) [[2]](diffhunk://#diff-f9fcb7afc747fdd287e53429c6493c863087a53af37514301e72d0024b039f80R206-R215)

**Unity XR/OpenXR configuration:**

* Added new `OpenXR Editor Settings.asset` and its corresponding `.meta` file to the Unity project, configuring Vulkan graphics queue and swapchain settings for OpenXR. [[1]](diffhunk://#diff-a59ac2b8820e36412c6672b4b4c166c98be20bd7a20229b420f4b1fdee4e58fcR1-R18) [[2]](diffhunk://#diff-de19edabbca11a26a018832d1bd250a3826873b3328f78d08d4a25ba76832f5dR1-R8)

**Unity project settings updates:**

* Updated `PackageManagerSettings.asset` to include compliance status and violations for package registries, and adjusted instance IDs for user modifications and originals. [[1]](diffhunk://#diff-bba315889f92b454a6a228bb935980a02c325fe7e915c509a5885d3518c49218R30-R32) [[2]](diffhunk://#diff-bba315889f92b454a6a228bb935980a02c325fe7e915c509a5885d3518c49218R51-R60)
* Updated `ShaderGraphSettings.asset` to add the `overrideShaderVariantLimit` property, enhancing shader variant configuration.…ettings for OpenXR and Shader Graph