### PR TITLE
feat: Refactoring network utility functions for local IP address retrival

### DIFF
--- a/STYLY-NetSync-Server/src/styly_netsync/network_utils.py
+++ b/STYLY-NetSync-Server/src/styly_netsync/network_utils.py
@@ -1,0 +1,60 @@
+"""Network utility functions for STYLY NetSync."""
+
+import logging
+import socket
+
+import psutil
+
+logger = logging.getLogger(__name__)
+
+
+def get_local_ip_addresses() -> list[str]:
+    """
+    Get all local IP addresses of the machine from physical network interfaces.
+
+    Filters out virtual interfaces (bridges, VPNs, Docker, etc.) and APIPA addresses
+    (169.254.x.x) to show only IP addresses that are likely accessible from external devices.
+
+    Returns:
+        list: List of IP addresses as strings
+
+    Example:
+        >>> ips = get_local_ip_addresses()
+        >>> print(ips)
+        ['192.168.1.100', '10.0.0.50']
+    """
+    ip_addresses = []
+    try:
+        # Patterns to exclude virtual/bridge interfaces
+        # These are common virtual interface prefixes across different platforms
+        virtual_prefixes = (
+            "bridge",  # VMware, Parallels bridges
+            "docker",  # Docker interfaces
+            "veth",  # Virtual Ethernet (Docker, LXC)
+            "vmnet",  # VMware network
+            "vboxnet",  # VirtualBox network
+            "virbr",  # libvirt bridge
+            "tun",  # VPN tunnels
+            "tap",  # Virtual network tap
+            "utun",  # macOS VPN tunnels
+            "vnic",  # Virtual NIC
+            "ppp",  # Point-to-Point Protocol (VPN)
+        )
+
+        # Get all network interfaces
+        for interface_name, interface_addresses in psutil.net_if_addrs().items():
+            # Skip virtual interfaces
+            if interface_name.lower().startswith(virtual_prefixes):
+                continue
+
+            for address in interface_addresses:
+                # Filter for IPv4 addresses only
+                if address.family == socket.AF_INET:
+                    ip = address.address
+                    # Exclude localhost and APIPA addresses (169.254.x.x)
+                    if ip != "127.0.0.1" and not ip.startswith("169.254."):
+                        ip_addresses.append(ip)
+    except Exception as e:
+        logger.warning(f"Failed to get local IP addresses: {e}")
+
+    return ip_addresses

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/ServerDiscoveryManager.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/ServerDiscoveryManager.cs
@@ -7,6 +7,7 @@ using System.Net.Sockets;
 using System.Text;
 using System.Threading;
 using UnityEngine;
