### PR TITLE
fix: correct broken GitHub link in server README

### DIFF
--- a/STYLY-NetSync-Server/README.md
+++ b/STYLY-NetSync-Server/README.md
@@ -77,7 +77,7 @@ To customize settings:
 
 1. Get the default config file:
    - From local clone: `cp src/styly_netsync/default.toml my-config.toml`
-   - Or download from GitHub: [default.toml](https://github.com/psychic-vr-lab/STYLY-NetSync/blob/main/STYLY-NetSync-Server/src/styly_netsync/default.toml)
+   - Or download from GitHub: [default.toml](https://github.com/styly-dev/STYLY-NetSync/blob/develop/STYLY-NetSync-Server/src/styly_netsync/default.toml)
 
 2. Edit `my-config.toml` and keep only the settings you want to change (delete the rest)
 


### PR DESCRIPTION
## Summary
- Fix broken link to `default.toml` in server README
- Update org name from `psychic-vr-lab` to `styly-dev`
- Update branch from `main` to `develop`

## Test plan
- [ ] Verify the link resolves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)