### PR TITLE
Add Device-ID-Provider as a dependency

### DIFF
--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/package.json
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/package.json
@@ -5,6 +5,7 @@
   "unity": "6000.0",
   "description": "STYLY NetSync",
   "dependencies": {
+    "com.styly.device-id-provider": "0.2.0",
     "com.styly.shader-collection.urp": "0.0.5",
     "org.nuget.netmq": "4.0.2",
     "com.unity.xr.core-utils": "2.1.1",

--- a/STYLY-NetSync-Unity/Packages/manifest.json
+++ b/STYLY-NetSync-Unity/Packages/manifest.json
@@ -50,6 +50,7 @@
       "name": "package.openupm.com",
       "url": "https://package.openupm.com",
       "scopes": [
+        "com.styly.device-id-provider",
         "com.styly.styly-xr-rig",
         "com.styly.shader-collection.urp",
         "org.nuget.asyncio",

--- a/STYLY-NetSync-Unity/Packages/packages-lock.json
+++ b/STYLY-NetSync-Unity/Packages/packages-lock.json
@@ -1,5 +1,12 @@
 {
   "dependencies": {
+    "com.styly.device-id-provider": {
+      "version": "0.2.0",
+      "depth": 1,
+      "source": "registry",
+      "dependencies": {},
+      "url": "https://package.openupm.com"
+    },
     "com.styly.shader-collection.urp": {
       "version": "0.0.5",
       "depth": 1,
@@ -12,6 +19,7 @@
       "depth": 0,
       "source": "embedded",
       "dependencies": {
+        "com.styly.device-id-provider": "0.2.0",
         "com.styly.shader-collection.urp": "0.0.5",
         "org.nuget.netmq": "4.0.2",
         "com.unity.xr.core-utils": "2.1.1",


### PR DESCRIPTION
This pull request adds a new dependency on the `com.styly.device-id-provider` package (version 0.2.0) to the project. The changes ensure that this package is included in the dependency management files and is available from the correct registry.

Dependency management updates:

* Added `com.styly.device-id-provider` (version 0.2.0) to the dependencies in `package.json`, ensuring the package is required by the project.
* Updated `manifest.json` to include `com.styly.device-id-provider` in the OpenUPM registry scopes, allowing Unity to resolve the package from the correct source.
* Added `com.styly.device-id-provider` (version 0.2.0) to `packages-lock.json` with its source and URL, locking its version for consistent installs.
* Updated the dependencies section in `packages-lock.json` to reflect the addition of `com.styly.device-id-provider` as a dependency of the main package.