### PR TITLE
feat: enhance message publishing in NetSyncServer and improve validation test readability

### DIFF
--- a/STYLY-NetSync-Server/tests/test_config.py
+++ b/STYLY-NetSync-Server/tests/test_config.py
@@ -498,12 +498,16 @@ class TestValidateConfig:
         # Test below range
         config = replace(default_config, transform_broadcast_rate=0)
         errors = validate_config(config)
-        assert any("transform_broadcast_rate" in e and "0.5 and 60" in e for e in errors)
+        assert any(
+            "transform_broadcast_rate" in e and "0.5 and 60" in e for e in errors
+        )
 
         # Test above range
         config = replace(default_config, transform_broadcast_rate=100)
         errors = validate_config(config)
-        assert any("transform_broadcast_rate" in e and "0.5 and 60" in e for e in errors)
+        assert any(
+            "transform_broadcast_rate" in e and "0.5 and 60" in e for e in errors
+        )
 
     def test_valid_timing_relationships(self, default_config: ServerConfig) -> None:
         """Test that valid timing relationships pass validation."""


### PR DESCRIPTION
This pull request improves the efficiency and reliability of the publisher loop in the `STYLY-NetSync-Server`, specifically in how transform and control messages are batched and sent. It also makes minor formatting improvements for better readability in both logging and tests.

**Publisher loop improvements:**

* Refactored the `_publisher_loop` to flush all coalesced transform messages in batches before processing control messages, improving throughput and reducing per-message overhead. Now, transform data is sent in batches rather than one-at-a-time.
* Changed both transform and control message sends to use the `zmq.DONTWAIT` flag, preventing the publisher from blocking if the send queue is full. Improved error handling for both cases. [[1]](diffhunk://#diff-e88eea98ef9a164151fc1fdd4bf5ed9a273abbfd449f658a8d82ff1b636df45dR531-R550) [[2]](diffhunk://#diff-e88eea98ef9a164151fc1fdd4bf5ed9a273abbfd449f658a8d82ff1b636df45dL543-R582)
* Updated the sleep logic so the loop only sleeps if no messages (either transform or control) were sent in that iteration, ensuring better responsiveness under load.

**Code readability improvements:**

* Reformatted log output in `main()` for configuration overrides to improve readability when displaying overridden values.
* Reformatted assertions in `test_transform_broadcast_rate_out_of_range` to use multi-line expressions for better clarity in test code.