+using Styly.NetSync.Utils;
 
 namespace Styly.NetSync
 {
@@ -236,7 +237,7 @@ namespace Styly.NetSync
             try
             {
                 // Get local IP address and check if it's cellular
-                GetLocalIpAddressWithType(out string localIp, out bool isCellular);
+                NetworkUtils.GetLocalIpAddressWithType(out string localIp, out bool isCellular);
 
                 if (string.IsNullOrEmpty(localIp))
                 {
@@ -244,7 +245,15 @@ namespace Styly.NetSync
                     return ips;
                 }
 
-                DebugLog($"Local IP: {localIp}");
+                // Log connection type
+                if (isCellular)
+                {
+                    DebugLog($"Local IP: {localIp} (Cellular)");
+                }
+                else
+                {
+                    DebugLog($"Local IP: {localIp} (Wi-Fi/Ethernet)");
+                }
 
                 // Do not perform port scanning on cellular data connections
                 if (isCellular)
@@ -294,132 +303,6 @@ namespace Styly.NetSync
             }
 
             return ips;
-        }
-
-        private void GetLocalIpAddressWithType(out string ipAddress, out bool isCellular)
-        {
-            ipAddress = null;
-            isCellular = false;
-
-            try
-            {
-                // Virtual interface prefixes to exclude (matches server.py logic)
-                var virtualPrefixes = new[]
-                {
-                    "bridge",   // VMware, Parallels bridges
-                    "docker",   // Docker interfaces
-                    "veth",     // Virtual Ethernet (Docker, LXC)
-                    "vmnet",    // VMware network
-                    "vboxnet",  // VirtualBox network
-                    "virbr",    // libvirt bridge
-                    "tun",      // VPN tunnels
-                    "tap",      // Virtual network tap
-                    "utun",     // macOS VPN tunnels
-                    "vnic",     // Virtual NIC
-                    "ppp",      // Point-to-Point Protocol (VPN)
-                };
-
-                // Get all network interfaces
-                var interfaces = System.Net.NetworkInformation.NetworkInterface.GetAllNetworkInterfaces();
-                var wifiCandidates = new List<string>();
-                var cellularCandidates = new List<string>();
-                var otherCandidates = new List<string>();
-
-                foreach (var iface in interfaces)
-                {
-                    // Skip interfaces that are down or loopback
-                    if (iface.OperationalStatus != System.Net.NetworkInformation.OperationalStatus.Up)
-                    {
-                        continue;
-                    }
-
-                    if (iface.NetworkInterfaceType == System.Net.NetworkInformation.NetworkInterfaceType.Loopback)
-                    {
-                        continue;
-                    }
-
-                    // Skip virtual interfaces
-                    string ifaceName = iface.Name.ToLower();
-                    bool isVirtual = false;
-                    foreach (var prefix in virtualPrefixes)
-                    {
-                        if (ifaceName.StartsWith(prefix))
-                        {
-                            isVirtual = true;
-                            break;
-                        }
-                    }
-                    if (isVirtual)
-                    {
-                        continue;
-                    }
-
-                    // Get IP addresses for this interface
-                    var ipProps = iface.GetIPProperties();
-                    foreach (var addr in ipProps.UnicastAddresses)
-                    {
-                        if (addr.Address.AddressFamily == AddressFamily.InterNetwork)
-                        {
-                            string ipStr = addr.Address.ToString();
-
-                            // Skip loopback and APIPA addresses
-                            if (ipStr.StartsWith("127.") || ipStr.StartsWith("169.254."))
-                            {
-                                continue;
-                            }
-
-                            // Categorize interfaces by type
-                            string ifaceNameLower = iface.Name.ToLower();
-                            bool isWifiOrEthernet = ifaceNameLower.StartsWith("en") ||
-                                                    ifaceNameLower.StartsWith("eth") ||
-                                                    ifaceNameLower.StartsWith("wlan") ||
-                                                    iface.NetworkInterfaceType == System.Net.NetworkInformation.NetworkInterfaceType.Wireless80211 ||
-                                                    iface.NetworkInterfaceType == System.Net.NetworkInformation.NetworkInterfaceType.Ethernet;
-
-                            bool isCellularInterface = ifaceNameLower.StartsWith("pdp_ip") ||
-                                                    ifaceNameLower.StartsWith("rmnet") ||
-                                                    ifaceNameLower.StartsWith("ccmni");
-
-                            if (isWifiOrEthernet)
-                            {
-                                wifiCandidates.Add(ipStr);
-                            }
-                            else if (isCellularInterface)
-                            {
-                                cellularCandidates.Add(ipStr);
-                            }
-                            else
-                            {
-                                otherCandidates.Add(ipStr);
-                            }
-                        }
-                    }
-                }
-
-                // Prioritize Wi-Fi/Ethernet first, then other, then cellular (last resort)
-                if (wifiCandidates.Count > 0)
-                {
-                    ipAddress = wifiCandidates[0];
-                    isCellular = false;
-                    DebugLog($"Local IP: {ipAddress} (Wi-Fi/Ethernet)");
-                }
-                else if (otherCandidates.Count > 0)
-                {
-                    ipAddress = otherCandidates[0];
-                    isCellular = false;
-                    DebugLog($"Local IP: {ipAddress}");
-                }
-                else if (cellularCandidates.Count > 0)
-                {
-                    ipAddress = cellularCandidates[0];
-                    isCellular = true;
-                    DebugLog($"Local IP: {ipAddress} (Cellular)");
-                }
-            }
-            catch (Exception ex)
-            {
-                Debug.LogWarning($"[ServerDiscovery] Error getting local IP: {ex.Message}");
-            }
         }
 
         private string GetCachedServerIp()

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Util Scripts/NetworkUtils.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Util Scripts/NetworkUtils.cs
@@ -1,0 +1,175 @@
+// NetworkUtils.cs - Network utility functions for STYLY NetSync
+using System;
+using System.Collections.Generic;
+using System.Net.Sockets;
+using UnityEngine;
+
+namespace Styly.NetSync.Utils
+{
+    /// <summary>
+    /// Network utility functions for STYLY NetSync.
+    /// Provides methods for retrieving local IP addresses and network information.
+    /// </summary>
+    public static class NetworkUtils
+    {
+        /// <summary>
+        /// Get local IP address with network type detection.
+        /// Filters out virtual interfaces (bridges, VPNs, Docker, etc.) and APIPA addresses (169.254.x.x).
+        /// Prioritizes Wi-Fi/Ethernet connections over cellular connections.
+        /// </summary>
+        /// <param name="ipAddress">Output: Local IP address string, or null if not found</param>
+        /// <param name="isCellular">Output: True if the detected connection is cellular data</param>
+        /// <example>
+        /// <code>
+        /// NetworkUtils.GetLocalIpAddressWithType(out string ip, out bool isCellular);
+        /// if (ip != null)
+        /// {
+        ///     Debug.Log($"Local IP: {ip}, Cellular: {isCellular}");
+        /// }
+        /// </code>
+        /// </example>
+        public static void GetLocalIpAddressWithType(out string ipAddress, out bool isCellular)
+        {
+            ipAddress = null;
+            isCellular = false;
+
+            try
+            {
+                // Virtual interface prefixes to exclude (matches server.py logic)
+                var virtualPrefixes = new[]
+                {
+                    "bridge",   // VMware, Parallels bridges
+                    "docker",   // Docker interfaces
+                    "veth",     // Virtual Ethernet (Docker, LXC)
+                    "vmnet",    // VMware network
+                    "vboxnet",  // VirtualBox network
+                    "virbr",    // libvirt bridge
+                    "tun",      // VPN tunnels
+                    "tap",      // Virtual network tap
+                    "utun",     // macOS VPN tunnels
+                    "vnic",     // Virtual NIC
+                    "ppp",      // Point-to-Point Protocol (VPN)
+                };
+
+                // Get all network interfaces
+                var interfaces = System.Net.NetworkInformation.NetworkInterface.GetAllNetworkInterfaces();
+                var wifiCandidates = new List<string>();
+                var cellularCandidates = new List<string>();
+                var otherCandidates = new List<string>();
+
+                foreach (var iface in interfaces)
+                {
+                    // Skip interfaces that are down or loopback
+                    if (iface.OperationalStatus != System.Net.NetworkInformation.OperationalStatus.Up)
+                    {
+                        continue;
+                    }
+
+                    if (iface.NetworkInterfaceType == System.Net.NetworkInformation.NetworkInterfaceType.Loopback)
+                    {
+                        continue;
+                    }
+
+                    // Skip virtual interfaces
+                    string ifaceName = iface.Name.ToLower();
+                    bool isVirtual = false;
+                    foreach (var prefix in virtualPrefixes)
+                    {
+                        if (ifaceName.StartsWith(prefix))
+                        {
+                            isVirtual = true;
+                            break;
+                        }
+                    }
+                    if (isVirtual)
+                    {
+                        continue;
+                    }
+
+                    // Get IP addresses for this interface
+                    var ipProps = iface.GetIPProperties();
+                    foreach (var addr in ipProps.UnicastAddresses)
+                    {
+                        if (addr.Address.AddressFamily == AddressFamily.InterNetwork)
+                        {
+                            string ipStr = addr.Address.ToString();
+
+                            // Skip loopback and APIPA addresses
+                            if (ipStr.StartsWith("127.") || ipStr.StartsWith("169.254."))
+                            {
+                                continue;
+                            }
+
+                            // Categorize interfaces by type
+                            string ifaceNameLower = iface.Name.ToLower();
+                            bool isWifiOrEthernet = ifaceNameLower.StartsWith("en") ||
+                                                    ifaceNameLower.StartsWith("eth") ||
+                                                    ifaceNameLower.StartsWith("wlan") ||
+                                                    iface.NetworkInterfaceType == System.Net.NetworkInformation.NetworkInterfaceType.Wireless80211 ||
+                                                    iface.NetworkInterfaceType == System.Net.NetworkInformation.NetworkInterfaceType.Ethernet;
+
+                            bool isCellularInterface = ifaceNameLower.StartsWith("pdp_ip") ||
+                                                    ifaceNameLower.StartsWith("rmnet") ||
+                                                    ifaceNameLower.StartsWith("ccmni");
+
+                            if (isWifiOrEthernet)
+                            {
+                                wifiCandidates.Add(ipStr);
+                            }
+                            else if (isCellularInterface)
+                            {
+                                cellularCandidates.Add(ipStr);
+                            }
+                            else
+                            {
+                                otherCandidates.Add(ipStr);
+                            }
+                        }
+                    }
+                }
+
+                // Prioritize Wi-Fi/Ethernet first, then other, then cellular (last resort)
+                if (wifiCandidates.Count > 0)
+                {
+                    ipAddress = wifiCandidates[0];
+                    isCellular = false;
+                }
+                else if (otherCandidates.Count > 0)
+                {
+                    ipAddress = otherCandidates[0];
+                    isCellular = false;
+                }
+                else if (cellularCandidates.Count > 0)
+                {
+                    ipAddress = cellularCandidates[0];
+                    isCellular = true;
+                }
+            }
+            catch (Exception ex)
+            {
+                Debug.LogWarning($"[NetworkUtils] Error getting local IP: {ex.Message}");
+            }
+        }
+
+        /// <summary>
+        /// Get local IP address without cellular detection.
+        /// This is a simplified version that returns only the IP address string.
+        /// Filters out virtual interfaces and APIPA addresses, prioritizing Wi-Fi/Ethernet.
+        /// </summary>
+        /// <returns>Local IP address string, or null if not found</returns>
+        /// <example>
+        /// <code>
+        /// string ip = NetworkUtils.GetLocalIpAddress();
+        /// if (ip != null)
+        /// {
+        ///     Debug.Log($"Local IP: {ip}");
+        /// }
+        /// </code>
+        /// </example>
+        public static string GetLocalIpAddress()
+        {
+            GetLocalIpAddressWithType(out string ip, out _);
+            return ip;
+        }
+    }
+}

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Util Scripts/NetworkUtils.cs.meta
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Util Scripts/NetworkUtils.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: c4c0d57abed644c40a4f3c55ddb08108


