### PR TITLE
feat: Add support for separate state channel and reliable RPC delivery

### DIFF
--- a/STYLY-NetSync-Server/src/styly_netsync/config.py
+++ b/STYLY-NetSync-Server/src/styly_netsync/config.py
@@ -64,6 +64,7 @@ class ServerConfig:
     # Network settings
     dealer_port: int
     pub_port: int
+    pub_state_port: int  # Port for state/control traffic (0 = use pub_port)
     server_discovery_port: int
     server_name: str
     enable_server_discovery: bool
@@ -105,6 +106,7 @@ _VALID_KEYS: set[str] = {
     # Network settings
     "dealer_port",
     "pub_port",
+    "pub_state_port",
     "server_discovery_port",
     "server_name",
     "enable_server_discovery",
@@ -236,6 +238,13 @@ def validate_config(config: ServerConfig) -> list[str]:
         port = getattr(config, field_name)
         if not 1 <= port <= 65535:
             errors.append(f"{field_name} must be between 1 and 65535, got {port}")
+
+    # pub_state_port special validation (0 = use pub_port, or 1-65535)
+    if config.pub_state_port != 0 and not 1 <= config.pub_state_port <= 65535:
+        errors.append(
+            f"pub_state_port must be 0 (use pub_port) or between 1 and 65535, "
+            f"got {config.pub_state_port}"
+        )
 
     # Timing validation (must be positive)
     timing_fields = [

--- a/STYLY-NetSync-Server/src/styly_netsync/default.toml
+++ b/STYLY-NetSync-Server/src/styly_netsync/default.toml
@@ -14,8 +14,12 @@
 # ZeroMQ DEALER port for client-server communication
 dealer_port = 5555
 
-# ZeroMQ PUB port for server-to-client broadcasts
+# ZeroMQ PUB port for high-frequency transform broadcasts
 pub_port = 5556
+
+# ZeroMQ PUB port for state/control traffic (NV, ID mappings, RPC)
+# Set to 0 to use the same port as pub_port (legacy single-channel mode)
+pub_state_port = 5557
 
 # UDP port for server discovery service
 server_discovery_port = 9999

--- a/STYLY-NetSync-Server/tests/test_config.py
+++ b/STYLY-NetSync-Server/tests/test_config.py
@@ -39,6 +39,7 @@ class TestLoadDefaultConfig:
         # Network
         assert config.dealer_port == 5555
         assert config.pub_port == 5556
+        assert config.pub_state_port == 5557
         assert config.server_discovery_port == 9999
         assert config.server_name == "STYLY-NetSync-Server"
         assert config.enable_server_discovery is True
@@ -85,6 +86,7 @@ class TestServerConfig:
         config = ServerConfig(
             dealer_port=6666,
             pub_port=6667,
+            pub_state_port=6668,
             server_discovery_port=8888,
             server_name="Custom Server",
             enable_server_discovery=False,
@@ -114,6 +116,7 @@ class TestServerConfig:
         )
         assert config.dealer_port == 6666
         assert config.pub_port == 6667
+        assert config.pub_state_port == 6668
         assert config.server_discovery_port == 8888
         assert config.server_name == "Custom Server"
         assert config.enable_server_discovery is False

--- a/STYLY-NetSync-Server/tests/test_python_client.py
+++ b/STYLY-NetSync-Server/tests/test_python_client.py
@@ -69,8 +69,9 @@ def test_transforms_pull_based():
     """Test pull-based transform consumption."""
     print("\n=== Testing Pull-based Transforms ===")
 
+    # Use ports that don't conflict with default pub_state_port (5557)
     server = NetSyncServer(
-        dealer_port=5557, pub_port=5558, enable_server_discovery=False
+        dealer_port=5565, pub_port=5566, enable_server_discovery=False
     )
     server_thread = threading.Thread(target=lambda: server.start(), daemon=True)
     server_thread.start()
@@ -78,10 +79,10 @@ def test_transforms_pull_based():
 
     try:
         client1 = net_sync_manager(
-            server="tcp://localhost", dealer_port=5557, sub_port=5558, room="demo"
+            server="tcp://localhost", dealer_port=5565, sub_port=5566, room="demo"
         )
         client2 = net_sync_manager(
-            server="tcp://localhost", dealer_port=5557, sub_port=5558, room="demo"
+            server="tcp://localhost", dealer_port=5565, sub_port=5566, room="demo"
         )
 
         client1.start()

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/DataStructure.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/DataStructure.cs
@@ -97,6 +97,20 @@ namespace Styly.NetSync
         public string argumentsJson;
     }
 
+    // Reliable RPC delivery message (server -> client via DEALER with ACK)
+    [Serializable]
+    internal class RPCDeliveryMessage
+    {
+        // Unique RPC ID for acknowledgment tracking
+        public uint rpcId;
+        // Client number of the sender
+        public int senderClientNo;
+        // Name of function to call
+        public string functionName;
+        // JSON-serialized function arguments array
+        public string argumentsJson;
+    }
+
 
     // Device ID mapping data
     [Serializable]


### PR DESCRIPTION
- Updated configuration to include pub_state_port for server settings.
- Modified tests to validate new pub_state_port configurations.
- Implemented reliable RPC delivery mechanism with acknowledgment handling.
- Added heartbeat message serialization to maintain client connection.
- Enhanced ConnectionManager to support separate state channel for non-transform traffic.
- Updated ServerDiscoveryManager to parse and handle stateSubPort during server discovery.
- Implemented periodic heartbeat sending in NetSyncManager to prevent false timeouts.