### PR TITLE
refactor(server): remove unnecessary log output for dirty rooms and file descriptors

### DIFF
--- a/STYLY-NetSync-Server/src/styly_netsync/server.py
+++ b/STYLY-NetSync-Server/src/styly_netsync/server.py
@@ -1696,25 +1696,12 @@ class NetSyncServer:
                             else:
                                 normal_clients += 1
 
-                    dirty_rooms = sum(
-                        1 for flag in self.room_dirty_flags.values() if flag
-                    )
                     total_device_ids = len(self.device_id_last_seen)
-
-                    # Get FD information for status log
-                    open_fds, soft, _ = self._get_fd_snapshot()
-                    fd_part = ""
-                    if open_fds is not None:
-                        if soft is not None:
-                            fd_part = f", FD {open_fds}/{soft}"
-                        else:
-                            fd_part = f", FD {open_fds}"
 
                     logger.info(
                         f"Status: {len(self.rooms)} rooms, {normal_clients} normal clients, "
                         f"{stealth_clients} stealth clients, "
-                        f"{dirty_rooms} dirty rooms, {total_device_ids} tracked device IDs"
-                        f"{fd_part}"
+                        f"{total_device_ids} tracked device IDs"
                     )
                     last_log = current_time
 


### PR DESCRIPTION
…
This pull request simplifies the status logging in the `_periodic_loop` method by removing some details from the log output. The most important change is that information about dirty rooms and file descriptors (FDs) is no longer included in the status log.

Logging simplification:

* Removed the calculation and logging of the number of dirty rooms from the status output.
* Removed the retrieval and logging of file descriptor (FD) usage information from the status output.