### PR TITLE
feat: split transform/state PUBs, heartbeat liveness, and reliable RPC delivery

### DIFF
--- a/STYLY-NetSync-Server/src/styly_netsync/__init__.py
+++ b/STYLY-NetSync-Server/src/styly_netsync/__init__.py
@@ -16,7 +16,9 @@ Examples:
 
     # Use server programmatically
     from styly_netsync import NetSyncServer
-    server = NetSyncServer(dealer_port=5555, pub_port=5556)
+    server = NetSyncServer(
+        dealer_port=5555, transform_pub_port=5556, state_pub_port=5557
+    )
     server.start()
 
     # Use client programmatically

--- a/STYLY-NetSync-Server/src/styly_netsync/binary_serializer.py
+++ b/STYLY-NetSync-Server/src/styly_netsync/binary_serializer.py
@@ -18,6 +18,9 @@ MSG_CLIENT_VAR_SET = 9  # Set client variable
 MSG_CLIENT_VAR_SYNC = 10  # Sync client variables
 MSG_CLIENT_POSE_V2 = 11
 MSG_ROOM_POSE_V2 = 12
+MSG_HEARTBEAT = 13
+MSG_RPC_DELIVERY = 14
+MSG_RPC_ACK = 15
 
 # Transform data type identifiers (deprecated - kept for reference)
 
@@ -214,6 +217,37 @@ def serialize_rpc_message(data: dict[str, Any]) -> bytes:
     return bytes(buffer)
 
 
