### PR TITLE
feat: split transform/state PUB, heartbeat liveness, reliable RPC

### DIFF
--- a/STYLY-NetSync-Server/src/styly_netsync/binary_serializer.py
+++ b/STYLY-NetSync-Server/src/styly_netsync/binary_serializer.py
@@ -18,6 +18,9 @@ MSG_CLIENT_VAR_SET = 9  # Set client variable
 MSG_CLIENT_VAR_SYNC = 10  # Sync client variables
 MSG_CLIENT_POSE_V2 = 11
 MSG_ROOM_POSE_V2 = 12
+MSG_HEARTBEAT = 13
+MSG_RPC_DELIVERY = 14
+MSG_RPC_ACK = 15
 
 # Transform data type identifiers (deprecated - kept for reference)
 
@@ -214,6 +217,41 @@ def serialize_rpc_message(data: dict[str, Any]) -> bytes:
     return bytes(buffer)
 
 
+def serialize_heartbeat(data: dict[str, Any]) -> bytes:
+    """Serialize heartbeat message.
+
+    Args:
+        data: Dictionary with deviceId, clientNo, timestamp
+    """
+    buffer = bytearray()
+    buffer.append(MSG_HEARTBEAT)
+    _pack_string(buffer, data.get("deviceId", ""))
+    buffer.extend(struct.pack("<H", data.get("clientNo", 0)))
+    buffer.extend(struct.pack("<d", data.get("timestamp", 0.0)))
+    return bytes(buffer)
+
+
+def serialize_rpc_delivery(data: dict[str, Any]) -> bytes:
+    """Serialize RPC delivery message."""
+    buffer = bytearray()
+    buffer.append(MSG_RPC_DELIVERY)
+    _pack_string(buffer, data.get("rpcId", ""), use_ushort=True)
+    buffer.extend(struct.pack("<H", data.get("senderClientNo", 0)))
+    _pack_string(buffer, data.get("functionName", ""))
+    _pack_string(buffer, data.get("argumentsJson", ""), use_ushort=True)
+    return bytes(buffer)
+
+
+def serialize_rpc_ack(data: dict[str, Any]) -> bytes:
+    """Serialize RPC ack message."""
+    buffer = bytearray()
+    buffer.append(MSG_RPC_ACK)
+    _pack_string(buffer, data.get("rpcId", ""), use_ushort=True)
+    buffer.extend(struct.pack("<H", data.get("receiverClientNo", 0)))
+    buffer.extend(struct.pack("<d", data.get("timestamp", 0.0)))
+    return bytes(buffer)
+
+
 def parse_version(version_str: str) -> tuple[int, int, int]:
     """Parse semantic version string into (major, minor, patch) tuple.
 
@@ -397,7 +435,7 @@ def deserialize(data: bytes) -> tuple[int, dict[str, Any] | None, bytes]:
     offset += 1
 
     # Validate message type is within valid range
-    if message_type < MSG_CLIENT_TRANSFORM or message_type > MSG_ROOM_POSE_V2:
+    if message_type < MSG_CLIENT_TRANSFORM or message_type > MSG_RPC_ACK:
         # Return invalid message type with None data instead of raising exception
         return message_type, None, b""
 
@@ -426,6 +464,12 @@ def deserialize(data: bytes) -> tuple[int, dict[str, Any] | None, bytes]:
             return message_type, _deserialize_client_var_set(data, offset), b""
         elif message_type == MSG_CLIENT_VAR_SYNC:
             return message_type, _deserialize_client_var_sync(data, offset), b""
+        elif message_type == MSG_HEARTBEAT:
+            return message_type, _deserialize_heartbeat(data, offset), b""
+        elif message_type == MSG_RPC_DELIVERY:
+            return message_type, _deserialize_rpc_delivery(data, offset), b""
+        elif message_type == MSG_RPC_ACK:
+            return message_type, _deserialize_rpc_ack(data, offset), b""
         else:
             # Should not reach here due to validation above
             return message_type, None, b""
@@ -491,6 +535,37 @@ def _deserialize_rpc_message(data: bytes, offset: int) -> dict[str, Any]:
 
     result["functionName"], offset = _unpack_string(data, offset)
     result["argumentsJson"], offset = _unpack_string(data, offset, use_ushort=True)
+    return result
+
+
+def _deserialize_heartbeat(data: bytes, offset: int) -> dict[str, Any]:
+    """Deserialize heartbeat message."""
+    result: dict[str, Any] = {}
+    result["deviceId"], offset = _unpack_string(data, offset)
+    result["clientNo"] = struct.unpack("<H", data[offset : offset + 2])[0]
+    offset += 2
+    result["timestamp"] = struct.unpack("<d", data[offset : offset + 8])[0]
+    return result
+
+
+def _deserialize_rpc_delivery(data: bytes, offset: int) -> dict[str, Any]:
+    """Deserialize RPC delivery message."""
+    result: dict[str, Any] = {}
+    result["rpcId"], offset = _unpack_string(data, offset, use_ushort=True)
+    result["senderClientNo"] = struct.unpack("<H", data[offset : offset + 2])[0]
+    offset += 2
+    result["functionName"], offset = _unpack_string(data, offset)
+    result["argumentsJson"], offset = _unpack_string(data, offset, use_ushort=True)
+    return result
+
+
+def _deserialize_rpc_ack(data: bytes, offset: int) -> dict[str, Any]:
+    """Deserialize RPC ack message."""
+    result: dict[str, Any] = {}
+    result["rpcId"], offset = _unpack_string(data, offset, use_ushort=True)
+    result["receiverClientNo"] = struct.unpack("<H", data[offset : offset + 2])[0]
+    offset += 2
+    result["timestamp"] = struct.unpack("<d", data[offset : offset + 8])[0]
     return result
 
 

--- a/STYLY-NetSync-Server/src/styly_netsync/default.toml
+++ b/STYLY-NetSync-Server/src/styly_netsync/default.toml
@@ -17,6 +17,12 @@ dealer_port = 5555
 # ZeroMQ PUB port for server-to-client broadcasts
 pub_port = 5556
 
+# ZeroMQ PUB port for transform broadcasts (lossy/latest-only)
+transform_pub_port = 5556
+
+# ZeroMQ PUB port for state broadcasts (lossy/latest-only)
+state_pub_port = 5557
+
 # UDP port for server discovery service
 server_discovery_port = 9999
 
@@ -38,6 +44,9 @@ transform_broadcast_rate = 10
 # Client disconnect timeout in seconds
 client_timeout = 2.5
 
+# Heartbeat timeout in seconds (liveness watchdog)
+heartbeat_timeout = 2.5
+
 # Cleanup interval in seconds for removing stale data
 cleanup_interval = 1.0
 
@@ -52,6 +61,12 @@ main_loop_sleep = 0.02
 
 # ZeroMQ poll timeout in milliseconds
 poll_timeout = 100
+
+# State broadcast rate in Hz (global/client variables + device ID mappings)
+state_broadcast_rate_hz = 10
+
+# Expected heartbeat interval in seconds (diagnostic)
+heartbeat_expected_interval = 1.0
 
 # Network Variable Settings
 # Maximum global variables per room
@@ -84,6 +99,12 @@ pub_queue_maxsize = 10000
 
 # Delta ring buffer size for NV synchronization
 delta_ring_size = 10000
+
+# RPC retry settings
+rpc_retry_initial_ms = 100
+rpc_retry_max_ms = 1000
+rpc_retry_max_attempts = 30
+rpc_outbox_max_per_client = 128
 
 # Logging Settings
 # Directory for log files (empty string for console-only logging)

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/DataStructure.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/DataStructure.cs
@@ -97,6 +97,23 @@ namespace Styly.NetSync
         public string argumentsJson;
     }
 
+    [Serializable]
+    internal class RpcDeliveryMessage
+    {
+        public string rpcId;
+        public int senderClientNo;
+        public string functionName;
+        public string argumentsJson;
+    }
+
+    [Serializable]
+    internal class RpcAckMessage
+    {
+        public string rpcId;
+        public int receiverClientNo;
+        public double timestamp;
+    }
+
 
     // Device ID mapping data
     [Serializable]

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/HeartbeatManager.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/HeartbeatManager.cs
@@ -1,0 +1,59 @@
+using System;
+using NetMQ;
+using UnityEngine;
+
+namespace Styly.NetSync
+{
+    internal class HeartbeatManager
+    {
+        private readonly ConnectionManager _connectionManager;
+        private readonly NetSyncManager _netSyncManager;
+        private readonly string _deviceId;
+        private readonly double _intervalSeconds;
+        private double _nextSendTime;
+
+        public HeartbeatManager(ConnectionManager connectionManager, NetSyncManager netSyncManager, string deviceId, double intervalSeconds)
+        {
+            _connectionManager = connectionManager;
+            _netSyncManager = netSyncManager;
+            _deviceId = deviceId;
+            _intervalSeconds = intervalSeconds;
+            _nextSendTime = 0.0;
+        }
+
+        public void Tick(string roomId)
+        {
+            if (_connectionManager.DealerSocket == null)
+            {
+                return;
+            }
+
+            var now = Time.realtimeSinceStartupAsDouble;
+            if (now < _nextSendTime)
+            {
+                return;
+            }
+            _nextSendTime = now + _intervalSeconds;
+
+            var payload = BinarySerializer.SerializeHeartbeat(_deviceId, _netSyncManager.ClientNo, now);
+            try
+            {
+                var msg = new NetMQMessage();
+                try
+                {
+                    msg.Append(roomId);
+                    msg.Append(payload);
+                    _connectionManager.DealerSocket.TrySendMultipartMessage(msg);
+                }
+                finally
+                {
+                    msg.Clear();
+                }
+            }
+            catch (Exception ex)
+            {
+                Debug.LogWarning($"[NetSync/Heartbeat] Failed to send heartbeat: {ex.Message}");
+            }
+        }
+    }
+}

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/MessageProcessor.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/MessageProcessor.cs
@@ -108,6 +108,10 @@ namespace Styly.NetSync
                         _messagesReceived++;
                         break;
 
+                    case BinarySerializer.MSG_RPC_DELIVERY when data is RpcDeliveryMessage delivery:
+                        _messageQueue.Enqueue(new NetworkMessage { type = "rpc_delivery", dataObj = delivery });
+                        _messagesReceived++;
+                        break;
 
                     case BinarySerializer.MSG_DEVICE_ID_MAPPING when data is DeviceIdMappingData mappingData:
                         // Queue ID mappings for main thread processing (thread-safety fix)
@@ -185,6 +189,17 @@ namespace Styly.NetSync
                         else
                         {
                             Debug.LogError("[MessageProcessor] rpc without dataObj (unexpected)");
+                        }
+                        break;
+
+                    case "rpc_delivery":
+                        if (msg.dataObj is RpcDeliveryMessage delivery)
+                        {
+                            rpcManager.HandleRpcDelivery(delivery);
+                        }
+                        else
+                        {
+                            Debug.LogError("[MessageProcessor] rpc_delivery without dataObj (unexpected)");
                         }
                         break;
 

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/ServerDiscoveryManager.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/ServerDiscoveryManager.cs
@@ -40,7 +40,7 @@ namespace Styly.NetSync
         public int MaxParallelConnections { get; set; } = 20; // Scan up to 20 IPs concurrently
         public int TcpConnectionTimeoutMs { get; set; } = 300; // Reduced timeout for faster scanning
 
-        public event Action<string, int, int> OnServerDiscovered;
+        public event Action<string, int, int, int> OnServerDiscovered;
 
         public ServerDiscoveryManager(bool enableDebugLogs)
         {
@@ -500,19 +500,33 @@ namespace Styly.NetSync
                 if (parts.Length >= 3 && parts[0] == "STYLY-NETSYNC")
                 {
                     var dealerPort = int.Parse(parts[1]);
-                    var subPort = int.Parse(parts[2]);
-                    var serverName = parts.Length >= 4 ? parts[3] : "Unknown Server";
+                    int transformSubPort;
+                    int stateSubPort;
+                    string serverName;
+
+                    if (parts.Length >= 5)
+                    {
+                        transformSubPort = int.Parse(parts[2]);
+                        stateSubPort = int.Parse(parts[3]);
+                        serverName = parts[4];
+                    }
+                    else
+                    {
+                        transformSubPort = int.Parse(parts[2]);
+                        stateSubPort = transformSubPort;
+                        serverName = parts.Length >= 4 ? parts[3] : "Unknown Server";
+                    }
 
                     var serverAddress = $"tcp://{sender.Address}";
 
                     // Cache the discovered server IP for future connections
                     QueueCacheServerIp(sender.Address.ToString());
 
-                    DebugLog($"Discovered server '{serverName}' at {serverAddress} (dealer:{dealerPort}, sub:{subPort})");
+                    DebugLog($"Discovered server '{serverName}' at {serverAddress} (dealer:{dealerPort}, transform:{transformSubPort}, state:{stateSubPort})");
 
                     if (OnServerDiscovered != null)
                     {
-                        OnServerDiscovered.Invoke(serverAddress, dealerPort, subPort);
+                        OnServerDiscovered.Invoke(serverAddress, dealerPort, transformSubPort, stateSubPort);
                     }
 
                     // Stop sending more discovery requests once we found a server

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/NetSyncManager.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/NetSyncManager.cs
@@ -18,7 +18,8 @@ namespace Styly.NetSync
         [Header("Connection Settings")]
         [SerializeField, Tooltip("Server IP address or hostname (e.g. 192.168.1.100, localhost). Leave empty to auto-discover server on local network")] private string _serverAddress = "";
         private int _dealerPort = 5555;
-        private int _subPort = 5556;
+        private int _transformSubPort = 5556;
+        private int _stateSubPort = 5557;
         [SerializeField] private string _roomId = "default_room";
 
         [Header("Avatar Settings")]
@@ -253,6 +254,7 @@ namespace Styly.NetSync
         private ServerDiscoveryManager _discoveryManager;
         private NetworkVariableManager _networkVariableManager;
         private HumanPresenceManager _humanPresenceManager;
+        private HeartbeatManager _heartbeatManager;
         private readonly NetSyncTimeEstimator _timeEstimator = new NetSyncTimeEstimator();
 
         // State
@@ -261,7 +263,8 @@ namespace Styly.NetSync
         private bool _roomSwitching; // Flag to prevent operations during room switching
         private string _discoveredServer;
         private int _discoveredDealerPort;
-        private int _discoveredSubPort;
+        private int _discoveredTransformSubPort;
+        private int _discoveredStateSubPort;
         private float _discoveryStartTime;
         private const float ReconnectDelay = 10f;
         private const float DiscoveryRetryDelay = 5f; // Retry discovery every 5 seconds after failure
@@ -484,6 +487,7 @@ namespace Styly.NetSync
             // Skip transform/NV operations during room switching
             if (!_roomSwitching)
             {
+                _heartbeatManager?.Tick(_roomId);
                 SendTransformUpdates();
 
                 // Process Network Variables debounced updates
@@ -553,6 +557,7 @@ namespace Styly.NetSync
             _avatarManager = new AvatarManager(_enableDebugLogs);
             _rpcManager = new RPCManager(_connectionManager, _deviceId, this);
             _transformSyncManager = new TransformSyncManager(_connectionManager, _deviceId, _transformSendRate);
+            _heartbeatManager = new HeartbeatManager(_connectionManager, this, _deviceId, 0.5);
             _discoveryManager = new ServerDiscoveryManager(_enableDebugLogs);
             _discoveryManager.SetServerDiscoveryPort(ServerDiscoveryPort);
             _networkVariableManager = new NetworkVariableManager(_connectionManager, _deviceId, this);
@@ -728,19 +733,21 @@ namespace Styly.NetSync
             _shouldCheckReady = true;
         }
 
-        private void OnServerDiscovered(string serverAddress, int dealerPort, int subPort)
+        private void OnServerDiscovered(string serverAddress, int dealerPort, int transformSubPort, int stateSubPort)
         {
             _discoveredServer = serverAddress;
             _discoveredDealerPort = dealerPort;
-            _discoveredSubPort = subPort;
+            _discoveredTransformSubPort = transformSubPort;
+            _discoveredStateSubPort = stateSubPort;
 
             // Update the server address for future connections
             // Remove tcp:// prefix (discovery always returns with tcp://)
             _serverAddress = serverAddress.Substring(6);
             _dealerPort = dealerPort;
-            _subPort = subPort;
+            _transformSubPort = transformSubPort;
+            _stateSubPort = stateSubPort;
 
-            DebugLog($"Server discovered: {serverAddress} (dealer:{dealerPort}, sub:{subPort})");
+            DebugLog($"Server discovered: {serverAddress} (dealer:{dealerPort}, transform:{transformSubPort}, state:{stateSubPort})");
         }
         #endregion ------------------------------------------------------------------------
 
@@ -756,7 +763,7 @@ namespace Styly.NetSync
 
             // Add tcp:// prefix
             string fullAddress = $"tcp://{_serverAddress}";
-            _connectionManager.Connect(fullAddress, _dealerPort, _subPort, _roomId);
+            _connectionManager.Connect(fullAddress, _dealerPort, _transformSubPort, _stateSubPort, _roomId);
         }
 
         private void StopNetworking()
@@ -793,7 +800,7 @@ namespace Styly.NetSync
             {
                 _isDiscovering = false;
                 StopDiscovery();
-                _connectionManager.ProcessDiscoveredServer(_discoveredServer, _discoveredDealerPort, _discoveredSubPort);
+                _connectionManager.ProcessDiscoveredServer(_discoveredServer, _discoveredDealerPort, _discoveredTransformSubPort, _discoveredStateSubPort);
                 _discoveredServer = null;
                 return; // Exit early - no need to check timeout or retry
             }


### PR DESCRIPTION
### Motivation
- Prevent JOIN/REMOVE churn and large NV/RPC backlogs under low-bandwidth by separating lossy high-rate transforms from state traffic, decoupling liveness from transforms, and making RPCs reliable.
- Ensure state (Network Variables, ID mappings) is latest-only and non-blocking while transforms remain lossy and rate-limited.
- Provide exactly-once semantics for RPC execution via server retries + client ACKs and client-side de-duplication.

### Description
- Configuration: added new config fields and defaults in `default.toml` and `ServerConfig` for `transform_pub_port`, `state_pub_port`, `heartbeat_timeout`, `state_broadcast_rate_hz`, `heartbeat_expected_interval`, and RPC retry/backpressure limits (`rpc_retry_initial_ms`, `rpc_retry_max_ms`, `rpc_retry_max_attempts`, `rpc_outbox_max_per_client`). `process_toml_config` backfills `transform_pub_port` from `pub_port` when not provided.
- Server (Python): split single PUB into `pub_transform` and `pub_state` with tuned `SNDHWM`, non-blocking sends (`DONTWAIT`), and separate queues; added `_enqueue_state_pub` and latest-only coalescing for transforms; added heartbeat deserialization and `MSG_HEARTBEAT` handling; refreshed client liveness on every incoming message via `_refresh_client_liveness` so timeouts no longer depend on transform arrival; added periodic state snapshots (`_broadcast_state_snapshot`) and `state_broadcast_rate_hz` cadence; implemented reliable RPC outbox per (room,device) with `MSG_RPC_DELIVERY`/`MSG_RPC_ACK`, retry/backoff, max attempts/drop logging, and ACK processing to remove delivered items; discovery responses now advertise both transform and state PUB ports.
- Binary protocol (Python/C#): added message IDs `MSG_HEARTBEAT = 13`, `MSG_RPC_DELIVERY = 14`, `MSG_RPC_ACK = 15`; implemented serialize/deserialize helpers for heartbeat, RPC delivery, and RPC ack in `binary_serializer.py` (Python) and `BinarySerializer.cs` (Unity) and kept IDs consistent.
- Unity client (C#): `ConnectionManager` now opens two SUB sockets (`_transformSubSocket`, `_stateSubSocket`) plus the existing DEALER and polls/receives from all three without blocking; `MessageProcessor` accepts `MSG_RPC_DELIVERY` and queues it; `RPCManager` de-duplicates recent `rpcId`s, executes once, and sends `MSG_RPC_ACK` back to server; added `HeartbeatManager` that sends heartbeats periodically over DEALER; `NetSyncManager` integrates heartbeat ticking and discovery/connection changes to use transform/state ports; added `RpcDeliveryMessage` / `RpcAckMessage` types.
- Python client: updated to support separate `transform_sub_port` and `state_sub_port`, subscribe to both, parse discovery responses advertising two SUB ports, handle `MSG_RPC_DELIVERY` with de-dup and send `MSG_RPC_ACK` back to server.
- Misc: replaced usages of previous single state PUB enqueue with `self._enqueue_state_pub` and swapped server cleanup to use `heartbeat_timeout` for liveness checks.

### Testing
- Automated tests: none executed as part of this change (`No automated tests were run`).
- Notes for verification (recommended): run `pytest -q` in `STYLY-NetSync-Server`, start server and Unity client, simulate low-bandwidth with `styly-netsync-simulator` to verify no JOIN/REMOVE churn, transforms are latest-only, NV snapshots flow on `state` PUB, and RPCs are retried until ACKed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6977787b2d28832885735193fe70ffba)