### PR TITLE
chore: set client disconnect timeout to 5 seconds

### DIFF
--- a/STYLY-NetSync-Server/src/styly_netsync/default.toml
+++ b/STYLY-NetSync-Server/src/styly_netsync/default.toml
@@ -36,7 +36,7 @@ idle_broadcast_interval = 2.0
 transform_broadcast_rate = 10
 
 # Client disconnect timeout in seconds
-client_timeout = 2.5
+client_timeout = 5
 
 # Cleanup interval in seconds for removing stale data
 cleanup_interval = 1.0


### PR DESCRIPTION
Updates client_timeout from 2.5s to 5s in default.toml.

Closes #340

Generated with [Claude Code](https://claude.ai/code)