+def serialize_heartbeat(data: dict[str, Any]) -> bytes:
+    """Serialize heartbeat message."""
+    buffer = bytearray()
+    buffer.append(MSG_HEARTBEAT)
+    _pack_string(buffer, data.get("deviceId", ""))
+    buffer.extend(struct.pack("<H", data.get("clientNo", 0)))
+    buffer.extend(struct.pack("<d", data.get("timestamp", 0.0)))
+    return bytes(buffer)
+
+
+def serialize_rpc_delivery(data: dict[str, Any]) -> bytes:
+    """Serialize RPC delivery message with rpcId."""
+    buffer = bytearray()
+    buffer.append(MSG_RPC_DELIVERY)
+    _pack_string(buffer, data.get("rpcId", ""), use_ushort=True)
+    buffer.extend(struct.pack("<H", data.get("senderClientNo", 0)))
+    _pack_string(buffer, data.get("functionName", ""))
+    _pack_string(buffer, data.get("argumentsJson", ""), use_ushort=True)
+    return bytes(buffer)
+
+
+def serialize_rpc_ack(data: dict[str, Any]) -> bytes:
+    """Serialize RPC ACK message."""
+    buffer = bytearray()
+    buffer.append(MSG_RPC_ACK)
+    _pack_string(buffer, data.get("rpcId", ""), use_ushort=True)
+    _pack_string(buffer, data.get("deviceId", ""))
+    buffer.extend(struct.pack("<d", data.get("timestamp", 0.0)))
+    return bytes(buffer)
+
+
 def parse_version(version_str: str) -> tuple[int, int, int]:
     """Parse semantic version string into (major, minor, patch) tuple.
 
@@ -397,7 +431,7 @@ def deserialize(data: bytes) -> tuple[int, dict[str, Any] | None, bytes]:
     offset += 1
 
     # Validate message type is within valid range
-    if message_type < MSG_CLIENT_TRANSFORM or message_type > MSG_ROOM_POSE_V2:
+    if message_type < MSG_CLIENT_TRANSFORM or message_type > MSG_RPC_ACK:
         # Return invalid message type with None data instead of raising exception
         return message_type, None, b""
 
@@ -426,6 +460,12 @@ def deserialize(data: bytes) -> tuple[int, dict[str, Any] | None, bytes]:
             return message_type, _deserialize_client_var_set(data, offset), b""
         elif message_type == MSG_CLIENT_VAR_SYNC:
             return message_type, _deserialize_client_var_sync(data, offset), b""
+        elif message_type == MSG_HEARTBEAT:
+            return message_type, _deserialize_heartbeat(data, offset), b""
+        elif message_type == MSG_RPC_DELIVERY:
+            return message_type, _deserialize_rpc_delivery(data, offset), b""
+        elif message_type == MSG_RPC_ACK:
+            return message_type, _deserialize_rpc_ack(data, offset), b""
         else:
             # Should not reach here due to validation above
             return message_type, None, b""
@@ -478,6 +518,33 @@ def _deserialize_client_transform(data: bytes, offset: int) -> dict[str, Any]:
             vt, offset = _unpack_full_transform(data, offset)
             result["virtuals"].append(vt)
 
+    return result
+
+
+def _deserialize_heartbeat(data: bytes, offset: int) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    result["deviceId"], offset = _unpack_string(data, offset)
+    result["clientNo"] = struct.unpack("<H", data[offset : offset + 2])[0]
+    offset += 2
+    result["timestamp"] = struct.unpack("<d", data[offset : offset + 8])[0]
+    return result
+
+
+def _deserialize_rpc_delivery(data: bytes, offset: int) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    result["rpcId"], offset = _unpack_string(data, offset, use_ushort=True)
+    result["senderClientNo"] = struct.unpack("<H", data[offset : offset + 2])[0]
+    offset += 2
+    result["functionName"], offset = _unpack_string(data, offset)
+    result["argumentsJson"], offset = _unpack_string(data, offset, use_ushort=True)
+    return result
+
+
+def _deserialize_rpc_ack(data: bytes, offset: int) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    result["rpcId"], offset = _unpack_string(data, offset, use_ushort=True)
+    result["deviceId"], offset = _unpack_string(data, offset)
+    result["timestamp"] = struct.unpack("<d", data[offset : offset + 8])[0]
     return result
 
 

--- a/STYLY-NetSync-Server/src/styly_netsync/default.toml
+++ b/STYLY-NetSync-Server/src/styly_netsync/default.toml
@@ -17,6 +17,12 @@ dealer_port = 5555
 # ZeroMQ PUB port for server-to-client broadcasts
 pub_port = 5556
 
+# ZeroMQ PUB port for transform downlink (lossy, latest-only)
+transform_pub_port = 5556
+
+# ZeroMQ PUB port for state downlink (lossy, latest-only)
+state_pub_port = 5557
+
 # UDP port for server discovery service
 server_discovery_port = 9999
 
@@ -37,6 +43,9 @@ transform_broadcast_rate = 10
 
 # Client disconnect timeout in seconds
 client_timeout = 2.5
+
+# Heartbeat-based timeout in seconds (liveness)
+heartbeat_timeout = 2.5
 
 # Cleanup interval in seconds for removing stale data
 cleanup_interval = 1.0
@@ -74,6 +83,18 @@ nv_monitor_window_size = 1.0
 
 # NV requests per second before warning
 nv_monitor_threshold = 200
+
+# State broadcast rate in Hz (snapshots/deltas)
+state_broadcast_rate_hz = 10.0
+
+# Expected heartbeat interval in seconds (diagnostics only)
+heartbeat_expected_interval = 1.0
+
+# RPC retry settings (milliseconds)
+rpc_retry_initial_ms = 100
+rpc_retry_max_ms = 1000
+rpc_retry_max_attempts = 30
+rpc_outbox_max_per_client = 256
 
 # Internal Limits
 # Maximum virtual transforms per client

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/DataStructure.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/DataStructure.cs
@@ -97,6 +97,15 @@ namespace Styly.NetSync
         public string argumentsJson;
     }
 
+    [Serializable]
+    internal class RpcDeliveryMessage
+    {
+        public string rpcId;
+        public int senderClientNo;
+        public string functionName;
+        public string argumentsJson;
+    }
+
 
     // Device ID mapping data
     [Serializable]

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/HeartbeatManager.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/HeartbeatManager.cs
@@ -1,0 +1,58 @@
+// HeartbeatManager.cs - Handles heartbeat messages for liveness
+using System;
+using System.IO;
+
+namespace Styly.NetSync
+{
+    internal class HeartbeatManager
+    {
+        private readonly ConnectionManager _connectionManager;
+        private readonly string _deviceId;
+        private readonly double _intervalSeconds;
+        private double _lastSentAt;
+
+        private readonly ReusableBufferWriter _buf;
+        private const int InitialBufferCapacity = 128;
+
+        public HeartbeatManager(ConnectionManager connectionManager, string deviceId, double intervalSeconds)
+        {
+            _connectionManager = connectionManager;
+            _deviceId = deviceId;
+            _intervalSeconds = Math.Max(0.1, intervalSeconds);
+            _buf = new ReusableBufferWriter(InitialBufferCapacity);
+        }
+
+        public void Tick(string roomId, int clientNo)
+        {
+            if (_connectionManager == null || !_connectionManager.IsConnected)
+            {
+                return;
+            }
+
+            var now = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() / 1000.0;
+            if (now - _lastSentAt < _intervalSeconds)
+            {
+                return;
+            }
+
+            _lastSentAt = now;
+
+            var required = 1 + 1 + (_deviceId?.Length ?? 0) + 2 + 8;
+            _buf.EnsureCapacity(required);
+            _buf.Stream.Position = 0;
+
+            BinarySerializer.SerializeHeartbeatInto(_buf.Writer, _deviceId, (ushort)Math.Max(0, clientNo), now);
+            _buf.Writer.Flush();
+
+            var length = (int)_buf.Stream.Position;
+            var payload = new byte[length];
+            Buffer.BlockCopy(_buf.GetBufferUnsafe(), 0, payload, 0, length);
+            _connectionManager.TrySendDealerMessage(roomId, payload);
+        }
+
+        public void Dispose()
+        {
+            _buf.Dispose();
+        }
+    }
+}

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/ServerDiscoveryManager.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/ServerDiscoveryManager.cs
@@ -40,7 +40,7 @@ namespace Styly.NetSync
         public int MaxParallelConnections { get; set; } = 20; // Scan up to 20 IPs concurrently
         public int TcpConnectionTimeoutMs { get; set; } = 300; // Reduced timeout for faster scanning
 
-        public event Action<string, int, int> OnServerDiscovered;
+        public event Action<string, int, int, int> OnServerDiscovered;
 
         public ServerDiscoveryManager(bool enableDebugLogs)
         {
@@ -500,19 +500,20 @@ namespace Styly.NetSync
                 if (parts.Length >= 3 && parts[0] == "STYLY-NETSYNC")
                 {
                     var dealerPort = int.Parse(parts[1]);
-                    var subPort = int.Parse(parts[2]);
+                    var transformSubPort = int.Parse(parts[2]);
                     var serverName = parts.Length >= 4 ? parts[3] : "Unknown Server";
+                    var stateSubPort = parts.Length >= 5 ? int.Parse(parts[4]) : transformSubPort;
 
                     var serverAddress = $"tcp://{sender.Address}";
 
                     // Cache the discovered server IP for future connections
                     QueueCacheServerIp(sender.Address.ToString());
 
-                    DebugLog($"Discovered server '{serverName}' at {serverAddress} (dealer:{dealerPort}, sub:{subPort})");
+                    DebugLog($"Discovered server '{serverName}' at {serverAddress} (dealer:{dealerPort}, transform:{transformSubPort}, state:{stateSubPort})");
 
                     if (OnServerDiscovered != null)
                     {
-                        OnServerDiscovered.Invoke(serverAddress, dealerPort, subPort);
+                        OnServerDiscovered.Invoke(serverAddress, dealerPort, transformSubPort, stateSubPort);
                     }
 
                     // Stop sending more discovery requests once we found a server

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/NetSyncManager.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/NetSyncManager.cs
@@ -18,7 +18,8 @@ namespace Styly.NetSync
         [Header("Connection Settings")]
         [SerializeField, Tooltip("Server IP address or hostname (e.g. 192.168.1.100, localhost). Leave empty to auto-discover server on local network")] private string _serverAddress = "";
         private int _dealerPort = 5555;
-        private int _subPort = 5556;
+        private int _transformSubPort = 5556;
+        private int _stateSubPort = 5557;
         [SerializeField] private string _roomId = "default_room";
 
         [Header("Avatar Settings")]
@@ -224,6 +225,7 @@ namespace Styly.NetSync
 
             // Update room ID
             _roomId = newRoomId;
+            _messageProcessor?.SetCurrentRoomId(_roomId);
 
             // Clear room-scoped state to prevent leaks across rooms
             _messageProcessor?.ClearRoomScopedState();
@@ -249,6 +251,7 @@ namespace Styly.NetSync
         private AvatarManager _avatarManager;
         private RPCManager _rpcManager;
         private TransformSyncManager _transformSyncManager;
+        private HeartbeatManager _heartbeatManager;
         private MessageProcessor _messageProcessor;
         private ServerDiscoveryManager _discoveryManager;
         private NetworkVariableManager _networkVariableManager;
@@ -261,7 +264,8 @@ namespace Styly.NetSync
         private bool _roomSwitching; // Flag to prevent operations during room switching
         private string _discoveredServer;
         private int _discoveredDealerPort;
-        private int _discoveredSubPort;
+        private int _discoveredTransformSubPort;
+        private int _discoveredStateSubPort;
         private float _discoveryStartTime;
         private const float ReconnectDelay = 10f;
         private const float DiscoveryRetryDelay = 5f; // Retry discovery every 5 seconds after failure
@@ -481,6 +485,8 @@ namespace Styly.NetSync
             HandleReconnection();
             ProcessMessages();
 
+            _heartbeatManager?.Tick(_roomId, _clientNo);
+
             // Skip transform/NV operations during room switching
             if (!_roomSwitching)
             {
@@ -547,12 +553,15 @@ namespace Styly.NetSync
             _messageProcessor = new MessageProcessor(_logNetworkTraffic);
             _messageProcessor.SetLocalDeviceId(_deviceId);
             _messageProcessor.SetNetSyncManager(this);
+            _messageProcessor.SetCurrentRoomId(_roomId);
             _messageProcessor.OnLocalClientNoAssigned += OnLocalClientNoAssigned;
             _messageProcessor.OnVersionMismatch += HandleVersionMismatch;
             _connectionManager = new ConnectionManager(this, _messageProcessor, _enableDebugLogs, _logNetworkTraffic);
+            _messageProcessor.SetConnectionManager(_connectionManager);
             _avatarManager = new AvatarManager(_enableDebugLogs);
             _rpcManager = new RPCManager(_connectionManager, _deviceId, this);
             _transformSyncManager = new TransformSyncManager(_connectionManager, _deviceId, _transformSendRate);
+            _heartbeatManager = new HeartbeatManager(_connectionManager, _deviceId, 0.5);
             _discoveryManager = new ServerDiscoveryManager(_enableDebugLogs);
             _discoveryManager.SetServerDiscoveryPort(ServerDiscoveryPort);
             _networkVariableManager = new NetworkVariableManager(_connectionManager, _deviceId, this);
@@ -728,19 +737,21 @@ namespace Styly.NetSync
             _shouldCheckReady = true;
         }
 
-        private void OnServerDiscovered(string serverAddress, int dealerPort, int subPort)
+        private void OnServerDiscovered(string serverAddress, int dealerPort, int transformSubPort, int stateSubPort)
         {
             _discoveredServer = serverAddress;
             _discoveredDealerPort = dealerPort;
-            _discoveredSubPort = subPort;
+            _discoveredTransformSubPort = transformSubPort;
+            _discoveredStateSubPort = stateSubPort;
 
             // Update the server address for future connections
             // Remove tcp:// prefix (discovery always returns with tcp://)
             _serverAddress = serverAddress.Substring(6);
             _dealerPort = dealerPort;
-            _subPort = subPort;
+            _transformSubPort = transformSubPort;
+            _stateSubPort = stateSubPort;
 
-            DebugLog($"Server discovered: {serverAddress} (dealer:{dealerPort}, sub:{subPort})");
+            DebugLog($"Server discovered: {serverAddress} (dealer:{dealerPort}, transform:{transformSubPort}, state:{stateSubPort})");
         }
         #endregion ------------------------------------------------------------------------
 
@@ -756,7 +767,7 @@ namespace Styly.NetSync
 
             // Add tcp:// prefix
             string fullAddress = $"tcp://{_serverAddress}";
-            _connectionManager.Connect(fullAddress, _dealerPort, _subPort, _roomId);
+            _connectionManager.Connect(fullAddress, _dealerPort, _transformSubPort, _stateSubPort, _roomId);
         }
 
         private void StopNetworking()
@@ -793,7 +804,12 @@ namespace Styly.NetSync
             {
                 _isDiscovering = false;
                 StopDiscovery();
-                _connectionManager.ProcessDiscoveredServer(_discoveredServer, _discoveredDealerPort, _discoveredSubPort);
+                _connectionManager.ProcessDiscoveredServer(
+                    _discoveredServer,
+                    _discoveredDealerPort,
+                    _discoveredTransformSubPort,
+                    _discoveredStateSubPort
+                );
                 _discoveredServer = null;
                 return; // Exit early - no need to check timeout or retry
             }
@@ -1008,6 +1024,8 @@ namespace Styly.NetSync
             _transformSyncManager = null;
             _networkVariableManager?.Dispose();
             _networkVariableManager = null;
+            _heartbeatManager?.Dispose();
+            _heartbeatManager = null;
         }
 
         /// <summary>


### PR DESCRIPTION
### Motivation

- Prevent JOIN/REMOVE churn and long NV/RPC delays when available bandwidth is below aggregate message production by separating high-rate transforms from lower-rate state traffic and decoupling liveness from transform flow.
- Ensure RPCs are delivered reliably under congestion by moving delivery off the lossy PUB channel and adding ACK+retry semantics over ROUTER/DEALER.
- Provide a lightweight heartbeat so client "last_update" is refreshed even when transform frames are dropped, avoiding false timeouts.

### Description

- Added configuration options in `ServerConfig` and `default.toml` for `transform_pub_port`, `state_pub_port`, `heartbeat_timeout`, `state_broadcast_rate_hz`, heartbeat diagnostics, and RPC retry/outbox parameters such as `rpc_retry_initial_ms`, `rpc_retry_max_ms`, `rpc_retry_max_attempts`, and `rpc_outbox_max_per_client`.
- Server changes (`server.py`): replaced single PUB with two PUB sockets `pub_transform` and `pub_state` (independent SNDHWM tuning, non-blocking `DONTWAIT` sends), routed transforms → transform PUB and NV/device mappings → state PUB, implemented latest-only coalescing for transforms, added periodic state snapshot broadcasting, added `_refresh_client_liveness()` to refresh `last_update` on any incoming message (including heartbeat), and switched client cleanup to use heartbeat timeout.
- Reliable RPC on server: stopped broadcasting RPCs via PUB; instead each RPC creates a unique `rpcId`, enqueues per-target outbox entries, immediately attempts send via the `router` (ROUTER/DEALER), maintains an RPC outbox with retry/backoff and max attempts, and processes `MSG_RPC_ACK` to remove acknowledged entries; expired deliveries are logged and dropped.
- Binary protocol: added message types `MSG_HEARTBEAT=13`, `MSG_RPC_DELIVERY=14`, `MSG_RPC_ACK=15` and implemented serialize/deserialize helpers in Python (`binary_serializer.py`) and matching additions in Unity `BinarySerializer.cs`.
- Unity client changes: `ConnectionManager` now connects to three endpoints (DEALER + `transformSub` + `stateSub`) and polls all sockets without blocking; `MessageProcessor` supports `MSG_RPC_DELIVERY` with deduplication and sends ACKs back; added `HeartbeatManager.cs` to send periodic heartbeats over DEALER; `BinarySerializer` and data structures updated to support new message types and RPC delivery message shape; `NetSyncManager` wires the heartbeat tick and discovery now propagates both transform/state subs.
- Python client changes (`net_sync_manager`): added separate `transform_sub` and `state_sub` sockets, sends heartbeats on the DEALER uplink, acknowledges `MSG_RPC_DELIVERY` with `MSG_RPC_ACK`, and processes state PUB messages and DEALER inbound messages.
- Misc: rest discovery responses now advertise both transform and state sub ports, housekeeping to remove RPC outbox entries when clients are removed, and numerous comments/guardrails for non-blocking behavior and bounded outboxes.

### Testing

- Automated tests: none were executed for this patch.
- Recommend running `pytest -q` for Python tests and manual Unity verification with `Demo-01.unity` / `Debug Scene.unity` while running the Python server to validate dual-sub behavior, heartbeat liveness, NV convergence, and RPC reliability under simulated low-bandwidth conditions.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6977787b2d28832885735193fe70ffba)