### PR TITLE
fix: normalize version input by stripping leading 'v' or 'V' prefix in release workflow

### DIFF
--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -29,8 +29,7 @@ jobs:
         run: |
           VERSION="${{ github.event.inputs.version }}"
           # Strip leading 'v' or 'V' prefix if present
-          VERSION="${VERSION#v}"
-          VERSION="${VERSION#V}"
+          VERSION="${VERSION#[vV]}"
           # Check semantic versioning format (including pre-release versions)
           if ! echo "$VERSION" | grep -E '^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.-]+)?$' > /dev/null; then
             echo "❌ Error: Invalid version format: $VERSION"


### PR DESCRIPTION
This pull request improves the version handling logic in the `.github/workflows/release-workflow.yml` file. The main change is the normalization of the version input by stripping any leading 'v' or 'V' characters, ensuring consistent semantic versioning throughout the workflow. The normalized version is then used in all subsequent steps, reducing redundancy and potential errors.

**Version normalization and usage improvements:**

* Added logic to strip leading 'v' or 'V' from the version input and export the normalized value as an environment variable for use in later steps.
* Updated all workflow steps to use the normalized `VERSION` environment variable instead of referencing `github.event.inputs.version` directly, ensuring consistency across version updates in `package.json`, `version.txt`, `pyproject.toml`, markdown files, commit messages, release tags, and summary steps. [[1]](diffhunk://#diff-35fb489f38dbca17d499e36a6a81fec543d4debd63c8ea3e6f0920180cc38014L62-L71) [[2]](diffhunk://#diff-35fb489f38dbca17d499e36a6a81fec543d4debd63c8ea3e6f0920180cc38014L88) [[3]](diffhunk://#diff-35fb489f38dbca17d499e36a6a81fec543d4debd63c8ea3e6f0920180cc38014L105) [[4]](diffhunk://#diff-35fb489f38dbca17d499e36a6a81fec543d4debd63c8ea3e6f0920180cc38014L122-L123) [[5]](diffhunk://#diff-35fb489f38dbca17d499e36a6a81fec543d4debd63c8ea3e6f0920180cc38014L187-L188) [[6]](diffhunk://#diff-35fb489f38dbca17d499e36a6a81fec543d4debd63c8ea3e6f0920180cc38014L244) [[7]](diffhunk://#diff-35fb489f38dbca17d499e36a6a81fec543d4debd63c8ea3e6f0920180cc38014L266)