### PR TITLE
fix: send empty device ID mapping when room peers disconnect

### DIFF
--- a/STYLY-NetSync-Server/src/styly_netsync/server.py
+++ b/STYLY-NetSync-Server/src/styly_netsync/server.py
@@ -1608,18 +1608,19 @@ class NetSyncServer:
                 is_stealth = client_data.get("is_stealth", False)
                 mappings.append((client_no, device_id, is_stealth))
 
-            if mappings:
-                # Serialize and broadcast the mappings with server version
-                server_version = binary_serializer.parse_version(get_version())
-                message_bytes = binary_serializer.serialize_device_id_mapping(
-                    mappings, server_version
-                )
-                # Send via ROUTER unicast (lock is held, but _send_ctrl_to_room_via_router
-                # will acquire the lock again - RLock allows this)
-                self._send_ctrl_to_room_via_router(room_id, message_bytes)
-                logger.info(
-                    f"Broadcasted {len(mappings)} ID mappings to room {room_id} via ROUTER"
-                )
+            # Serialize and broadcast the mappings with server version.
+            # Send even when the mapping list is empty so connected clients can
+            # clear stale entries after other peers disconnect.
+            server_version = binary_serializer.parse_version(get_version())
+            message_bytes = binary_serializer.serialize_device_id_mapping(
+                mappings, server_version
+            )
+            # Send via ROUTER unicast (lock is held, but _send_ctrl_to_room_via_router
+            # will acquire the lock again - RLock allows this)
+            self._send_ctrl_to_room_via_router(room_id, message_bytes)
+            logger.info(
+                f"Broadcasted {len(mappings)} ID mappings to room {room_id} via ROUTER"
+            )
 
     def _flush_debounced_id_mapping_broadcasts(self, current_time: float) -> None:
         """Flush ID mapping broadcasts that have been debounced long enough."""

--- a/STYLY-NetSync-Server/tests/test_id_mapping_broadcast.py
+++ b/STYLY-NetSync-Server/tests/test_id_mapping_broadcast.py
@@ -1,0 +1,35 @@
+"""Unit tests for ID mapping broadcasts."""
+
+from __future__ import annotations
+
+from styly_netsync import binary_serializer
+from styly_netsync.config import load_default_config
+from styly_netsync.server import NetSyncServer
+
+
+def test_broadcast_id_mappings_sends_empty_mapping_to_clear_stale_clients() -> None:
+    """Even with no connected clients, an empty mapping message is still sent."""
+    config = load_default_config()
+    server = NetSyncServer(config=config)
+
+    room_id = "room_with_only_stealth_observers"
+    server.room_device_id_to_client_no[room_id] = {"disconnected_device": 7}
+    server.rooms[room_id] = {}
+
+    sent_messages: list[tuple[str, bytes]] = []
+
+    def _record_send(target_room_id: str, payload: bytes) -> None:
+        sent_messages.append((target_room_id, payload))
+
+    server._send_ctrl_to_room_via_router = _record_send  # type: ignore[method-assign]
+
+    server._broadcast_id_mappings(room_id)
+
+    assert len(sent_messages) == 1
+    target_room_id, payload = sent_messages[0]
+    assert target_room_id == room_id
+
+    msg_type, msg_data, _ = binary_serializer.deserialize(payload)
+    assert msg_type == binary_serializer.MSG_DEVICE_ID_MAPPING
+    assert msg_data == {"mappings": []}
+


### PR DESCRIPTION
### Motivation
- Stealth clients retained stale client IDs because the server skipped sending device ID mapping updates when no connected (non-stealth) mappings remained.  
- When the last normal client left a room, remaining observers received no notification to clear the disconnected client from their mapping table.  

### Description
- Always serialize and send `MSG_DEVICE_ID_MAPPING` from `_broadcast_id_mappings()` even if the computed `mappings` list is empty so clients can clear stale entries.  
- Removed the `if mappings:` gate and ensured the message is sent via ROUTER unicast in `src/styly_netsync/server.py`.  
- Added a focused unit test `tests/test_id_mapping_broadcast.py` that simulates a room with stale mapping state but no currently connected clients and asserts an empty mapping payload is broadcast.  

### Testing
- Ran `pytest -q tests/test_id_mapping_broadcast.py tests/test_room_expiry.py` and the tests passed (`.......` / 100%).  
- New unit test verifies `MSG_DEVICE_ID_MAPPING` is sent with `{"mappings": []}` when appropriate.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a3f287caf483288bbb4615105af38f)