### PR TITLE
feat: make debug logs configurable from Advanced Options

### DIFF
--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Editor/NetSyncManagerEditor.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Editor/NetSyncManagerEditor.cs
@@ -15,7 +15,8 @@ namespace Styly.NetSync.Editor
             "_offlineMode",
             "_transformSendRate",
             "_serverDiscoveryPort",
-            "_syncBatteryLevel"
+            "_syncBatteryLevel",
+            "_enableDebugLogs"
         };
         private static readonly HashSet<string> AdvancedProperties = new HashSet<string>(AdvancedPropertyOrder);
 

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/NetSyncManager.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/NetSyncManager.cs
@@ -27,7 +27,8 @@ namespace Styly.NetSync
         [SerializeField, Tooltip("Prefab shown at each remote user's physical position")] private GameObject _humanPresencePrefab;
 
         // [Header("Debug Settings")]
-        private bool _enableDebugLogs = true;
+        [SerializeField, Tooltip("Enable debug log output to the console.")]
+        private bool _enableDebugLogs = false;
         private bool _logTransformDetail = false;
         private bool _logNetworkTraffic = false;
 


### PR DESCRIPTION
## Summary
- Add `_enableDebugLogs` as a serialized field visible in the **Advanced Options** foldout in the Inspector
- Change default value from `true` to `false`

## Test plan
- [ ] Open NetSyncManager in Inspector and verify "Enable Debug Logs" appears under Advanced Options
- [ ] Confirm default value is unchecked (false)
- [ ] Toggle on and verify debug logs appear in Console during play mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)