### PR TITLE
Fix thread-safety issue in MessageProcessor ID mapping handling

### DIFF
--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/MessageProcessor.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/MessageProcessor.cs
@@ -173,17 +173,35 @@ namespace Styly.NetSync
                         break;
 
                     case "global_var_sync":
-                        ProcessGlobalVariableSync(msg.dataObj as Dictionary<string, object>, networkVariableManager);
+                        if (msg.dataObj is Dictionary<string, object> globalVarData)
+                        {
+                            ProcessGlobalVariableSync(globalVarData, networkVariableManager);
+                        }
+                        else
+                        {
+                            Debug.LogError("[MessageProcessor] global_var_sync without valid dataObj (unexpected)");
+                        }
                         break;
 
                     case "client_var_sync":
-                        ProcessClientVariableSync(msg.dataObj as Dictionary<string, object>, networkVariableManager);
+                        if (msg.dataObj is Dictionary<string, object> clientVarData)
+                        {
+                            ProcessClientVariableSync(clientVarData, networkVariableManager);
+                        }
+                        else
+                        {
+                            Debug.LogError("[MessageProcessor] client_var_sync without valid dataObj (unexpected)");
+                        }
                         break;
 
                     case "id_mapping":
                         if (msg.dataObj is DeviceIdMappingData mappingData)
                         {
                             ProcessIdMappings(mappingData);
+                        }
+                        else
+                        {
+                            Debug.LogError("[MessageProcessor] id_mapping without valid dataObj (unexpected)");
                         }
                         break;
                 }


### PR DESCRIPTION
Move ProcessIdMappings from being called directly on the background
network thread to being queued and processed on the main thread.
This prevents potential race conditions with dictionary access.