### PR DESCRIPTION
This pull request refactors the logic for retrieving local IP addresses and network interface information in both the server (Python) and Unity (C#) components of STYLY NetSync. The main change is the extraction of network utility functions into dedicated modules, improving code reuse and consistency across platforms. Additionally, the Unity implementation now provides clearer logging about the type of network connection (Wi-Fi/Ethernet or Cellular).

**Network utility module extraction and reuse:**

* Created a new Python module `network_utils.py` containing the `get_local_ip_addresses` function, which filters out virtual and APIPA addresses for more reliable external connectivity detection. The server now imports and uses this module instead of duplicating logic. [[1]](diffhunk://#diff-fb928cc7f2bca2426ca077c75b781c9d2749da04731ef29f7d6332be124bd1baR1-R60) [[2]](diffhunk://#diff-e88eea98ef9a164151fc1fdd4bf5ed9a273abbfd449f658a8d82ff1b636df45dR30) [[3]](diffhunk://#diff-e88eea98ef9a164151fc1fdd4bf5ed9a273abbfd449f658a8d82ff1b636df45dL1717-R1670) [[4]](diffhunk://#diff-e88eea98ef9a164151fc1fdd4bf5ed9a273abbfd449f658a8d82ff1b636df45dL1636-L1682)
* Created a new C# utility class `NetworkUtils` in `NetworkUtils.cs` that provides methods for retrieving local IP addresses with network type detection, mirroring the logic used in the Python server for filtering interfaces. [[1]](diffhunk://#diff-68317b9eff24719cb16d606b5ffadc6515af5b519a27be1afc311d6082ca8cacR1-R175) [[2]](diffhunk://#diff-d1fed4608e0b1a9b7066c3c2c3e8267437c28fe7712e1530c7297bd2dc0bb410R1-R2)

**Unity code improvements:**

* Updated `ServerDiscoveryManager.cs` to use the new `NetworkUtils.GetLocalIpAddressWithType` method, removing the previous inline implementation and improving maintainability. [[1]](diffhunk://#diff-58f9324bccdb7b3a8c21a06e9bf8fd87b55fef7fcf17af3229ca245fc96b4fc4R10) [[2]](diffhunk://#diff-58f9324bccdb7b3a8c21a06e9bf8fd87b55fef7fcf17af3229ca245fc96b4fc4L239-R256) [[3]](diffhunk://#diff-58f9324bccdb7b3a8c21a06e9bf8fd87b55fef7fcf17af3229ca245fc96b4fc4L299-L424)
* Enhanced logging in Unity to display whether the detected IP address is from a Wi-Fi/Ethernet or Cellular connection, providing clearer diagnostics for users.

These changes make the codebase more modular and ensure consistent network interface filtering logic between Python and C#, reducing duplication and potential for platform-specific bugs.