### PR TITLE
fix: queue dealer sends and conflate transform traffic

### DIFF
--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/TransformSyncManager.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/TransformSyncManager.cs
@@ -5,7 +5,6 @@ using System;
 using System.Buffers;
 using System.IO;
 using System.Text;
-using NetMQ;
 using UnityEngine;
 
 namespace Styly.NetSync
@@ -41,7 +40,7 @@ namespace Styly.NetSync
 
         public bool SendLocalTransform(NetSyncAvatar localAvatar, string roomId)
         {
-            if (localAvatar == null || _connectionManager.DealerSocket == null)
+            if (localAvatar == null)
                 return false;
 
             try
@@ -62,25 +61,11 @@ namespace Styly.NetSync
 
                 var length = (int)_buf.Stream.Position;
 
-                // Build a fresh message per send to ensure proper frame lifetime.
-                var msg = new NetMQMessage();
-                try
-                {
-                    msg.Append(roomId);
-                    // Copy the exact payload length into a fresh array owned by NetMQ (avoid sharing pooled buffer).
-                    var payload = new byte[length];
-                    Buffer.BlockCopy(_buf.GetBufferUnsafe(), 0, payload, 0, length);
-                    msg.Append(payload);
-
-                    var ok = _connectionManager.DealerSocket.TrySendMultipartMessage(msg);
-                    if (ok) _messagesSent++;
-                    return ok;
-                }
-                finally
-                {
-                    // NetMQMessage is not IDisposable; clear to release frames promptly.
-                    msg.Clear();
-                }
+                var payload = new byte[length];
+                Buffer.BlockCopy(_buf.GetBufferUnsafe(), 0, payload, 0, length);
+                var ok = _connectionManager.EnqueueTransformSend(roomId, payload);
+                if (ok) _messagesSent++;
+                return ok;
             }
             catch (Exception ex)
             {
@@ -91,9 +76,6 @@ namespace Styly.NetSync
 
         internal bool SendStealthHandshake(string roomId)
         {
-            if (_connectionManager.DealerSocket == null)
-                return false;
-
             try
             {
                 // Estimate size for handshake and ensure capacity
@@ -106,22 +88,11 @@ namespace Styly.NetSync
 
                 var length = (int)_buf.Stream.Position;
 
-                var msg = new NetMQMessage();
-                try
-                {
-                    msg.Append(roomId);
-                    var payload = new byte[length];
-                    Buffer.BlockCopy(_buf.GetBufferUnsafe(), 0, payload, 0, length);
-                    msg.Append(payload);
-
-                    var ok = _connectionManager.DealerSocket.TrySendMultipartMessage(msg);
-                    if (ok) _messagesSent++;
-                    return ok;
-                }
-                finally
-                {
-                    msg.Clear();
-                }
+                var payload = new byte[length];
+                Buffer.BlockCopy(_buf.GetBufferUnsafe(), 0, payload, 0, length);
+                var ok = _connectionManager.EnqueueReliableSend(roomId, payload);
+                if (ok) _messagesSent++;
+                return ok;
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
### Motivation
- Prevent Transform receive CPU spikes by avoiding repeated deserialization of buffered transform frames and keep only the most-recent transform for processing.
- Ensure DealerSocket is only touched from the network thread to remove a cross-thread instability source and improve send reliability.
- Improve resilience under congestion by making transform sends latest-wins (conflation) and routing RPC/NV/handshake sends through a bounded reliable queue.

### Description
- Added send-queue infra to `ConnectionManager.cs`: `EnqueueTransformSend`, `EnqueueReliableSend`, reliable FIFO queue, single-item transform slot (latest-wins), `FlushOutgoing` to send from the network thread, and `ClearOutgoingBuffers` to flush on disconnect.
- Changed transform SUB receive handling in `ConnectionManager.cs` to use `ReceiveHighWatermark = 2` and to drain incoming topic/payload frames then only call `_messageProcessor.ProcessIncomingMessage` once with the last payload.
- Replaced direct `DealerSocket.TrySendMultipartMessage` usages with queueing calls: `TransformSyncManager.cs` now uses `EnqueueTransformSend` for transforms and `EnqueueReliableSend` for stealth handshake, `RPCManager.cs` and `NetworkVariableManager.cs` now enqueue payloads to the reliable queue instead of touching the dealer socket directly.
- Kept send semantics conservative: reliable queue is FIFO with an in-flight slot to preserve ordering while avoiding blocking the main thread, transform path is single-slot conflation to prefer newest state.
- Modifications affect these runtime files: `ConnectionManager.cs`, `TransformSyncManager.cs`, `RPCManager.cs`, and `NetworkVariableManager.cs`.

### Testing
- No automated Unity or unit tests were run as part of this change; validation requires running the Unity client (`STYLY-NetSync-Unity`) with the Python server (`styly-netsync-server`) and exercising high-rate transform traffic to confirm reduced CPU spikes and stable behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6978aee6d8d88328895060ce7d8e51fc)