### PR TITLE
feat(client): add connection loss detection and reconnection

### DIFF
--- a/STYLY-NetSync-Server/src/styly_netsync/client.py
+++ b/STYLY-NetSync-Server/src/styly_netsync/client.py
@@ -364,7 +364,7 @@ class net_sync_manager:
                 # Start receive thread
                 self._running = True
                 self._reconnect_at = None  # Clear stale reconnect state
-                self._last_message_time = time.monotonic()
+                self._last_message_time = 0.0  # Armed on first inbound message
                 self._receive_thread = threading.Thread(
                     target=self._receive_loop, daemon=True
                 )
@@ -580,8 +580,8 @@ class net_sync_manager:
                             poller.register(self._sub_socket, zmq.POLLIN)
                         if self._dealer_socket:
                             poller.register(self._dealer_socket, zmq.POLLIN)
-                        # Reset silence clock so we don't immediately re-trigger
-                        self._last_message_time = time.monotonic()
+                        # Disarm silence detection until first inbound message
+                        self._last_message_time = 0.0
                     else:
                         # Reconnect failed; retry after the configured delay
                         self._reconnect_at = time.monotonic() + self._reconnect_delay
@@ -590,9 +590,10 @@ class net_sync_manager:
                 continue
 
             # ------------------------------------------------------------------
-            # Server-silence detection
+            # Server-silence detection (armed only after the first inbound
+            # message, so an empty room doesn't cause false-positive reconnects)
             # ------------------------------------------------------------------
-            if self._receive_timeout is not None:
+            if self._receive_timeout is not None and self._last_message_time > 0:
                 now = time.monotonic()
                 if now - self._last_message_time > self._receive_timeout:
                     self._trigger_reconnect(

--- a/STYLY-NetSync-Server/tests/test_python_client.py
+++ b/STYLY-NetSync-Server/tests/test_python_client.py
@@ -356,6 +356,10 @@ def test_receive_timeout_triggers_connection_error():
     manager.on_connection_error.add_listener(errors.append)
     manager.start()
 
+    # Silence detection is only armed after the first inbound message.
+    # Simulate that by setting the clock manually.
+    manager._last_message_time = time.monotonic()
+
     try:
         # Wait long enough for the silence timeout to fire (0.3s) + margin
         time.sleep(1.2)
@@ -401,6 +405,9 @@ def test_stop_from_connection_error_listener():
 
     manager.on_connection_error.add_listener(on_error)
     manager.start()
+
+    # Arm silence detection (only active after first inbound message)
+    manager._last_message_time = time.monotonic()
 
     try:
         # Wait for silence timeout (0.3s) + margin for stop() to complete


### PR DESCRIPTION
Implements connection loss detection and automatic reconnection for the Python client (`net_sync_manager`), closing the gap with the C# Unity client.

## Changes
- `on_connection_error` EventHandler — fires with error message on connection loss
- `receive_timeout` constructor param (default 30s) — server-silence threshold
- `reconnect_delay` constructor param (default 5s) — delay before reconnect attempt
- `_trigger_reconnect()` — resets state, fires event, schedules socket teardown
- `_perform_socket_reconnect()` — tears down + recreates sockets, auto-restarts discovery
- Terminal ZMQ errors now escalate to reconnect instead of continuing with broken socket
- `reconnect_count` added to stats
- 4 new tests

Closes #366

Generated with [Claude Code](https://claude.ai/code)