### PR TITLE
fix(connection_manager): simplify ZeroMQ connect address handling by removing source-NIC binding logic

### DIFF
--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/ConnectionManager.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/ConnectionManager.cs
@@ -218,27 +218,20 @@ namespace Styly.NetSync
         }
 
         /// <summary>
-        /// Build a ZeroMQ connect address with automatic source-NIC binding.
-        /// When the destination is a remote host, the OS routing table is queried
-        /// to find the correct source NIC, and the ZeroMQ extended TCP format
-        /// (tcp://source_ip:0;dest_host:port) is used.
+        /// Build a ZeroMQ connect address from a server address and port.
+        /// Note: NetMQ (pure C# ZeroMQ) does not support the libzmq extended TCP
+        /// format (tcp://source:0;dest:port) for source-NIC binding, so we use
+        /// the plain tcp://host:port format.
         /// </summary>
         private static string BuildConnectAddress(string serverAddress, int port)
         {
-            // Extract host from "tcp://host" format
             string host = serverAddress;
             if (host.StartsWith("tcp://"))
             {
                 host = host.Substring(6);
             }
 
-            string sourceIp = NetworkUtils.ResolveSourceAddress(host, port);
-            if (sourceIp != null)
-            {
-                return $"tcp://{sourceIp}:0;{host}:{port}";
-            }
-
-            return $"{serverAddress}:{port}";
+            return $"tcp://{host}:{port}";
         }
 
         private void NetworkLoop(string serverAddress, int dealerPort, int subPort, string roomId)


### PR DESCRIPTION

This pull request updates the logic for building ZeroMQ connection addresses in the `ConnectionManager` to ensure compatibility with NetMQ, which does not support the extended TCP format used by libzmq. The method now always returns a standard `tcp://host:port` address, simplifying the connection process.

**Networking compatibility update:**

* Updated the `BuildConnectAddress` method in `ConnectionManager.cs` to always use the plain `tcp://host:port` format, removing logic for source-NIC binding and the unsupported extended TCP format, to ensure compatibility with NetMQ.