### PR TITLE
fix: remove unnecessary checks for empty client snapshot and count in NetSyncServer

### DIFF
--- a/STYLY-NetSync-Server/src/styly_netsync/server.py
+++ b/STYLY-NetSync-Server/src/styly_netsync/server.py
@@ -1807,9 +1807,6 @@ class NetSyncServer:
         room_id: str,
         client_snapshot: list[tuple[int, float, dict[str, Any] | None, bytes]],
     ) -> bytes | None:
-        if not client_snapshot:
-            return None
-
         buffer = bytearray()
         buffer.append(binary_serializer.MSG_ROOM_POSE)
         buffer.append(binary_serializer.PROTOCOL_VERSION)
@@ -1831,9 +1828,6 @@ class NetSyncServer:
                 transform_data["poseTime"] = pose_time
                 binary_serializer._serialize_client_data_short(buffer, transform_data)
                 count += 1
-
-        if count == 0:
-            return None
 
         struct.pack_into("<H", buffer, count_offset, count)
         return bytes(buffer)


### PR DESCRIPTION
Close https://github.com/styly-dev/STYLY-NetSync/issues/349

This pull request makes a small change to the `_serialize_room_transform` method in `STYLY-NetSync-Server/src/styly_netsync/server.py`, removing early returns that previously caused the function to return `None` when there were no client snapshots or when no client data was serialized. Now, the function always returns a serialized buffer, even if it is empty. [[1]](diffhunk://#diff-e88eea98ef9a164151fc1fdd4bf5ed9a273abbfd449f658a8d82ff1b636df45dL1810-L1812) [[2]](diffhunk://#diff-e88eea98ef9a164151fc1fdd4bf5ed9a273abbfd449f658a8d82ff1b636df45dL1835-L1837)

