### PR TITLE
[Merge with Minor version increment] feat: add version parsing and compatibility checks for server-client communication

### DIFF
--- a/STYLY-NetSync-Server/src/styly_netsync/server.py
+++ b/STYLY-NetSync-Server/src/styly_netsync/server.py
@@ -1438,9 +1438,12 @@ class NetSyncServer:
                 mappings.append((client_no, device_id, is_stealth))
 
             if mappings:
-                # Serialize and broadcast the mappings
+                # Serialize and broadcast the mappings with server version
                 topic_bytes = room_id.encode("utf-8")
-                message_bytes = binary_serializer.serialize_device_id_mapping(mappings)
+                server_version = binary_serializer.parse_version(get_version())
+                message_bytes = binary_serializer.serialize_device_id_mapping(
+                    mappings, server_version
+                )
                 self._enqueue_pub(topic_bytes, message_bytes)
                 sub_count = self._get_sub_connection_count()
                 logger.info(
@@ -2013,7 +2016,9 @@ def main() -> None:
         if config_overrides:
             logger.info("Configuration overrides from user config:")
             for override in config_overrides:
-                logger.info(f"  {override.key}: {override.default_value} -> {override.new_value}")
+                logger.info(
+                    f"  {override.key}: {override.default_value} -> {override.new_value}"
+                )
 
     # Apply global configuration settings
     binary_serializer.set_max_virtual_transforms(config.max_virtual_transforms)

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/BinarySerializer.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/BinarySerializer.cs
@@ -416,6 +416,11 @@ namespace Styly.NetSync
             var data = new DeviceIdMappingData();
             data.mappings = new List<DeviceIdMapping>();
 
+            // Server version (3 bytes: major, minor, patch)
+            data.serverVersionMajor = reader.ReadByte();
+            data.serverVersionMinor = reader.ReadByte();
+            data.serverVersionPatch = reader.ReadByte();
+
             // Number of mappings
             var count = reader.ReadUInt16();
 

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/DataStructure.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/DataStructure.cs
@@ -92,6 +92,9 @@ namespace Styly.NetSync
     [Serializable]
     internal class DeviceIdMappingData
     {
+        public int serverVersionMajor;
+        public int serverVersionMinor;
+        public int serverVersionPatch;
         public List<DeviceIdMapping> mappings;
     }
 }

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/Information.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/Information.cs
@@ -1,3 +1,4 @@
+using System;
 using UnityEngine;
 
 namespace Styly.NetSync
@@ -19,6 +20,61 @@ namespace Styly.NetSync
             var ta = Resources.Load<TextAsset>(ResourcePath);
             if (ta != null) return ta.text.Trim();
             return "unknown";
+        }
+
+        /// <summary>
+        /// Parse semantic version string into (major, minor, patch) tuple.
+        /// </summary>
+        /// <param name="versionStr">Version string like "0.7.5" or "1.2.3-beta"</param>
+        /// <returns>Tuple of (major, minor, patch) integers. Returns (0, 0, 0) for invalid input.</returns>
+        public static (int major, int minor, int patch) ParseVersion(string versionStr)
+        {
+            if (string.IsNullOrEmpty(versionStr) || versionStr == "unknown")
+            {
+                return (0, 0, 0);
+            }
+
+            try
+            {
+                // Remove any suffix like "-beta", "-rc1", etc.
+                var baseVersion = versionStr.Split('-')[0].Split('+')[0];
+                var parts = baseVersion.Split('.');
+                int major = parts.Length > 0 ? int.Parse(parts[0]) : 0;
+                int minor = parts.Length > 1 ? int.Parse(parts[1]) : 0;
+                int patch = parts.Length > 2 ? int.Parse(parts[2]) : 0;
+                // Clamp to 0-255 range for single byte storage
+                return (Math.Min(major, 255), Math.Min(minor, 255), Math.Min(patch, 255));
+            }
+            catch (Exception)
+            {
+                return (0, 0, 0);
+            }
+        }
+
+        /// <summary>
+        /// Check if the client version is compatible with the server version.
+        /// Major and minor versions must match. Patch version mismatches are OK.
+        /// </summary>
+        /// <param name="serverMajor">Server major version</param>
+        /// <param name="serverMinor">Server minor version</param>
+        /// <param name="serverPatch">Server patch version (unused, for reference only)</param>
+        /// <returns>True if versions are compatible, false otherwise</returns>
+        public static bool IsVersionCompatible(int serverMajor, int serverMinor, int serverPatch)
+        {
+            var (clientMajor, clientMinor, _) = ParseVersion(GetVersion());
+
+            // If either version is unknown (0.0.x), skip version check
+            if (clientMajor == 0 && clientMinor == 0)
+            {
+                return true;
+            }
+            if (serverMajor == 0 && serverMinor == 0)
+            {
+                return true;
+            }
+
+            // Major and minor must match
+            return clientMajor == serverMajor && clientMinor == serverMinor;
         }
     }
 }

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/MessageProcessor.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/MessageProcessor.cs
@@ -36,6 +36,14 @@ namespace Styly.NetSync
         public int MessagesReceived => _messagesReceived;
         public event System.Action<int> OnLocalClientNoAssigned;
 
