### PR TITLE
feat: harden low-bandwidth NetSync transport

### DIFF
--- a/STYLY-NetSync-Server/src/styly_netsync/binary_serializer.py
+++ b/STYLY-NetSync-Server/src/styly_netsync/binary_serializer.py
@@ -18,6 +18,9 @@ MSG_CLIENT_VAR_SET = 9  # Set client variable
 MSG_CLIENT_VAR_SYNC = 10  # Sync client variables
 MSG_CLIENT_POSE_V2 = 11
 MSG_ROOM_POSE_V2 = 12
+MSG_HEARTBEAT = 13
+MSG_RPC_DELIVERY = 14
+MSG_RPC_ACK = 15
 
 # Transform data type identifiers (deprecated - kept for reference)
 
@@ -214,6 +217,41 @@ def serialize_rpc_message(data: dict[str, Any]) -> bytes:
     return bytes(buffer)
 
 
+def serialize_heartbeat(data: dict[str, Any]) -> bytes:
+    """Serialize heartbeat message.
+
+    Args:
+        data: Dictionary with deviceId, clientNo (optional), timestamp
+    """
+    buffer = bytearray()
+    buffer.append(MSG_HEARTBEAT)
+    _pack_string(buffer, data.get("deviceId", ""))
+    buffer.extend(struct.pack("<H", data.get("clientNo", 0)))
+    buffer.extend(struct.pack("<d", data.get("timestamp", 0.0)))
+    return bytes(buffer)
+
+
+def serialize_rpc_delivery(data: dict[str, Any]) -> bytes:
+    """Serialize RPC delivery message (reliable server->client RPC)."""
+    buffer = bytearray()
+    buffer.append(MSG_RPC_DELIVERY)
+    _pack_string(buffer, data.get("rpcId", ""), use_ushort=True)
+    buffer.extend(struct.pack("<H", data.get("senderClientNo", 0)))
+    _pack_string(buffer, data.get("functionName", ""))
+    _pack_string(buffer, data.get("argumentsJson", ""), use_ushort=True)
+    return bytes(buffer)
+
+
+def serialize_rpc_ack(data: dict[str, Any]) -> bytes:
+    """Serialize RPC ACK message."""
+    buffer = bytearray()
+    buffer.append(MSG_RPC_ACK)
+    _pack_string(buffer, data.get("rpcId", ""), use_ushort=True)
+    buffer.extend(struct.pack("<H", data.get("receiverClientNo", 0)))
+    buffer.extend(struct.pack("<d", data.get("timestamp", 0.0)))
+    return bytes(buffer)
+
+
 def parse_version(version_str: str) -> tuple[int, int, int]:
     """Parse semantic version string into (major, minor, patch) tuple.
 
@@ -397,7 +435,7 @@ def deserialize(data: bytes) -> tuple[int, dict[str, Any] | None, bytes]:
     offset += 1
 
     # Validate message type is within valid range
-    if message_type < MSG_CLIENT_TRANSFORM or message_type > MSG_ROOM_POSE_V2:
+    if message_type < MSG_CLIENT_TRANSFORM or message_type > MSG_RPC_ACK:
         # Return invalid message type with None data instead of raising exception
         return message_type, None, b""
 
@@ -426,6 +464,12 @@ def deserialize(data: bytes) -> tuple[int, dict[str, Any] | None, bytes]:
             return message_type, _deserialize_client_var_set(data, offset), b""
         elif message_type == MSG_CLIENT_VAR_SYNC:
             return message_type, _deserialize_client_var_sync(data, offset), b""
+        elif message_type == MSG_HEARTBEAT:
+            return message_type, _deserialize_heartbeat(data, offset), b""
+        elif message_type == MSG_RPC_DELIVERY:
+            return message_type, _deserialize_rpc_delivery(data, offset), b""
+        elif message_type == MSG_RPC_ACK:
+            return message_type, _deserialize_rpc_ack(data, offset), b""
         else:
             # Should not reach here due to validation above
             return message_type, None, b""
@@ -491,6 +535,39 @@ def _deserialize_rpc_message(data: bytes, offset: int) -> dict[str, Any]:
 
     result["functionName"], offset = _unpack_string(data, offset)
     result["argumentsJson"], offset = _unpack_string(data, offset, use_ushort=True)
+    return result
+
+
+def _deserialize_heartbeat(data: bytes, offset: int) -> dict[str, Any]:
+    """Deserialize heartbeat message."""
+    result: dict[str, Any] = {}
+    result["deviceId"], offset = _unpack_string(data, offset)
+    result["clientNo"] = struct.unpack("<H", data[offset : offset + 2])[0]
+    offset += 2
+    result["timestamp"] = struct.unpack("<d", data[offset : offset + 8])[0]
+    offset += 8
+    return result
+
+
+def _deserialize_rpc_delivery(data: bytes, offset: int) -> dict[str, Any]:
+    """Deserialize RPC delivery message."""
+    result: dict[str, Any] = {}
+    result["rpcId"], offset = _unpack_string(data, offset, use_ushort=True)
+    result["senderClientNo"] = struct.unpack("<H", data[offset : offset + 2])[0]
+    offset += 2
+    result["functionName"], offset = _unpack_string(data, offset)
+    result["argumentsJson"], offset = _unpack_string(data, offset, use_ushort=True)
+    return result
+
+
+def _deserialize_rpc_ack(data: bytes, offset: int) -> dict[str, Any]:
+    """Deserialize RPC ACK message."""
+    result: dict[str, Any] = {}
+    result["rpcId"], offset = _unpack_string(data, offset, use_ushort=True)
+    result["receiverClientNo"] = struct.unpack("<H", data[offset : offset + 2])[0]
+    offset += 2
+    result["timestamp"] = struct.unpack("<d", data[offset : offset + 8])[0]
+    offset += 8
     return result
 
 

--- a/STYLY-NetSync-Server/src/styly_netsync/config.py
+++ b/STYLY-NetSync-Server/src/styly_netsync/config.py
@@ -64,6 +64,8 @@ class ServerConfig:
     # Network settings
     dealer_port: int
     pub_port: int
+    transform_pub_port: int
+    state_pub_port: int
     server_discovery_port: int
     server_name: str
     enable_server_discovery: bool
@@ -72,6 +74,9 @@ class ServerConfig:
     idle_broadcast_interval: float
     transform_broadcast_rate: int
     client_timeout: float
+    heartbeat_timeout: float
+    state_broadcast_rate_hz: int
+    heartbeat_expected_interval: float
     cleanup_interval: float
     device_id_expiry_time: float
     status_log_interval: float
@@ -91,6 +96,10 @@ class ServerConfig:
     max_virtual_transforms: int
     pub_queue_maxsize: int
     delta_ring_size: int
+    rpc_retry_initial_ms: int
+    rpc_retry_max_ms: int
+    rpc_retry_max_attempts: int
+    rpc_outbox_max_per_client: int
 
     # Logging settings
     log_dir: str | None
@@ -105,6 +114,8 @@ _VALID_KEYS: set[str] = {
     # Network settings
     "dealer_port",
     "pub_port",
+    "transform_pub_port",
+    "state_pub_port",
     "server_discovery_port",
     "server_name",
     "enable_server_discovery",
@@ -112,6 +123,9 @@ _VALID_KEYS: set[str] = {
     "idle_broadcast_interval",
     "transform_broadcast_rate",
     "client_timeout",
+    "heartbeat_timeout",
+    "state_broadcast_rate_hz",
+    "heartbeat_expected_interval",
     "cleanup_interval",
     "device_id_expiry_time",
     "status_log_interval",
@@ -129,6 +143,10 @@ _VALID_KEYS: set[str] = {
     "max_virtual_transforms",
     "pub_queue_maxsize",
     "delta_ring_size",
+    "rpc_retry_initial_ms",
+    "rpc_retry_max_ms",
+    "rpc_retry_max_attempts",
+    "rpc_outbox_max_per_client",
     # Logging settings
     "log_dir",
     "log_level_console",
@@ -231,7 +249,13 @@ def validate_config(config: ServerConfig) -> list[str]:
     errors: list[str] = []
 
     # Port validation (1-65535)
-    port_fields = ["dealer_port", "pub_port", "server_discovery_port"]
+    port_fields = [
+        "dealer_port",
+        "pub_port",
+        "transform_pub_port",
+        "state_pub_port",
+        "server_discovery_port",
+    ]
     for field_name in port_fields:
         port = getattr(config, field_name)
         if not 1 <= port <= 65535:
@@ -241,6 +265,8 @@ def validate_config(config: ServerConfig) -> list[str]:
     timing_fields = [
         "idle_broadcast_interval",
         "client_timeout",
+        "heartbeat_timeout",
+        "heartbeat_expected_interval",
         "cleanup_interval",
         "device_id_expiry_time",
         "status_log_interval",
@@ -272,6 +298,12 @@ def validate_config(config: ServerConfig) -> list[str]:
     if config.poll_timeout <= 0:
         errors.append(f"poll_timeout must be positive, got {config.poll_timeout}")
 
+    if config.state_broadcast_rate_hz <= 0:
+        errors.append(
+            "state_broadcast_rate_hz must be positive, "
+            f"got {config.state_broadcast_rate_hz}"
+        )
+
     # Network Variable limits validation (must be positive integers)
     nv_int_fields = [
         "max_global_vars",
@@ -293,7 +325,15 @@ def validate_config(config: ServerConfig) -> list[str]:
             errors.append(f"{field_name} must be positive, got {value}")
 
     # Internal limits validation (must be positive integers)
-    limits_fields = ["max_virtual_transforms", "pub_queue_maxsize", "delta_ring_size"]
+    limits_fields = [
+        "max_virtual_transforms",
+        "pub_queue_maxsize",
+        "delta_ring_size",
+        "rpc_retry_initial_ms",
+        "rpc_retry_max_ms",
+        "rpc_retry_max_attempts",
+        "rpc_outbox_max_per_client",
+    ]
     for field_name in limits_fields:
         value = getattr(config, field_name)
         if value <= 0:

--- a/STYLY-NetSync-Server/src/styly_netsync/default.toml
+++ b/STYLY-NetSync-Server/src/styly_netsync/default.toml
@@ -17,6 +17,12 @@ dealer_port = 5555
 # ZeroMQ PUB port for server-to-client broadcasts
 pub_port = 5556
 
+# ZeroMQ PUB port for lossy transform snapshots
+transform_pub_port = 5556
+
+# ZeroMQ PUB port for lossy state snapshots (NV sync, ID mapping)
+state_pub_port = 5557
+
 # UDP port for server discovery service
 server_discovery_port = 9999
 
@@ -37,6 +43,15 @@ transform_broadcast_rate = 10
 
 # Client disconnect timeout in seconds
 client_timeout = 2.5
+
+# Heartbeat-based timeout in seconds
+heartbeat_timeout = 2.5
+
+# State broadcast frequency in Hz (network variables, ID mapping)
+state_broadcast_rate_hz = 10
+
+# Expected heartbeat interval in seconds (diagnostics only)
+heartbeat_expected_interval = 1.0
 
 # Cleanup interval in seconds for removing stale data
 cleanup_interval = 1.0
@@ -84,6 +99,12 @@ pub_queue_maxsize = 10000
 
 # Delta ring buffer size for NV synchronization
 delta_ring_size = 10000
+
+# RPC retry parameters (reliable RPC over ROUTER/DEALER)
+rpc_retry_initial_ms = 100
+rpc_retry_max_ms = 1000
+rpc_retry_max_attempts = 30
+rpc_outbox_max_per_client = 200
 
 # Logging Settings
 # Directory for log files (empty string for console-only logging)

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/BinarySerializer.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/BinarySerializer.cs
@@ -22,6 +22,9 @@ namespace Styly.NetSync
         public const byte MSG_CLIENT_VAR_SYNC = 10;  // Sync client variables
         public const byte MSG_CLIENT_POSE_V2 = 11;  // Client pose (quaternion + timestamps)
         public const byte MSG_ROOM_POSE_V2 = 12;  // Room pose snapshot (quaternion + timestamps)
+        public const byte MSG_HEARTBEAT = 13;  // Heartbeat message
+        public const byte MSG_RPC_DELIVERY = 14;  // Reliable RPC delivery
+        public const byte MSG_RPC_ACK = 15;  // Reliable RPC ACK
 
         // Transform data type identifiers (deprecated - kept for reference)
         // All transforms now use 6 floats for consistency
@@ -169,7 +172,7 @@ namespace Styly.NetSync
                 var messageType = reader.ReadByte();
 
                 // Validate message type is within valid range
-                if (messageType < MSG_CLIENT_TRANSFORM || messageType > MSG_ROOM_POSE_V2)
+                if (messageType < MSG_CLIENT_TRANSFORM || messageType > MSG_RPC_ACK)
                 {
                     // Don't throw exception, just return invalid type with null data
                     // This allows the caller to handle it gracefully
@@ -185,6 +188,8 @@ namespace Styly.NetSync
                     case MSG_RPC:
                         // RPC message
                         return (messageType, DeserializeRPCMessage(reader));
+                    case MSG_RPC_DELIVERY:
+                        return (messageType, DeserializeRpcDelivery(reader));
                     // MSG_RPC_SERVER and MSG_RPC_CLIENT are reserved for future use
                     case MSG_DEVICE_ID_MAPPING:
                         // Device ID mapping notification
@@ -325,6 +330,32 @@ namespace Styly.NetSync
             writer.Write(argsBytes);
         }
 
+        public static byte[] SerializeHeartbeat(string deviceId, int clientNo, double timestamp)
+        {
+            using var ms = new MemoryStream();
+            using var writer = new BinaryWriter(ms);
+            writer.Write(MSG_HEARTBEAT);
+            var deviceIdBytes = System.Text.Encoding.UTF8.GetBytes(deviceId ?? string.Empty);
+            writer.Write((byte)deviceIdBytes.Length);
+            writer.Write(deviceIdBytes);
+            writer.Write((ushort)clientNo);
+            writer.Write(timestamp);
+            return ms.ToArray();
+        }
+
+        public static byte[] SerializeRpcAck(RpcAckMessage msg)
+        {
+            using var ms = new MemoryStream();
+            using var writer = new BinaryWriter(ms);
+            writer.Write(MSG_RPC_ACK);
+            var rpcIdBytes = System.Text.Encoding.UTF8.GetBytes(msg.rpcId ?? string.Empty);
+            writer.Write((ushort)rpcIdBytes.Length);
+            writer.Write(rpcIdBytes);
+            writer.Write((ushort)msg.receiverClientNo);
+            writer.Write(msg.timestamp);
+            return ms.ToArray();
+        }
+
 
         /// <summary>
         /// Serialize global variable set message
@@ -429,6 +460,24 @@ namespace Styly.NetSync
             var argsJson = System.Text.Encoding.UTF8.GetString(reader.ReadBytes(argsLen));
             return new RPCMessage
             {
+                senderClientNo = senderClientNo,
+                functionName = name,
+                argumentsJson = argsJson
+            };
+        }
+
+        private static RpcDeliveryMessage DeserializeRpcDelivery(BinaryReader reader)
+        {
+            var rpcIdLen = reader.ReadUInt16();
+            var rpcId = System.Text.Encoding.UTF8.GetString(reader.ReadBytes(rpcIdLen));
+            var senderClientNo = reader.ReadUInt16();
+            var nameLen = reader.ReadByte();
+            var name = System.Text.Encoding.UTF8.GetString(reader.ReadBytes(nameLen));
+            var argsLen = reader.ReadUInt16();
+            var argsJson = System.Text.Encoding.UTF8.GetString(reader.ReadBytes(argsLen));
+            return new RpcDeliveryMessage
+            {
+                rpcId = rpcId,
                 senderClientNo = senderClientNo,
                 functionName = name,
                 argumentsJson = argsJson

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/DataStructure.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/DataStructure.cs
@@ -97,6 +97,23 @@ namespace Styly.NetSync
         public string argumentsJson;
     }
 
+    [Serializable]
+    internal class RpcDeliveryMessage
+    {
+        public string rpcId;
+        public int senderClientNo;
+        public string functionName;
+        public string argumentsJson;
+    }
+
+    [Serializable]
+    internal class RpcAckMessage
+    {
+        public string rpcId;
+        public int receiverClientNo;
+        public double timestamp;
+    }
+
 
     // Device ID mapping data
     [Serializable]

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/HeartbeatManager.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/HeartbeatManager.cs
@@ -1,0 +1,50 @@
+using System;
+using NetMQ;
+
+namespace Styly.NetSync
+{
+    internal class HeartbeatManager
+    {
+        private readonly ConnectionManager _connectionManager;
+        private readonly string _deviceId;
+        private readonly double _intervalSeconds;
+        private double _lastSentAt;
+
+        public HeartbeatManager(ConnectionManager connectionManager, string deviceId, double intervalSeconds = 1.0)
+        {
+            _connectionManager = connectionManager;
+            _deviceId = deviceId;
+            _intervalSeconds = Math.Max(0.1, intervalSeconds);
+            _lastSentAt = 0.0;
+        }
+
+        public void Tick(string roomId, int clientNo)
+        {
+            if (string.IsNullOrEmpty(roomId))
+            {
+                return;
+            }
+
+            var now = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() / 1000.0;
+            if (now - _lastSentAt < _intervalSeconds)
+            {
+                return;
+            }
+
+            var dealer = _connectionManager.DealerSocket;
+            if (dealer == null)
+            {
+                return;
+            }
+
+            var payload = BinarySerializer.SerializeHeartbeat(_deviceId, clientNo, now);
+            var msg = new NetMQMessage();
+            msg.Append(roomId);
+            msg.Append(payload);
+            dealer.TrySendMultipartMessage(msg);
+            msg.Clear();
+
+            _lastSentAt = now;
+        }
+    }
+}

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/ServerDiscoveryManager.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/ServerDiscoveryManager.cs
@@ -40,7 +40,7 @@ namespace Styly.NetSync
         public int MaxParallelConnections { get; set; } = 20; // Scan up to 20 IPs concurrently
         public int TcpConnectionTimeoutMs { get; set; } = 300; // Reduced timeout for faster scanning
 
-        public event Action<string, int, int> OnServerDiscovered;
+        public event Action<string, int, int, int> OnServerDiscovered;
 
         public ServerDiscoveryManager(bool enableDebugLogs)
         {
@@ -500,19 +500,31 @@ namespace Styly.NetSync
                 if (parts.Length >= 3 && parts[0] == "STYLY-NETSYNC")
                 {
                     var dealerPort = int.Parse(parts[1]);
-                    var subPort = int.Parse(parts[2]);
-                    var serverName = parts.Length >= 4 ? parts[3] : "Unknown Server";
+                    var transformPort = int.Parse(parts[2]);
+                    int statePort;
+                    string serverName;
+
+                    if (parts.Length >= 4 && int.TryParse(parts[3], out var parsedStatePort))
+                    {
+                        statePort = parsedStatePort;
+                        serverName = parts.Length >= 5 ? parts[4] : "Unknown Server";
+                    }
+                    else
+                    {
+                        statePort = transformPort;
+                        serverName = parts.Length >= 4 ? parts[3] : "Unknown Server";
+                    }
 
                     var serverAddress = $"tcp://{sender.Address}";
 
                     // Cache the discovered server IP for future connections
                     QueueCacheServerIp(sender.Address.ToString());
 
-                    DebugLog($"Discovered server '{serverName}' at {serverAddress} (dealer:{dealerPort}, sub:{subPort})");
+                    DebugLog($"Discovered server '{serverName}' at {serverAddress} (dealer:{dealerPort}, transform:{transformPort}, state:{statePort})");
 
                     if (OnServerDiscovered != null)
                     {
-                        OnServerDiscovered.Invoke(serverAddress, dealerPort, subPort);
+                        OnServerDiscovered.Invoke(serverAddress, dealerPort, transformPort, statePort);
                     }
 
                     // Stop sending more discovery requests once we found a server


### PR DESCRIPTION
### Motivation
- Prevent false JOIN/REMOVE churn by decoupling liveness from transform flow so clients are not removed when transforms are dropped under congestion.
- Ensure Network Variables converge quickly by publishing consolidated state snapshots instead of queuing every set when bandwidth is constrained.
- Guarantee RPC delivery under lossy downlink by moving server→client RPCs off PUB/SUB and implementing ROUTER/DEALER delivery with ACK+retry and client-side dedup.

### Description
- Configuration: added new fields and defaults in `default.toml` and `ServerConfig` (`transform_pub_port`, `state_pub_port`, `heartbeat_timeout`, `state_broadcast_rate_hz`, `heartbeat_expected_interval`, `rpc_retry_*`, `rpc_outbox_max_per_client`).
- Binary protocol: added message IDs and (de)serializers for `MSG_HEARTBEAT`, `MSG_RPC_DELIVERY`, and `MSG_RPC_ACK` in `binary_serializer.py` and the Unity `BinarySerializer` to keep Python/C# protocol consistent.
- Server (Python): split the downlink into `pub_transform` and `pub_state`, introduced a state PUB queue (`_pub_queue_state`) with latest-only and DONTWAIT sends, added periodic state snapshot broadcasts, added heartbeat handling and `_refresh_client_liveness()` to update `last_update` on any message containing/associated with `deviceId`, and implemented reliable RPC outbox with per-(room,device) outboxes, `RpcOutboxEntry`, exponential retry scheduling, and ACK processing (`_queue_rpc_outbox`, `_try_send_rpc_payload`, `_retry_rpc_outbox`, `_handle_rpc_ack`).
- Server routing: transforms still use latest-only coalescing and transform PUB; NV syncs, ID mappings, and state snapshots are published to the state PUB; RPC server→client deliveries use ROUTER sends (not PUB).
- Unity client: `ConnectionManager` now opens two SUB sockets (`_transformSubSocket`, `_stateSubSocket`) and continues to use a `DealerSocket` for sends/acks, updated receive loop to poll transform SUB, state SUB, and dealer without blocking, `MessageProcessor` handles `RpcDelivery` messages (dedupe + enqueue) and sends back `RpcAck` via the dealer, added `HeartbeatManager` to emit heartbeats on the dealer channel, and added new message types/structures in `DataStructure.cs` and updated serializers/deserializers.
- Discovery and REST: server discovery responses and client discovery parsing were extended to include transform/state pub ports so clients discover both PUB endpoints.
- Misc: added small logging/metrics improvements and ensured outbox cleanup on client removal/expiry.

### Testing
- Automated tests: none were executed as part of this change set (no `pytest`/Unity automated runs were requested or performed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6977787b2d28832885735193fe70ffba)