### PR TITLE
fix: adjust NetSyncSmoothingSettings for improved buffer and tolerance values

### DIFF
--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/NetSyncSmoothing.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/NetSyncSmoothing.cs
@@ -424,17 +424,17 @@ namespace Styly.NetSync
     [Serializable]
     internal sealed class NetSyncSmoothingSettings
     {
-        public double BaseBufferMultiplier = 1.5;
+        public double BaseBufferMultiplier = 0.45;
         public bool DynamicBuffer = true;
-        public double DynamicTolerance = 0.6;
+        public double DynamicTolerance = 0.1;
         public double MinBufferMultiplier = 1.1;
-        public double MaxBufferMultiplier = 4.0;
+        public double MaxBufferMultiplier = 1.2;
 
-        public PoseChannelSettings Physical = new PoseChannelSettings { MaxExtrapolationSeconds = 0.03, TauMinSeconds = 0.02f, TauMaxSeconds = 0.06f };
-        public PoseChannelSettings Head = new PoseChannelSettings { MaxExtrapolationSeconds = 0.04, TauMinSeconds = 0.02f, TauMaxSeconds = 0.05f };
-        public PoseChannelSettings Right = new PoseChannelSettings { MaxExtrapolationSeconds = 0.05, TauMinSeconds = 0.03f, TauMaxSeconds = 0.07f };
-        public PoseChannelSettings Left = new PoseChannelSettings { MaxExtrapolationSeconds = 0.05, TauMinSeconds = 0.03f, TauMaxSeconds = 0.07f };
-        public PoseChannelSettings Virtual = new PoseChannelSettings { MaxExtrapolationSeconds = 0.03, TauMinSeconds = 0.05f, TauMaxSeconds = 0.12f };
+        public PoseChannelSettings Physical = new PoseChannelSettings { MaxExtrapolationSeconds = 0.08, TauMinSeconds = 0.02f, TauMaxSeconds = 0.06f };
+        public PoseChannelSettings Head = new PoseChannelSettings { MaxExtrapolationSeconds = 0.08, EnableSecondPhaseSmoothing = false, TauMinSeconds = 0.02f, TauMaxSeconds = 0.05f };
+        public PoseChannelSettings Right = new PoseChannelSettings { MaxExtrapolationSeconds = 0.08, TauMinSeconds = 0.01f, TauMaxSeconds = 0.03f };
+        public PoseChannelSettings Left = new PoseChannelSettings { MaxExtrapolationSeconds = 0.08, TauMinSeconds = 0.01f, TauMaxSeconds = 0.03f };
+        public PoseChannelSettings Virtual = new PoseChannelSettings { MaxExtrapolationSeconds = 0.08, TauMinSeconds = 0.05f, TauMaxSeconds = 0.12f };
     }
 
     internal sealed class PoseChannel


### PR DESCRIPTION
Changed the parameters of the smoothing.

```
Here's a summary of what was changed in NetSyncSmoothing.cs:

  Buffer:                                                                                                                 
   
  ┌──────────────────────┬────────┬──────────────────┐                                                                    
  │       Setting        │ Before │      After       │                                                                  
  ├──────────────────────┼────────┼──────────────────┤
  │ BaseBufferMultiplier │ 1.5    │ 0.45             │
  ├──────────────────────┼────────┼──────────────────┤
  │ DynamicBuffer        │ true   │ true (unchanged) │
  ├──────────────────────┼────────┼──────────────────┤
  │ DynamicTolerance     │ 0.6    │ 0.1              │
  ├──────────────────────┼────────┼──────────────────┤
  │ MaxBufferMultiplier  │ 4.0    │ 1.2              │
  ├──────────────────────┼────────┼──────────────────┤
  │ MinBufferMultiplier  │ 1.1    │ 1.1 (unchanged)  │
  └──────────────────────┴────────┴──────────────────┘

  Extrapolation (MaxExtrapolationSeconds — all channels unified):

  ┌──────────┬────────┬───────┐
  │ Channel  │ Before │ After │
  ├──────────┼────────┼───────┤
  │ Physical │ 0.03   │ 0.08  │
  ├──────────┼────────┼───────┤
  │ Head     │ 0.04   │ 0.08  │
  ├──────────┼────────┼───────┤
  │ Right    │ 0.05   │ 0.08  │
  ├──────────┼────────┼───────┤
  │ Left     │ 0.05   │ 0.08  │
  ├──────────┼────────┼───────┤
  │ Virtual  │ 0.03   │ 0.08  │
  └──────────┴────────┴───────┘

  Smoothing:

  ┌────────────┬──────────────────────────────────────────────────────────────┐
  │  Channel   │                            Change                            │
  ├────────────┼──────────────────────────────────────────────────────────────┤
  │ Head       │ EnableSecondPhaseSmoothing = false (2nd-phase smoothing OFF) │
  ├────────────┼──────────────────────────────────────────────────────────────┤
  │ Right hand │ TauMin: 0.03 → 0.01, TauMax: 0.07 → 0.03                     │
  ├────────────┼──────────────────────────────────────────────────────────────┤
  │ Left hand  │ TauMin: 0.03 → 0.01, TauMax: 0.07 → 0.03                     │
  └────────────┴──────────────────────────────────────────────────────────────┘
```