### PR TITLE
fix: broadcast empty ID mappings when last normal client disconnects

### DIFF
--- a/STYLY-NetSync-Server/src/styly_netsync/server.py
+++ b/STYLY-NetSync-Server/src/styly_netsync/server.py
@@ -1608,18 +1608,18 @@ class NetSyncServer:
                 is_stealth = client_data.get("is_stealth", False)
                 mappings.append((client_no, device_id, is_stealth))
 
-            if mappings:
-                # Serialize and broadcast the mappings with server version
-                server_version = binary_serializer.parse_version(get_version())
-                message_bytes = binary_serializer.serialize_device_id_mapping(
-                    mappings, server_version
-                )
-                # Send via ROUTER unicast (lock is held, but _send_ctrl_to_room_via_router
-                # will acquire the lock again - RLock allows this)
-                self._send_ctrl_to_room_via_router(room_id, message_bytes)
-                logger.info(
-                    f"Broadcasted {len(mappings)} ID mappings to room {room_id} via ROUTER"
-                )
+            # Always broadcast, including an empty mapping payload. This allows
+            # clients to clear stale state when the final mapped client leaves.
+            server_version = binary_serializer.parse_version(get_version())
+            message_bytes = binary_serializer.serialize_device_id_mapping(
+                mappings, server_version
+            )
+            # Send via ROUTER unicast (lock is held, but _send_ctrl_to_room_via_router
+            # will acquire the lock again - RLock allows this)
+            self._send_ctrl_to_room_via_router(room_id, message_bytes)
+            logger.info(
+                f"Broadcasted {len(mappings)} ID mappings to room {room_id} via ROUTER"
+            )
 
     def _flush_debounced_id_mapping_broadcasts(self, current_time: float) -> None:
         """Flush ID mapping broadcasts that have been debounced long enough."""

--- a/STYLY-NetSync-Server/tests/test_id_mapping_broadcast.py
+++ b/STYLY-NetSync-Server/tests/test_id_mapping_broadcast.py
@@ -1,0 +1,35 @@
+"""Unit tests for ID mapping broadcasts."""
+
+from __future__ import annotations
+
+from styly_netsync import binary_serializer
+from styly_netsync.config import load_default_config
+from styly_netsync.server import NetSyncServer
+
+
+def test_broadcast_id_mapping_sends_empty_payload_for_stealth_only_room() -> None:
+    """Server should broadcast empty mappings so clients can clear stale state."""
+    config = load_default_config()
+    server = NetSyncServer(config=config)
+
+    room_id = "room_stealth_only"
+    stealth_device_id = "stealth-device"
+
+    # Keep room mapping table alive, but ensure no connected clients currently exist.
+    server.room_device_id_to_client_no[room_id] = {stealth_device_id: 7}
+    server.rooms[room_id] = {}
+
+    sent_messages: list[bytes] = []
+
+    def capture(_room_id: str, message: bytes, _exclude_identity: bytes | None = None) -> None:
+        sent_messages.append(message)
+
+    server._send_ctrl_to_room_via_router = capture  # type: ignore[method-assign]
+
+    server._broadcast_id_mappings(room_id)
+
+    assert len(sent_messages) == 1
+    msg_type, payload, _ = binary_serializer.deserialize(sent_messages[0])
+    assert msg_type == binary_serializer.MSG_DEVICE_ID_MAPPING
+    assert payload["mappings"] == []
+


### PR DESCRIPTION
### Motivation
- Stealth clients remaining in a room could retain stale device-to-client mappings when the last non-stealth client left because the server did not send an ID-mapping update for the empty set.  
- Clients have no way to clear disconnected clients from their local tables unless a mapping message (including an explicit empty mapping payload) is delivered.  

### Description
- Always emit an ID mapping control message for a room from `_broadcast_id_mappings`, even when the computed `mappings` list is empty, so connected clients can clear stale mappings (`src/styly_netsync/server.py`).  
- Added a unit test `tests/test_id_mapping_broadcast.py` that simulates a room where the mapping table exists but no clients are currently connected and asserts a `MSG_DEVICE_ID_MAPPING` with `mappings == []` is sent.  
- No protocol format changes were made; the change only ensures an empty `mappings` array is serialized and broadcast instead of skipping the broadcast.  

### Testing
- Ran the new unit test and related suites: `pytest -q tests/test_id_mapping_broadcast.py tests/test_room_expiry.py` and `pytest -q tests/test_binary_serializer.py`.  
- All targeted tests passed after the fix (new test verifies empty mapping payload is emitted).  
- The change is localized to `_broadcast_id_mappings` and the new unit test; no other regressions were observed in the exercised test suites.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a3f287caf483288bbb4615105af38f)