### PR TITLE
fix: queue dealer sends and drain transform receive

### DIFF
--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/NetworkVariableManager.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/NetworkVariableManager.cs
@@ -1,11 +1,7 @@
 // NetworkVariableManager.cs - Handles Network Variables system
 using System;
-using System.Buffers;
 using System.Collections.Generic;
-using System.Collections.Concurrent;
-using System.IO;
 using System.Text;
-using NetMQ;
 using UnityEngine;
 using Newtonsoft.Json.Linq;
 
@@ -159,11 +155,6 @@ namespace Styly.NetSync
 
             try
             {
-                if (_connectionManager.DealerSocket == null)
-                {
-                    return false;
-                }
-
                 var required = EstimateGlobalVarSetSize(name, value);
                 _buf.EnsureCapacity(required);
 
@@ -172,20 +163,9 @@ namespace Styly.NetSync
                 _buf.Writer.Flush();
                 var length = (int)_buf.Stream.Position;
 
-                bool sent;
-                var msg = new NetMQMessage();
-                try
-                {
-                    msg.Append(roomId);
-                    var payload = new byte[length];
-                    Buffer.BlockCopy(_buf.GetBufferUnsafe(), 0, payload, 0, length);
-                    msg.Append(payload);
-                    sent = _connectionManager.DealerSocket.TrySendMultipartMessage(msg);
-                }
-                finally
-                {
-                    msg.Clear();
-                }
+                var payload = new byte[length];
+                Buffer.BlockCopy(_buf.GetBufferUnsafe(), 0, payload, 0, length);
+                var sent = _connectionManager.EnqueueReliableSend(roomId, payload);
                 if (sent)
                 {
                     _lastSentGlobal[name] = value; // Update last sent cache
@@ -272,11 +252,6 @@ namespace Styly.NetSync
 
             try
             {
-                if (_connectionManager.DealerSocket == null)
-                {
-                    return false;
-                }
-
                 var required = EstimateClientVarSetSize(name, value);
                 _buf.EnsureCapacity(required);
 
@@ -285,20 +260,9 @@ namespace Styly.NetSync
                 _buf.Writer.Flush();
                 var length = (int)_buf.Stream.Position;
 
-                bool sent;
-                var msg = new NetMQMessage();
-                try
-                {
-                    msg.Append(roomId);
-                    var payload = new byte[length];
-                    Buffer.BlockCopy(_buf.GetBufferUnsafe(), 0, payload, 0, length);
-                    msg.Append(payload);
-                    sent = _connectionManager.DealerSocket.TrySendMultipartMessage(msg);
-                }
-                finally
-                {
-                    msg.Clear();
-                }
+                var payload = new byte[length];
+                Buffer.BlockCopy(_buf.GetBufferUnsafe(), 0, payload, 0, length);
+                var sent = _connectionManager.EnqueueReliableSend(roomId, payload);
                 if (sent)
                 {
                     var key = (targetClientNo, name);

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/RPCManager.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/RPCManager.cs
@@ -1,11 +1,8 @@
 // RPCManager.cs - Handles RPC (Remote Procedure Call) system
 using System;
-using System.Buffers;
-using System.IO;
 using System.Text;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using NetMQ;
 using Newtonsoft.Json;
 using UnityEngine;
 using UnityEngine.Events;
@@ -89,8 +86,6 @@ namespace Styly.NetSync
 
         private bool TrySendNow(string roomId, string functionName, string[] args)
         {
-            if (_connectionManager.DealerSocket == null) { return false; }
-
             // === Rate limit preflight (single global cap) ===
             if (!TryConsumeQuota(out var retryAfter, out var count))
             {
@@ -122,20 +117,9 @@ namespace Styly.NetSync
 
             try
             {
-                var msg = new NetMQMessage();
-                try
-                {
-                    msg.Append(roomId);
-                    var payload = new byte[length];
-                    Buffer.BlockCopy(_buf.GetBufferUnsafe(), 0, payload, 0, length);
-                    msg.Append(payload);
-                    return _connectionManager.DealerSocket.TrySendMultipartMessage(msg);
-                }
-                finally
-                {
-                    // Clear frames explicitly since NetMQMessage isn't IDisposable.
-                    msg.Clear();
-                }
+                var payload = new byte[length];
+                Buffer.BlockCopy(_buf.GetBufferUnsafe(), 0, payload, 0, length);
+                return _connectionManager.EnqueueReliableSend(roomId, payload);
             }
             catch (Exception ex)
             {

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/TransformSyncManager.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/TransformSyncManager.cs
@@ -2,10 +2,7 @@
 // Note: This class now reuses MemoryStream/BinaryWriter/NetMQMessage and a pooled byte[] buffer
 // to reduce per-send allocations and GC pressure.
 using System;
-using System.Buffers;
-using System.IO;
 using System.Text;
-using NetMQ;
 using UnityEngine;
 
 namespace Styly.NetSync
@@ -41,7 +38,7 @@ namespace Styly.NetSync
 
         public bool SendLocalTransform(NetSyncAvatar localAvatar, string roomId)
         {
-            if (localAvatar == null || _connectionManager.DealerSocket == null)
+            if (localAvatar == null)
                 return false;
 
             try
@@ -62,25 +59,13 @@ namespace Styly.NetSync
 
                 var length = (int)_buf.Stream.Position;
 
-                // Build a fresh message per send to ensure proper frame lifetime.
-                var msg = new NetMQMessage();
-                try
-                {
-                    msg.Append(roomId);
-                    // Copy the exact payload length into a fresh array owned by NetMQ (avoid sharing pooled buffer).
-                    var payload = new byte[length];
-                    Buffer.BlockCopy(_buf.GetBufferUnsafe(), 0, payload, 0, length);
-                    msg.Append(payload);
+                // Copy the exact payload length into a fresh array owned by NetMQ (avoid sharing pooled buffer).
+                var payload = new byte[length];
+                Buffer.BlockCopy(_buf.GetBufferUnsafe(), 0, payload, 0, length);
 
-                    var ok = _connectionManager.DealerSocket.TrySendMultipartMessage(msg);
-                    if (ok) _messagesSent++;
-                    return ok;
-                }
-                finally
-                {
-                    // NetMQMessage is not IDisposable; clear to release frames promptly.
-                    msg.Clear();
-                }
+                var ok = _connectionManager.EnqueueTransformSend(roomId, payload);
+                if (ok) _messagesSent++;
+                return ok;
             }
             catch (Exception ex)
             {
@@ -91,9 +76,6 @@ namespace Styly.NetSync
 
         internal bool SendStealthHandshake(string roomId)
         {
-            if (_connectionManager.DealerSocket == null)
-                return false;
-
             try
             {
                 // Estimate size for handshake and ensure capacity
@@ -106,22 +88,12 @@ namespace Styly.NetSync
 
                 var length = (int)_buf.Stream.Position;
 
-                var msg = new NetMQMessage();
-                try
-                {
-                    msg.Append(roomId);
-                    var payload = new byte[length];
-                    Buffer.BlockCopy(_buf.GetBufferUnsafe(), 0, payload, 0, length);
-                    msg.Append(payload);
+                var payload = new byte[length];
+                Buffer.BlockCopy(_buf.GetBufferUnsafe(), 0, payload, 0, length);
 
-                    var ok = _connectionManager.DealerSocket.TrySendMultipartMessage(msg);
-                    if (ok) _messagesSent++;
-                    return ok;
-                }
-                finally
-                {
-                    msg.Clear();
-                }
+                var ok = _connectionManager.EnqueueReliableSend(roomId, payload);
+                if (ok) _messagesSent++;
+                return ok;
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
### Motivation

- Reduce CPU spikes from repeated transform deserialization by draining the SUB socket and processing only the most recent transform frame.
- Make transform receive behavior latest-first and avoid piling up stale transform frames by lowering the SUB `ReceiveHighWatermark`.
- Eliminate unsafe cross-thread access to `DealerSocket` by routing all sends through a thread-safe enqueue/flush mechanism so only the network thread touches the socket.

### Description

- Added queued sending and flush logic to `ConnectionManager` including `EnqueueTransformSend`, `EnqueueReliableSend`, a reliable FIFO queue, a latest-wins transform slot, `FlushOutgoing`, and `TrySendDealer` so only the network thread calls the `DealerSocket` API; also added `ClearOutgoingQueues` and `DealerSendItem` struct in `ConnectionManager.cs`.
- Changed transform SUB handling in `ConnectionManager.cs` to drain incoming frames (`TryDrainTransform`) and call `_messageProcessor.ProcessIncomingMessage` only once for the last payload, and introduced `TransformRcvHwm = 2` to lower `ReceiveHighWatermark`.
- Replaced direct `DealerSocket.TrySendMultipartMessage` calls in `TransformSyncManager.cs` with `EnqueueTransformSend` for high-frequency transform sends and `EnqueueReliableSend` for handshake/other messages.
- Replaced direct `DealerSocket` sends in `RPCManager.cs` and `NetworkVariableManager.cs` with `EnqueueReliableSend` so RPC and NetworkVariable sends are routed through the `ConnectionManager` reliable queue.
- Removed a few unused NetMQ imports where send responsibilities moved into the `ConnectionManager`.

Files changed: `ConnectionManager.cs`, `TransformSyncManager.cs`, `RPCManager.cs`, `NetworkVariableManager.cs` (all under `Packages/com.styly.styly-netsync/Runtime/Internal Scripts`).

### Testing

- No automated tests were executed for these Unity client changes in this rollout.
- Changes were committed locally (no CI/unity-editor run in this session), and manual runtime verification is recommended (open the Unity project and run the sample scenes with the Python server to validate behavior).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6978aee6d8d88328895060ce7d8e51fc)