### PR TITLE
feat: harden NetSync for low-bandwidth — separate PUB channels, heartbeats, reliable RPC

### DIFF
--- a/STYLY-NetSync-Server/src/styly_netsync/__init__.py
+++ b/STYLY-NetSync-Server/src/styly_netsync/__init__.py
@@ -16,7 +16,7 @@ Examples:
 
     # Use server programmatically
     from styly_netsync import NetSyncServer
-    server = NetSyncServer(dealer_port=5555, pub_port=5556)
+    server = NetSyncServer(dealer_port=5555, transform_pub_port=5556, state_pub_port=5557)
     server.start()
 
     # Use client programmatically

--- a/STYLY-NetSync-Server/src/styly_netsync/binary_serializer.py
+++ b/STYLY-NetSync-Server/src/styly_netsync/binary_serializer.py
@@ -18,6 +18,9 @@ MSG_CLIENT_VAR_SET = 9  # Set client variable
 MSG_CLIENT_VAR_SYNC = 10  # Sync client variables
 MSG_CLIENT_POSE_V2 = 11
 MSG_ROOM_POSE_V2 = 12
+MSG_HEARTBEAT = 13
+MSG_RPC_DELIVERY = 14
+MSG_RPC_ACK = 15
 
 # Transform data type identifiers (deprecated - kept for reference)
 
@@ -214,6 +217,38 @@ def serialize_rpc_message(data: dict[str, Any]) -> bytes:
     return bytes(buffer)
 
 
