### PR TITLE
Add backoff delay when discovery socket errors occur (#252)

### DIFF
--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/ServerDiscoveryManager.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/ServerDiscoveryManager.cs
@@ -134,11 +134,16 @@ namespace Styly.NetSync
                             if (ex.SocketErrorCode != SocketError.TimedOut && _isDiscovering)
                             {
                                 Debug.LogWarning($"Discovery socket error: {ex.Message}");
+                                Thread.Sleep(1000);
                             }
                         }
                         catch (Exception ex)
                         {
-                            if (_isDiscovering) { Debug.LogWarning($"Discovery error: {ex.Message}"); }
+                            if (_isDiscovering)
+                            {
+                                Debug.LogWarning($"Discovery error: {ex.Message}");
+                                Thread.Sleep(1000);
+                            }
                         }
                     }
                 })


### PR DESCRIPTION
When network is unreachable, the discovery loop was running without any delay, causing ~2320 warning logs per second. This adds a 1-second sleep after non-timeout socket errors to prevent excessive logging.