### PR TITLE
Extend the upper limit of network variables

### DIFF
--- a/STYLY-NetSync-Server/src/styly_netsync/server.py
+++ b/STYLY-NetSync-Server/src/styly_netsync/server.py
@@ -245,8 +245,8 @@ class NetSyncServer:
         self.nv_monitor_threshold = 200  # Log warning if > 200 NV req/s
 
         # Network Variables limits
-        self.MAX_GLOBAL_VARS = 20
-        self.MAX_CLIENT_VARS = 20
+        self.MAX_GLOBAL_VARS = 100
+        self.MAX_CLIENT_VARS = 100
         self.MAX_VAR_NAME_LENGTH = 64
         self.MAX_VAR_VALUE_LENGTH = 1024
 

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/NetworkVariableManager.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/NetworkVariableManager.cs
@@ -26,8 +26,8 @@ namespace Styly.NetSync
         private readonly Dictionary<int, Dictionary<string, string>> _clientVariables = new();
 
         // Network Variables limits (must match server)
-        private const int MAX_GLOBAL_VARS = 20;
-        private const int MAX_CLIENT_VARS = 20;
+        private const int MAX_GLOBAL_VARS = 100;
+        private const int MAX_CLIENT_VARS = 100;
         private const int MAX_VAR_NAME_LENGTH = 64;
         private const int MAX_VAR_VALUE_LENGTH = 1024;
 


### PR DESCRIPTION
The upper limit of 20 for network variables feels surprisingly low.
I actually hit that limit while developing my content.
I think raising it to around 100 would provide ample room for now.