+        /// <summary>
+        /// Event fired when server version does not match client version.
+        /// Parameters: (serverMajor, serverMinor, serverPatch, clientMajor, clientMinor, clientPatch)
+        /// </summary>
+        public event System.Action<int, int, int, int, int, int> OnVersionMismatch;
+
+        private bool _versionChecked = false;
+
         public MessageProcessor(bool logNetworkTraffic)
         {
             _logNetworkTraffic = logNetworkTraffic;
@@ -50,6 +58,14 @@ namespace Styly.NetSync
         {
             _localClientNo = clientNo;
             // Local client number set
+        }
+
+        /// <summary>
+        /// Reset version check state. Should be called when switching rooms or reconnecting.
+        /// </summary>
+        public void ResetVersionCheck()
+        {
+            _versionChecked = false;
         }
         
         public void SetNetSyncManager(NetSyncManager netSyncManager)
@@ -357,6 +373,33 @@ namespace Styly.NetSync
 
         private void ProcessIdMappings(DeviceIdMappingData mappingData)
         {
+            // Check version compatibility on first ID mapping received
+            if (!_versionChecked)
+            {
+                _versionChecked = true;
+                if (!Information.IsVersionCompatible(
+                    mappingData.serverVersionMajor,
+                    mappingData.serverVersionMinor,
+                    mappingData.serverVersionPatch))
+                {
+                    var (clientMajor, clientMinor, clientPatch) = Information.ParseVersion(Information.GetVersion());
+                    Debug.LogError(
+                        $"[NetSync] Version mismatch! Server: {mappingData.serverVersionMajor}.{mappingData.serverVersionMinor}.{mappingData.serverVersionPatch}, " +
+                        $"Client: {clientMajor}.{clientMinor}.{clientPatch}. Major and minor versions must match.");
+
+                    if (OnVersionMismatch != null)
+                    {
+                        OnVersionMismatch.Invoke(
+                            mappingData.serverVersionMajor,
+                            mappingData.serverVersionMinor,
+                            mappingData.serverVersionPatch,
+                            clientMajor,
+                            clientMinor,
+                            clientPatch);
+                    }
+                }
+            }
+
             // Clear existing mappings
             _clientNoToDeviceId.Clear();
             _deviceIdToClientNo.Clear();
@@ -515,6 +558,7 @@ namespace Styly.NetSync
             _pendingClients.Clear();
             _knownConnectedClients.Clear();
             SetLocalClientNo(0);   // reset local mapping
+            ResetVersionCheck();   // reset version check for new room
 
             // Also clear message queues to avoid cross-room leakage.
             while (_roomTransformQueue.TryDequeue(out _)) { }

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/NetSyncManager.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/NetSyncManager.cs
@@ -39,6 +39,11 @@ namespace Styly.NetSync
         public UnityEvent<string, string, string> OnGlobalVariableChanged;
         public UnityEvent<int, string, string, string> OnClientVariableChanged;
         public UnityEvent OnReady;
+        /// <summary>
+        /// Event fired when server and client versions do not match.
+        /// Parameters: (serverVersion, clientVersion) as strings like "0.7.5"
+        /// </summary>
+        public UnityEvent<string, string> OnVersionMismatch = new UnityEvent<string, string>();
 
         // Advanced Options (drawn by NetSyncManagerEditor in a foldout)
         [SerializeField, Range(0.5f, 60), Tooltip("Transform sync frequency in Hz (sends per second). Higher values provide smoother movement but increase network traffic.")]
@@ -539,6 +544,7 @@ namespace Styly.NetSync
             _messageProcessor.SetLocalDeviceId(_deviceId);
             _messageProcessor.SetNetSyncManager(this);
             _messageProcessor.OnLocalClientNoAssigned += OnLocalClientNoAssigned;
+            _messageProcessor.OnVersionMismatch += HandleVersionMismatch;
             _connectionManager = new ConnectionManager(this, _messageProcessor, _enableDebugLogs, _logNetworkTraffic);
             _avatarManager = new AvatarManager(_enableDebugLogs);
             _rpcManager = new RPCManager(_connectionManager, _deviceId, this);
@@ -928,6 +934,28 @@ namespace Styly.NetSync
             {
                 _isHandlingConnectionError = false;
             }
+        }
+
+        /// <summary>
+        /// Handles version mismatch between server and client.
+        /// Disconnects from the server to prevent protocol incompatibility issues.
+        /// </summary>
+        private void HandleVersionMismatch(int serverMajor, int serverMinor, int serverPatch,
+            int clientMajor, int clientMinor, int clientPatch)
+        {
+            var serverVersion = $"{serverMajor}.{serverMinor}.{serverPatch}";
+            var clientVersion = $"{clientMajor}.{clientMinor}.{clientPatch}";
+
+            Debug.LogError($"[NetSyncManager] Version mismatch! Server: {serverVersion}, Client: {clientVersion}. Disconnecting.");
+
+            // Invoke the public UnityEvent for external handlers before disconnecting
+            if (OnVersionMismatch != null)
+            {
+                OnVersionMismatch.Invoke(serverVersion, clientVersion);
+            }
+
+            // Disconnect to prevent protocol incompatibility issues
+            StopNetworking();
         }
 
         /// <summary>


### PR DESCRIPTION
Version Check Feature                                                                                                                         
                                                                                                                                                
Overview                                                                                                                                      
                                                                                                                                              
The version check ensures that the server and Unity client are running compatible protocol versions. It is performed once when a client first 
connects to a room.                                                                                                                           
                                                                                                                                              
Protocol                                                                                                                                      
                                                                                                                                              
The server includes its version (3 bytes: major, minor, patch) in the MSG_DEVICE_ID_MAPPING message:                                          
                                                                                                                                              
[1 byte]  Message Type (6)                                                                                                                    
[1 byte]  Major Version  ← Added                                                                                                              
[1 byte]  Minor Version  ← Added                                                                                                              
[1 byte]  Patch Version  ← Added                                                                                                              
[2 bytes] Mapping Count                                                                                                                       
...                                                                                                                                           
                                                           
```
Compatibility Rules                                                                                                                           
┌───────────────────────────────────┬──────────────────────────────┐                                                                          
│             Condition             │            Result            │                                                                          
├───────────────────────────────────┼──────────────────────────────┤                                                                          
│ Major & Minor match               │ ✅ Compatible                │                                                                          
├───────────────────────────────────┼──────────────────────────────┤                                                                          
│ Patch mismatch only               │ ✅ Compatible                │                                                                          
├───────────────────────────────────┼──────────────────────────────┤                                                                          
│ Major or Minor mismatch           │ ❌ Incompatible → Disconnect │                                                                          
├───────────────────────────────────┼──────────────────────────────┤                                                                          
│ Either version is 0.0.x (unknown) │ ✅ Skip check                │                                                                          
└───────────────────────────────────┴──────────────────────────────┘                                                                          
```

Behavior on Mismatch                                                                                                                          
                                                                                                                                              
1. Error logged: [NetSyncManager] Version mismatch! Server: x.y.z, Client: a.b.c. Disconnecting.                                              
2. OnVersionMismatch UnityEvent fires (for UI notification)                                                                                   
3. Connection terminated via StopNetworking()                                                                                                 
                                                                                                                                              
Public API                                                                                                                                    
                                                                                                                                              
// NetSyncManager.cs                                                                                                                          
public UnityEvent<string, string> OnVersionMismatch;                                                                                          
// Parameters: (serverVersion, clientVersion) e.g., ("0.7.5", "0.8.0")                                                                        
                                                                                                                                              
Limitations                                                                                                                                   
                                                                                                                                              
If the protocol format itself changed incompatibly, the client's initial MSG_CLIENT_TRANSFORM may fail to parse on the server, preventing registration and ID mapping broadcast. In this case, the client will timeout rather than receive an explicit version mismatch error.          
                                                                              


Close https://github.com/styly-dev/STYLY-NetSync/issues/50