+def serialize_heartbeat(data: dict[str, Any]) -> bytes:
+    """Serialize heartbeat message."""
+    buffer = bytearray()
+    buffer.append(MSG_HEARTBEAT)
+    _pack_string(buffer, data.get("deviceId", ""))
+    buffer.extend(struct.pack("<H", data.get("clientNo", 0)))
+    buffer.extend(struct.pack("<d", data.get("timestamp", 0.0)))
+    return bytes(buffer)
+
+
+def serialize_rpc_delivery(data: dict[str, Any]) -> bytes:
+    """Serialize RPC delivery message with rpcId."""
+    buffer = bytearray()
+    buffer.append(MSG_RPC_DELIVERY)
+    buffer.extend(struct.pack("<Q", data.get("rpcId", 0)))
+    sender_client_no = data.get("senderClientNo", 0)
+    buffer.extend(struct.pack("<H", sender_client_no))
+    _pack_string(buffer, data.get("functionName", ""))
+    _pack_string(buffer, data.get("argumentsJson", ""), use_ushort=True)
+    return bytes(buffer)
+
+
+def serialize_rpc_ack(data: dict[str, Any]) -> bytes:
+    """Serialize RPC acknowledgment message."""
+    buffer = bytearray()
+    buffer.append(MSG_RPC_ACK)
+    buffer.extend(struct.pack("<Q", data.get("rpcId", 0)))
+    _pack_string(buffer, data.get("deviceId", ""))
+    buffer.extend(struct.pack("<d", data.get("timestamp", 0.0)))
+    return bytes(buffer)
+
+
 def parse_version(version_str: str) -> tuple[int, int, int]:
     """Parse semantic version string into (major, minor, patch) tuple.
 
@@ -397,7 +432,7 @@ def deserialize(data: bytes) -> tuple[int, dict[str, Any] | None, bytes]:
     offset += 1
 
     # Validate message type is within valid range
-    if message_type < MSG_CLIENT_TRANSFORM or message_type > MSG_ROOM_POSE_V2:
+    if message_type < MSG_CLIENT_TRANSFORM or message_type > MSG_RPC_ACK:
         # Return invalid message type with None data instead of raising exception
         return message_type, None, b""
 
@@ -416,6 +451,12 @@ def deserialize(data: bytes) -> tuple[int, dict[str, Any] | None, bytes]:
         elif message_type == MSG_RPC:
             return message_type, _deserialize_rpc_message(data, offset), b""
         # MSG_RPC_SERVER and MSG_RPC_CLIENT are reserved for future use
+        elif message_type == MSG_HEARTBEAT:
+            return message_type, _deserialize_heartbeat(data, offset), b""
+        elif message_type == MSG_RPC_DELIVERY:
+            return message_type, _deserialize_rpc_delivery(data, offset), b""
+        elif message_type == MSG_RPC_ACK:
+            return message_type, _deserialize_rpc_ack(data, offset), b""
         elif message_type == MSG_DEVICE_ID_MAPPING:
             return message_type, _deserialize_device_id_mapping(data, offset), b""
         elif message_type == MSG_GLOBAL_VAR_SET:
@@ -491,6 +532,38 @@ def _deserialize_rpc_message(data: bytes, offset: int) -> dict[str, Any]:
 
     result["functionName"], offset = _unpack_string(data, offset)
     result["argumentsJson"], offset = _unpack_string(data, offset, use_ushort=True)
+    return result
+
+
+def _deserialize_heartbeat(data: bytes, offset: int) -> dict[str, Any]:
+    """Deserialize heartbeat message from binary data."""
+    result: dict[str, Any] = {}
+    result["deviceId"], offset = _unpack_string(data, offset)
+    result["clientNo"] = struct.unpack("<H", data[offset : offset + 2])[0]
+    offset += 2
+    result["timestamp"] = struct.unpack("<d", data[offset : offset + 8])[0]
+    return result
+
+
+def _deserialize_rpc_delivery(data: bytes, offset: int) -> dict[str, Any]:
+    """Deserialize RPC delivery message from binary data."""
+    result: dict[str, Any] = {}
+    result["rpcId"] = struct.unpack("<Q", data[offset : offset + 8])[0]
+    offset += 8
+    result["senderClientNo"] = struct.unpack("<H", data[offset : offset + 2])[0]
+    offset += 2
+    result["functionName"], offset = _unpack_string(data, offset)
+    result["argumentsJson"], offset = _unpack_string(data, offset, use_ushort=True)
+    return result
+
+
+def _deserialize_rpc_ack(data: bytes, offset: int) -> dict[str, Any]:
+    """Deserialize RPC acknowledgment message from binary data."""
+    result: dict[str, Any] = {}
+    result["rpcId"] = struct.unpack("<Q", data[offset : offset + 8])[0]
+    offset += 8
+    result["deviceId"], offset = _unpack_string(data, offset)
+    result["timestamp"] = struct.unpack("<d", data[offset : offset + 8])[0]
     return result
 
 

--- a/STYLY-NetSync-Server/src/styly_netsync/default.toml
+++ b/STYLY-NetSync-Server/src/styly_netsync/default.toml
@@ -17,6 +17,12 @@ dealer_port = 5555
 # ZeroMQ PUB port for server-to-client broadcasts
 pub_port = 5556
 
+# ZeroMQ PUB port for transform snapshots (lossy, latest-only)
+transform_pub_port = 5556
+
+# ZeroMQ PUB port for state snapshots (lossy, latest-only)
+state_pub_port = 5557
+
 # UDP port for server discovery service
 server_discovery_port = 9999
 
@@ -38,6 +44,9 @@ transform_broadcast_rate = 10
 # Client disconnect timeout in seconds
 client_timeout = 2.5
 
+# Heartbeat timeout in seconds (liveness driven by heartbeat, not transforms)
+heartbeat_timeout = 5.0
+
 # Cleanup interval in seconds for removing stale data
 cleanup_interval = 1.0
 
@@ -52,6 +61,12 @@ main_loop_sleep = 0.02
 
 # ZeroMQ poll timeout in milliseconds
 poll_timeout = 100
+
+# State broadcast frequency in Hz (network variables + mappings)
+state_broadcast_rate_hz = 10.0
+
+# Expected heartbeat interval in seconds (diagnostics only)
+heartbeat_expected_interval = 1.0
 
 # Network Variable Settings
 # Maximum global variables per room
@@ -84,6 +99,19 @@ pub_queue_maxsize = 10000
 
 # Delta ring buffer size for NV synchronization
 delta_ring_size = 10000
+
+# RPC retry settings
+# Initial retry delay in milliseconds
+rpc_retry_initial_ms = 100
+
+# Max retry delay in milliseconds (exponential backoff ceiling)
+rpc_retry_max_ms = 1000
+
+# Max retry attempts before dropping an RPC delivery
+rpc_retry_max_attempts = 30
+
+# Max outbox entries per client (backpressure)
+rpc_outbox_max_per_client = 256
 
 # Logging Settings
 # Directory for log files (empty string for console-only logging)

--- a/STYLY-NetSync-Server/tests/test_python_client.py
+++ b/STYLY-NetSync-Server/tests/test_python_client.py
@@ -42,7 +42,10 @@ def test_connectivity():
     print("\n=== Testing Connectivity ===")
 
     server = NetSyncServer(
-        dealer_port=5555, pub_port=5556, enable_server_discovery=False
+        dealer_port=5555,
+        transform_pub_port=5556,
+        state_pub_port=5557,
+        enable_server_discovery=False,
     )
     server_thread = threading.Thread(target=lambda: server.start(), daemon=True)
     server_thread.start()
@@ -50,7 +53,11 @@ def test_connectivity():
 
     try:
         manager = net_sync_manager(
-            server="tcp://localhost", dealer_port=5555, sub_port=5556, room="test_room"
+            server="tcp://localhost",
+            dealer_port=5555,
+            sub_port=5556,
+            state_sub_port=5557,
+            room="test_room",
         )
         manager.start()
 
@@ -70,7 +77,10 @@ def test_transforms_pull_based():
     print("\n=== Testing Pull-based Transforms ===")
 
     server = NetSyncServer(
-        dealer_port=5557, pub_port=5558, enable_server_discovery=False
+        dealer_port=5557,
+        transform_pub_port=5558,
+        state_pub_port=5559,
+        enable_server_discovery=False,
     )
     server_thread = threading.Thread(target=lambda: server.start(), daemon=True)
     server_thread.start()
@@ -78,10 +88,18 @@ def test_transforms_pull_based():
 
     try:
         client1 = net_sync_manager(
-            server="tcp://localhost", dealer_port=5557, sub_port=5558, room="demo"
+            server="tcp://localhost",
+            dealer_port=5557,
+            sub_port=5558,
+            state_sub_port=5559,
+            room="demo",
         )
         client2 = net_sync_manager(
-            server="tcp://localhost", dealer_port=5557, sub_port=5558, room="demo"
+            server="tcp://localhost",
+            dealer_port=5557,
+            sub_port=5558,
+            state_sub_port=5559,
+            room="demo",
         )
 
         client1.start()
@@ -123,7 +141,10 @@ def test_device_mapping():
     print("\n=== Testing Device Mapping ===")
 
     server = NetSyncServer(
-        dealer_port=5559, pub_port=5560, enable_server_discovery=False
+        dealer_port=5559,
+        transform_pub_port=5560,
+        state_pub_port=5561,
+        enable_server_discovery=False,
     )
     server_thread = threading.Thread(target=lambda: server.start(), daemon=True)
     server_thread.start()
@@ -134,6 +155,7 @@ def test_device_mapping():
             server="tcp://localhost",
             dealer_port=5559,
             sub_port=5560,
+            state_sub_port=5561,
             room="mapping_test",
         )
         manager.start()
@@ -162,7 +184,10 @@ def test_rpc():
     print("\n=== Testing RPC ===")
 
     server = NetSyncServer(
-        dealer_port=5561, pub_port=5562, enable_server_discovery=False
+        dealer_port=5561,
+        transform_pub_port=5562,
+        state_pub_port=5563,
+        enable_server_discovery=False,
     )
     server_thread = threading.Thread(target=lambda: server.start(), daemon=True)
     server_thread.start()
@@ -173,6 +198,7 @@ def test_rpc():
             server="tcp://localhost",
             dealer_port=5561,
             sub_port=5562,
+            state_sub_port=5563,
             room="rpc_test",
             auto_dispatch=False,
         )
@@ -180,6 +206,7 @@ def test_rpc():
             server="tcp://localhost",
             dealer_port=5561,
             sub_port=5562,
+            state_sub_port=5563,
             room="rpc_test",
             auto_dispatch=False,
         )
@@ -222,7 +249,10 @@ def test_network_variables():
     print("\n=== Testing Network Variables ===")
 
     server = NetSyncServer(
-        dealer_port=5563, pub_port=5564, enable_server_discovery=False
+        dealer_port=5563,
+        transform_pub_port=5564,
+        state_pub_port=5565,
+        enable_server_discovery=False,
     )
     server_thread = threading.Thread(target=lambda: server.start(), daemon=True)
     server_thread.start()
@@ -230,10 +260,18 @@ def test_network_variables():
 
     try:
         client1 = net_sync_manager(
-            server="tcp://localhost", dealer_port=5563, sub_port=5564, room="nv_test"
+            server="tcp://localhost",
+            dealer_port=5563,
+            sub_port=5564,
+            state_sub_port=5565,
+            room="nv_test",
         )
         client2 = net_sync_manager(
-            server="tcp://localhost", dealer_port=5563, sub_port=5564, room="nv_test"
+            server="tcp://localhost",
+            dealer_port=5563,
+            sub_port=5564,
+            state_sub_port=5565,
+            room="nv_test",
         )
 
         client1.start()
@@ -268,7 +306,10 @@ def test_stealth_mode():
     print("\n=== Testing Stealth Mode ===")
 
     server = NetSyncServer(
-        dealer_port=5565, pub_port=5566, enable_server_discovery=False
+        dealer_port=5565,
+        transform_pub_port=5566,
+        state_pub_port=5567,
+        enable_server_discovery=False,
     )
     server_thread = threading.Thread(target=lambda: server.start(), daemon=True)
     server_thread.start()
@@ -279,12 +320,14 @@ def test_stealth_mode():
             server="tcp://localhost",
             dealer_port=5565,
             sub_port=5566,
+            state_sub_port=5567,
             room="stealth_test",
         )
         client2 = net_sync_manager(
             server="tcp://localhost",
             dealer_port=5565,
             sub_port=5566,
+            state_sub_port=5567,
             room="stealth_test",
         )
 

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/ConnectionManager.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/ConnectionManager.cs
@@ -13,7 +13,8 @@ namespace Styly.NetSync
     internal class ConnectionManager
     {
         private DealerSocket _dealerSocket;
-        private SubscriberSocket _subSocket;
+        private SubscriberSocket _transformSubSocket;
+        private SubscriberSocket _stateSubSocket;
         private Thread _receiveThread;
         private volatile bool _shouldStop;
         private bool _enableDebugLogs;
@@ -27,8 +28,9 @@ namespace Styly.NetSync
         private long _lastExceptionAtUnixMs;
 
         public DealerSocket DealerSocket => _dealerSocket;
-        public SubscriberSocket SubSocket => _subSocket;
-        public bool IsConnected => _dealerSocket != null && _subSocket != null && !_connectionError;
+        public SubscriberSocket TransformSubSocket => _transformSubSocket;
+        public SubscriberSocket StateSubSocket => _stateSubSocket;
+        public bool IsConnected => _dealerSocket != null && _transformSubSocket != null && _stateSubSocket != null && !_connectionError;
         public bool IsConnectionError => _connectionError;
         
         // Thread-safe accessors for exception state
@@ -49,7 +51,7 @@ namespace Styly.NetSync
             _logNetworkTraffic = logNetworkTraffic;
         }
 
-        public void Connect(string serverAddress, int dealerPort, int subPort, string roomId)
+        public void Connect(string serverAddress, int dealerPort, int transformSubPort, int stateSubPort, string roomId)
         {
             if (_receiveThread != null)
             {
@@ -59,7 +61,7 @@ namespace Styly.NetSync
             _currentRoomId = roomId;
             _connectionError = false;
             _shouldStop = false;
-            _receiveThread = new Thread(() => NetworkLoop(serverAddress, dealerPort, subPort, roomId))
+            _receiveThread = new Thread(() => NetworkLoop(serverAddress, dealerPort, transformSubPort, stateSubPort, roomId))
             {
                 IsBackground = true,
                 Name = "STYLY_NetworkThread"
@@ -73,18 +75,24 @@ namespace Styly.NetSync
             if (_receiveThread == null) { return; }
 
             _shouldStop = true;
+            _messageProcessor.SetDealerPayloadSender(null);
 
             // Dispose sockets
-            if (_subSocket != null)
+            if (_transformSubSocket != null)
             {
-                _subSocket.Dispose();
+                _transformSubSocket.Dispose();
+            }
+            if (_stateSubSocket != null)
+            {
+                _stateSubSocket.Dispose();
             }
             if (_dealerSocket != null)
             {
                 _dealerSocket.Dispose();
             }
 
-            _subSocket = null;
+            _transformSubSocket = null;
+            _stateSubSocket = null;
             _dealerSocket = null;
 
             // Wait for receive thread to exit (unless we're on the receive thread)
@@ -98,7 +106,7 @@ namespace Styly.NetSync
             SafeNetMQCleanup();
         }
 
-        private void NetworkLoop(string serverAddress, int dealerPort, int subPort, string roomId)
+        private void NetworkLoop(string serverAddress, int dealerPort, int transformSubPort, int stateSubPort, string roomId)
         {
             try
             {
@@ -111,17 +119,38 @@ namespace Styly.NetSync
 
                 DebugLog($"[Thread] DEALER connected → {serverAddress}:{dealerPort}");
 
-                // Subscriber (for receiving)
-                using var sub = new SubscriberSocket();
-                sub.Options.Linger = TimeSpan.Zero;
-                sub.Options.ReceiveHighWatermark = 10;
-                sub.Connect($"{serverAddress}:{subPort}");
-                // Subscribe with topic. Using string here is one-time and acceptable.
-                // Note: NetMQ also offers byte[] overloads, but subscription happens once per connection.
-                sub.Subscribe(roomId);
-                _subSocket = sub;
+                // Subscribers (for receiving)
+                using var transformSub = new SubscriberSocket();
+                transformSub.Options.Linger = TimeSpan.Zero;
+                transformSub.Options.ReceiveHighWatermark = 10;
+                transformSub.Connect($"{serverAddress}:{transformSubPort}");
+                transformSub.Subscribe(roomId);
+                _transformSubSocket = transformSub;
 
-                DebugLog($"[Thread] SUB connected    → {serverAddress}:{subPort}");
+                using var stateSub = new SubscriberSocket();
+                stateSub.Options.Linger = TimeSpan.Zero;
+                stateSub.Options.ReceiveHighWatermark = 10;
+                stateSub.Connect($"{serverAddress}:{stateSubPort}");
+                stateSub.Subscribe(roomId);
+                _stateSubSocket = stateSub;
+
+                DebugLog($"[Thread] SUB(transform) → {serverAddress}:{transformSubPort}");
+                DebugLog($"[Thread] SUB(state)     → {serverAddress}:{stateSubPort}");
+
+                _messageProcessor.SetDealerPayloadSender(payload =>
+                {
+                    var msg = new NetMQMessage();
+                    try
+                    {
+                        msg.Append(roomId);
+                        msg.Append(payload);
+                        return dealer.TrySendMultipartMessage(msg);
+                    }
+                    finally
+                    {
+                        msg.Clear();
+                    }
+                });
 
                 // Notify connection established
                 if (OnConnectionEstablished != null)
@@ -131,19 +160,64 @@ namespace Styly.NetSync
 
                 while (!_shouldStop)
                 {
-                    // Receive two frames: [topic][payload]. Use string topic and direct comparison.
-                    if (!sub.TryReceiveFrameString(TimeSpan.FromMilliseconds(10), out var topic)) { continue; }
-                    if (!sub.TryReceiveFrameBytes(TimeSpan.FromMilliseconds(10), out var payload)) { continue; }
+                    bool didWork = false;
 
-                    if (topic != roomId) { continue; }
-
-                    try
+                    if (transformSub.TryReceiveFrameString(TimeSpan.Zero, out var transformTopic))
                     {
-                        _messageProcessor.ProcessIncomingMessage(payload);
+                        if (transformSub.TryReceiveFrameBytes(TimeSpan.Zero, out var payload) && transformTopic == roomId)
+                        {
+                            didWork = true;
+                            try
+                            {
+                                _messageProcessor.ProcessIncomingMessage(payload);
+                            }
+                            catch (Exception ex)
+                            {
+                                Debug.LogError($"Binary parse error: {ex.Message}");
+                            }
+                        }
                     }
-                    catch (Exception ex)
+
+                    if (stateSub.TryReceiveFrameString(TimeSpan.Zero, out var stateTopic))
                     {
-                        Debug.LogError($"Binary parse error: {ex.Message}");
+                        if (stateSub.TryReceiveFrameBytes(TimeSpan.Zero, out var payload) && stateTopic == roomId)
+                        {
+                            didWork = true;
+                            try
+                            {
+                                _messageProcessor.ProcessIncomingMessage(payload);
+                            }
+                            catch (Exception ex)
+                            {
+                                Debug.LogError($"Binary parse error: {ex.Message}");
+                            }
+                        }
+                    }
+
+                    if (dealer.TryReceiveMultipartMessage(TimeSpan.Zero, out var msg))
+                    {
+                        if (msg != null && msg.FrameCount >= 2)
+                        {
+                            var topic = msg[0].ConvertToString();
+                            if (topic == roomId)
+                            {
+                                var payload = msg[1].ToByteArray();
+                                didWork = true;
+                                try
+                                {
+                                    _messageProcessor.ProcessIncomingMessage(payload);
+                                }
+                                catch (Exception ex)
+                                {
+                                    Debug.LogError($"Binary parse error: {ex.Message}");
+                                }
+                            }
+                        }
+                    }
+
+                    if (!didWork)
+                    {
+                        Thread.Sleep(1);
                     }
                 }
             }
@@ -161,7 +235,7 @@ namespace Styly.NetSync
                     
                     // Log detailed exception context
                     var threadId = Thread.CurrentThread.ManagedThreadId;
-                    var endpoint = $"{serverAddress}:{dealerPort}/{subPort}";
+                    var endpoint = $"{serverAddress}:{dealerPort}/{transformSubPort}/{stateSubPort}";
                     Debug.LogError($"[ConnectionManager] Network thread error. " +
                                    $"Type={ex_local.GetType().Name} Message={ex_local.Message} " +
                                    $"Endpoint={endpoint} ThreadId={threadId} " +
@@ -232,13 +306,13 @@ namespace Styly.NetSync
             }
         }
 
-        public void ProcessDiscoveredServer(string serverAddress, int dealerPort, int subPort)
+        public void ProcessDiscoveredServer(string serverAddress, int dealerPort, int transformSubPort, int stateSubPort)
         {
             if (_discoveryManager != null)
             {
                 _discoveryManager.StopDiscovery();
             }
-            Connect(serverAddress, dealerPort, subPort, _currentRoomId);
+            Connect(serverAddress, dealerPort, transformSubPort, stateSubPort, _currentRoomId);
         }
 
         public void DebugLog(string msg)

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/DataStructure.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/DataStructure.cs
@@ -97,6 +97,31 @@ namespace Styly.NetSync
         public string argumentsJson;
     }
 
+    [Serializable]
+    internal class RPCDeliveryMessage
+    {
+        public ulong rpcId;
+        public int senderClientNo;
+        public string functionName;
+        public string argumentsJson;
+    }
+
+    [Serializable]
+    internal class RpcAckMessage
+    {
+        public ulong rpcId;
+        public string deviceId;
+        public double timestamp;
+    }
+
+    [Serializable]
+    internal class HeartbeatMessage
+    {
+        public string deviceId;
+        public int clientNo;
+        public double timestamp;
+    }
+
 
     // Device ID mapping data
     [Serializable]

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/HeartbeatManager.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/HeartbeatManager.cs
@@ -1,0 +1,65 @@
+// HeartbeatManager.cs - Sends periodic heartbeat messages
+using System;
+using NetMQ;
+
+namespace Styly.NetSync
+{
+    internal class HeartbeatManager
+    {
+        private readonly ConnectionManager _connectionManager;
+        private readonly string _deviceId;
+        private readonly ReusableBufferWriter _buf;
+        private float _lastSendTime;
+
+        public float IntervalSeconds { get; set; }
+
+        private const int InitialBufferCapacity = 128;
+
+        public HeartbeatManager(ConnectionManager connectionManager, string deviceId, float intervalSeconds)
+        {
+            _connectionManager = connectionManager;
+            _deviceId = deviceId;
+            IntervalSeconds = intervalSeconds;
+            _buf = new ReusableBufferWriter(InitialBufferCapacity);
+        }
+
+        public void Tick(float currentTime, string roomId, int clientNo)
+        {
+            if (_connectionManager.DealerSocket == null)
+            {
+                return;
+            }
+
+            if (currentTime - _lastSendTime < IntervalSeconds)
+            {
+                return;
+            }
+
+            var timestamp = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() / 1000.0;
+            _buf.Stream.Position = 0;
+            BinarySerializer.SerializeHeartbeatInto(_buf.Writer, _deviceId, clientNo, timestamp);
+            _buf.Writer.Flush();
+
+            var length = (int)_buf.Stream.Position;
+            var msg = new NetMQMessage();
+            try
+            {
+                msg.Append(roomId);
+                var payload = new byte[length];
+                Buffer.BlockCopy(_buf.GetBufferUnsafe(), 0, payload, 0, length);
+                msg.Append(payload);
+                _connectionManager.DealerSocket.TrySendMultipartMessage(msg);
+                _lastSendTime = currentTime;
+            }
+            finally
+            {
+                msg.Clear();
+            }
+        }
+
+        public void Dispose()
+        {
+            _buf.Dispose();
+        }
+    }
+}

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/ServerDiscoveryManager.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/ServerDiscoveryManager.cs
@@ -40,7 +40,7 @@ namespace Styly.NetSync
         public int MaxParallelConnections { get; set; } = 20; // Scan up to 20 IPs concurrently
         public int TcpConnectionTimeoutMs { get; set; } = 300; // Reduced timeout for faster scanning
 
-        public event Action<string, int, int> OnServerDiscovered;
+        public event Action<string, int, int, int> OnServerDiscovered;
 
         public ServerDiscoveryManager(bool enableDebugLogs)
         {
@@ -500,19 +500,20 @@ namespace Styly.NetSync
                 if (parts.Length >= 3 && parts[0] == "STYLY-NETSYNC")
                 {
                     var dealerPort = int.Parse(parts[1]);
-                    var subPort = int.Parse(parts[2]);
-                    var serverName = parts.Length >= 4 ? parts[3] : "Unknown Server";
+                    var transformSubPort = int.Parse(parts[2]);
+                    var stateSubPort = parts.Length >= 5 ? int.Parse(parts[3]) : transformSubPort;
+                    var serverName = parts.Length >= 5 ? parts[4] : (parts.Length >= 4 ? parts[3] : "Unknown Server");
 
                     var serverAddress = $"tcp://{sender.Address}";
 
                     // Cache the discovered server IP for future connections
                     QueueCacheServerIp(sender.Address.ToString());
 
-                    DebugLog($"Discovered server '{serverName}' at {serverAddress} (dealer:{dealerPort}, sub:{subPort})");
+                    DebugLog($"Discovered server '{serverName}' at {serverAddress} (dealer:{dealerPort}, transform:{transformSubPort}, state:{stateSubPort})");
 
                     if (OnServerDiscovered != null)
                     {
-                        OnServerDiscovered.Invoke(serverAddress, dealerPort, subPort);
+                        OnServerDiscovered.Invoke(serverAddress, dealerPort, transformSubPort, stateSubPort);
                     }
 
                     // Stop sending more discovery requests once we found a server


### PR DESCRIPTION
### Motivation

- Prevent JOIN/REMOVE churn and long NV/RPC latency when available bandwidth is lower than aggregate production rate by separating QoS and adding heartbeats and reliable RPC delivery.
- Ensure transforms can be dropped under pressure while state and RPC are treated with separate semantics so clients converge to latest state and RPCs are reliably delivered.

### Description

- Server: split single PUB into two PUB sockets (`transform_pub` and `state_pub`) with independent SNDHWM and latest-only transform coalescing; never block on PUB sends and use `DONTWAIT` where appropriate; added `transform_pub_port` and `state_pub_port` config fields and discovery advertisements now include both ports (`server.py`, `config.py`, `default.toml`).
- Heartbeat & liveness: added `MSG_HEARTBEAT` message type and serializer/deserializer support; server refreshes client `last_update` on any message (including heartbeat) and uses a separate `heartbeat_timeout` for cleanup (`binary_serializer.py`, `server.py`).
- Network Variables / State PUB: NVs are consolidated and published periodically on the state PUB as latest-only snapshots at `state_broadcast_rate_hz`; NV buffer application remains latest-wins and NV flush/apply logic updated to send snapshots rather than enqueueing every set (`server.py`).
- Reliable RPC: added `MSG_RPC_DELIVERY` and `MSG_RPC_ACK` message types and serializers; server sends RPCs to each target over ROUTER (not PUB) via an RPC outbox keyed per (room, device), with exponential-backoff retry and max attempts, and removes entries on ACK (`server.py`, `binary_serializer.py`).
- Unity client: dual SUB sockets added (`_transformSubSocket`, `_stateSubSocket`) and DEALER receive integrated into the NetworkLoop; added heartbeat sender `HeartbeatManager` that emits `MSG_HEARTBEAT` periodically; added RPC delivery handling + ACK and dedup logic in `MessageProcessor` and new message types in Unity serializer; wiring updates in `ConnectionManager`, `NetSyncManager`, `MessageProcessor`, `BinarySerializer`, `DataStructure`, `RPCManager`, `HeartbeatManager`.
- Python client: added optional `state_sub_port` and dual SUB support, dealer listen path for ACKs/deliveries, RPC delivery processing with ACK + dedupe, and discovery handling for state port (`client.py`).
- Configuration: expanded `ServerConfig` with `transform_pub_port`, `state_pub_port`, heartbeat and state timing, and RPC retry limits; default values added to `default.toml` and validation updated (`config.py`, `default.toml`).
- Tests & examples: updated Python acceptance-style tests to use the new dual-port defaults and constructors (`tests/test_python_client.py`).

Files touched (high level): server.py, binary_serializer.py, config.py, default.toml, client.py, tests/test_python_client.py, Unity: ConnectionManager.cs, BinarySerializer.cs, MessageProcessor.cs, DataStructure.cs, NetSyncManager.cs, HeartbeatManager.cs, RPCManager.cs, and supporting changes.

### Testing

- Automated tests: none executed as part of this change; Python unit/integration tests in `STYLY-NetSync-Server/tests/` were updated to exercise the dual-port defaults but were not run in CI in this rollout.
- Local verification steps to run (recommended): run `pytest -q` from `STYLY-NetSync-Server` and launch the Unity sample scenes while running the server to verify dual-subscription, heartbeat liveness, NV snapshots, and RPC delivery under simulated low-bandwidth conditions.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6977787b2d28832885735193fe70ffba)