### PR TITLE
fix: enhance error handling for server port conflicts

### DIFF
--- a/STYLY-NetSync-Server/src/styly_netsync/server.py
+++ b/STYLY-NetSync-Server/src/styly_netsync/server.py
@@ -593,7 +593,7 @@ class NetSyncServer:
             logger.info("Server is ready and waiting for connections...")
 
         except zmq.error.ZMQError as e:
-            if "Address already in use" in str(e):
+            if "Address already in use" in str(e) or "Address in use" in str(e):
                 logger.error(
                     f"Error: Another server instance is already running on port {self.dealer_port}"
                 )


### PR DESCRIPTION
This pull request makes a small but important improvement to the error handling logic in the server startup process. The change ensures that the server correctly identifies when the address is already in use, even if the error message wording varies.

* Enhanced error detection in the `start` method of `styly_netsync/server.py` by checking for both "Address already in use" and "Address in use" in the exception message.

Close https://github.com/styly-dev/STYLY-NetSync/issues/219