### PR TITLE
fix: update server discovery port tooltip and restrict range to valid values

### DIFF
--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/NetSyncManager.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/NetSyncManager.cs
@@ -44,8 +44,8 @@ namespace Styly.NetSync
         public UnityEvent OnReady;
 
         // Advanced options
-        [Tooltip("UDP port used for server discovery.")]
-        [Min(1)] public int ServerDiscoveryPort = 9999;
+        [Tooltip("UDP port used for server discovery.\n(49152 to 65535)")]
+        [Range(49152, 65535)] public int ServerDiscoveryPort = 9999;
         [Tooltip("Enable synchronization of battery levels across devices.")]
         [SerializeField] private bool _syncBatteryLevel = true;
         private bool _enableDiscovery = true;


### PR DESCRIPTION
This pull request makes a small but important adjustment to the `NetSyncManager` class by restricting the valid range for the `ServerDiscoveryPort` property. This change helps prevent configuration errors by ensuring that only valid port numbers in the dynamic/private range can be selected.

- Configuration improvement:
  * [`NetSyncManager.cs`](diffhunk://#diff-85fbaac67340cd0e7530de3718988af88b85f2a51179892204c6e280b6d8506dL47-R48): Changed the `ServerDiscoveryPort` property to use the `[Range(49152, 65535)]` attribute instead of `[Min(1)]`, restricting the allowed UDP port range for server discovery to valid dynamic/private ports.