### PR TITLE
feat(unity): add RpcTo targeted client delivery

### DIFF
--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/MessageProcessor.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/MessageProcessor.cs
@@ -99,11 +99,16 @@ namespace Styly.NetSync
 
                     case BinarySerializer.MSG_RPC when data is RPCMessage rpc:
                         // Avoid JSON round-trip: parse args once and pass object via dataObj
+                        if (!RPCManager.TryResolveTargetedFunctionName(rpc.functionName, _localClientNo, out var resolvedFunctionName))
+                        {
+                            break;
+                        }
+
                         var args = JsonConvert.DeserializeObject<string[]>(rpc.argumentsJson);
                         _messageQueue.Enqueue(new NetworkMessage
                         {
                             type = "rpc",
-                            dataObj = new RpcMessageData { senderClientNo = rpc.senderClientNo, functionName = rpc.functionName, args = args }
+                            dataObj = new RpcMessageData { senderClientNo = rpc.senderClientNo, functionName = resolvedFunctionName, args = args }
                         });
                         _messagesReceived++;
                         break;

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/NetSyncManager.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/NetSyncManager.cs
@@ -92,6 +92,21 @@ namespace Styly.NetSync
             }
         }
 
+        public void RpcTo(int targetClientNo, string functionName, string[] args = null)
+        {
+            RpcTo(new[] { targetClientNo }, functionName, args);
+        }
+
+        public void RpcTo(int[] targetClientNos, string functionName, string[] args = null)
+        {
+            if (args == null) { args = Array.Empty<string>(); }
+
+            if (_rpcManager != null)
+            {
+                _rpcManager.SendTo(_roomId, targetClientNos, functionName, args);
+            }
+        }
+
         internal void Rpc_SystemRPC(string functionName, string[] args = null)
         {
             functionName = PrefixForSystem + functionName;


### PR DESCRIPTION
### Motivation
- Provide the Unity client API a way to send RPCs to one or more specific clients instead of always broadcasting to the whole room.
- Preserve existing `Rpc(...)` broadcast behaviour while enabling targeted delivery without server protocol changes.

### Description
- Added `NetSyncManager.RpcTo(int targetClientNo, ...)` and `NetSyncManager.RpcTo(int[] targetClientNos, ...)` to the Unity runtime to expose single/multi-target RPC sends via `RpcTo`.
- Extended `RPCManager` with `SendTo(...)`, `BuildTargetedFunctionName(...)` and `TryResolveTargetedFunctionName(...)` to encode targets into the outgoing function name using an internal `@target:` prefix and to decode/resolve it on receive.
- Updated `MessageProcessor` to call `RPCManager.TryResolveTargetedFunctionName(...)` when processing `MSG_RPC` messages and to drop RPCs that are not addressed to the local client, while invoking local handlers with the original (decoded) function name.
- Implementation avoids server changes by encoding target metadata in the RPC function name and keeps existing `Rpc(...)` broadcast semantics unchanged.

### Testing
- Ran repository structural/check command `git diff --check` and ensured no whitespace/diff-check issues were reported (success).
- Performed code inspection of changed files `NetSyncManager.cs`, `RPCManager.cs`, and `MessageProcessor.cs` to verify the send/receive target encoding and decoding logic was added.
- Note: No Unity Editor compile/play tests or Python unit tests were executed in this environment; manual verification in Unity Editor using `Demo-01.unity` or `Debug Scene.unity` with the server running is recommended.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ced2f3cf883288e3ee1f9b44e96cf)