### PR TITLE
[DO NOT MERGE] feat: Implement object synchronization for non-avatar objects

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,12 +80,14 @@ kill <PID>                          # Kill process using port
 **Unity Client:**
 - `NetSyncManager.cs` - Main singleton entry point and API
 - `NetSyncAvatar.cs` - Component for avatar synchronization
+- `NetSyncObject.cs` - Component for non-avatar object synchronization with ownership model
 - `Internal Scripts/` - Core networking components:
   - `ConnectionManager.cs` - ZeroMQ socket management and threading
   - `MessageProcessor.cs` - Binary protocol message handling
   - `TransformSyncManager.cs` - Position/rotation synchronization with SendRate cap, only-on-change filtering, and 1Hz idle heartbeat
   - `RPCManager.cs` - Remote procedure call system with priority-based sending and targeted delivery by client number
   - `NetworkVariableManager.cs` - Synchronized key-value storage
+  - `ObjectSyncManager.cs` - Non-avatar object transform synchronization with ownership
   - `AvatarManager.cs` - Player spawn/despawn management
   - `ServerDiscoveryManager.cs` - UDP discovery service client
   - `HumanPresenceManager.cs` - Collision avoidance visualization
@@ -108,6 +110,7 @@ kill <PID>                          # Kill process using port
 - Uses ZeroMQ with DEALER-ROUTER and PUB-SUB patterns
 - Transform protocol is `protocolVersion=3` only (`v2` compatibility removed)
 - Transform message IDs are `MSG_CLIENT_POSE=11` and `MSG_ROOM_POSE=12`
+- Object sync message IDs are `MSG_CLIENT_OBJECTS=13`, `MSG_ROOM_OBJECTS=14`, and `MSG_OBJECT_OWNER=19`
 - Compact transform encoding: int16 quantized positions, yaw-only physical rotation (`0.1°` units), and 32-bit smallest-three quaternion compression
 - `Head` is absolute; `Right/Left/Virtual` transforms are encoded relative to `Head`
 - Server relays cached raw client pose bodies to minimize reserialization work
@@ -131,7 +134,7 @@ kill <PID>                          # Kill process using port
 - **Server**: Multi-threaded (receive, periodic, discovery threads) with group-based room management
 - **Unity**: Manager pattern with internal components handling specific concerns
 - **Networking**: Binary protocol with efficient serialization
-- **Synchronization**: Transform, RPC, Network Variables, Device ID Mapping
+- **Synchronization**: Transform, Object Sync (with ownership), RPC, Network Variables, Device ID Mapping
 
 ### Unity–Python Feature Parity
 
@@ -144,6 +147,7 @@ The Python client (`net_sync_manager` in `client.py`) and the Unity client (`Net
   - `ServerDiscoveryManager.cs` ↔ discovery logic in `client.py`
   - `BinarySerializer.cs` ↔ `binary_serializer.py`
   - `RPCManager.cs` / `NetworkVariableManager.cs` ↔ RPC/NV logic in `client.py`
+  - `ObjectSyncManager.cs` / `NetSyncObject.cs` ↔ object sync logic in `client.py`
   - `server.py` has no Unity counterpart (server-only)
 
 ## Technology Stack

--- a/STYLY-NetSync-Server/src/styly_netsync/binary_serializer.py
+++ b/STYLY-NetSync-Server/src/styly_netsync/binary_serializer.py
@@ -19,6 +19,9 @@ MSG_CLIENT_VAR_SET = 9  # Set client variable
 MSG_CLIENT_VAR_SYNC = 10  # Sync client variables
 MSG_CLIENT_POSE = 11
 MSG_ROOM_POSE = 12
+MSG_CLIENT_OBJECTS = 13  # Client object transforms (batch)
+MSG_ROOM_OBJECTS = 14  # Room object transforms broadcast
+MSG_OBJECT_OWNER = 19  # Object ownership change
 
 # Transform data type identifiers (deprecated - kept for reference)
 
@@ -762,6 +765,100 @@ def serialize_client_var_sync(data: dict[str, Any]) -> bytes:
     return bytes(buffer)
 
 
+def serialize_room_objects(
+    broadcast_time: float, objects: list[tuple[int, int, bytes]]
+) -> bytes:
+    """Serialize MSG_ROOM_OBJECTS for server broadcast.
+
+    Args:
+        broadcast_time: Server broadcast timestamp.
+        objects: List of (object_id, owner_client_no, body_bytes_13B).
+
+    Returns:
+        Serialized message bytes.
+    """
+    buf = bytearray()
+    buf.append(MSG_ROOM_OBJECTS)
+    buf.append(PROTOCOL_VERSION)
+    buf.extend(struct.pack("<d", broadcast_time))
+    buf.append(len(objects) & 0xFF)
+
+    for object_id, owner_client_no, body_bytes in objects:
+        buf.extend(struct.pack("<H", object_id))
+        buf.extend(struct.pack("<H", owner_client_no))
+        buf.extend(body_bytes)  # 13B opaque pose data
+
+    return bytes(buf)
+
+
+def serialize_object_owner(object_id: int, new_owner_client_no: int, seq: int) -> bytes:
+    """Serialize MSG_OBJECT_OWNER message.
+
+    Args:
+        object_id: The object identifier.
+        new_owner_client_no: New owner's client number (0 = unowned).
+        seq: Monotonic ownership sequence number.
+
+    Returns:
+        Serialized message bytes.
+    """
+    buf = bytearray(7)
+    buf[0] = MSG_OBJECT_OWNER
+    struct.pack_into("<H", buf, 1, object_id)
+    struct.pack_into("<H", buf, 3, new_owner_client_no)
+    struct.pack_into("<H", buf, 5, seq)
+    return bytes(buf)
+
+
+def serialize_client_objects(
+    pose_seq: int,
+    objects: list[tuple[int, float, float, float, float, float, float, float]],
+) -> bytes:
+    """Serialize MSG_CLIENT_OBJECTS for Python client.
+
+    Args:
+        pose_seq: Pose sequence number.
+        objects: List of (objectId, px, py, pz, rx, ry, rz, rw).
+
+    Returns:
+        Serialized message bytes.
+    """
+    buf = bytearray()
+    buf.append(MSG_CLIENT_OBJECTS)
+    buf.append(PROTOCOL_VERSION)
+    buf.extend(struct.pack("<H", pose_seq & 0xFFFF))
+    buf.append(len(objects) & 0xFF)
+
+    for obj_id, px, py, pz, rx, ry, rz, rw in objects:
+        buf.extend(struct.pack("<H", obj_id))
+        _pack_int24_le(buf, _quantize_signed_int24(px, ABS_POS_SCALE))
+        _pack_int24_le(buf, _quantize_signed_int24(py, ABS_POS_SCALE))
+        _pack_int24_le(buf, _quantize_signed_int24(pz, ABS_POS_SCALE))
+        packed_rot = _compress_quaternion_smallest_three(rx, ry, rz, rw)
+        buf.extend(struct.pack("<I", packed_rot))
+
+    return bytes(buf)
+
+
+_VALID_MSG_TYPES = {
+    MSG_CLIENT_TRANSFORM,
+    MSG_ROOM_TRANSFORM,
+    MSG_RPC,
+    MSG_RPC_SERVER,
+    MSG_RPC_CLIENT,
+    MSG_DEVICE_ID_MAPPING,
+    MSG_GLOBAL_VAR_SET,
+    MSG_GLOBAL_VAR_SYNC,
+    MSG_CLIENT_VAR_SET,
+    MSG_CLIENT_VAR_SYNC,
+    MSG_CLIENT_POSE,
+    MSG_ROOM_POSE,
+    MSG_CLIENT_OBJECTS,
+    MSG_ROOM_OBJECTS,
+    MSG_OBJECT_OWNER,
+}
+
+
 def deserialize(data: bytes) -> tuple[int, dict[str, Any] | None, bytes]:
     """Deserialize binary data to message type, data, and raw payload
 
@@ -777,7 +874,7 @@ def deserialize(data: bytes) -> tuple[int, dict[str, Any] | None, bytes]:
     offset += 1
 
     # Validate message type is within valid range
-    if message_type < MSG_CLIENT_TRANSFORM or message_type > MSG_ROOM_POSE:
+    if message_type not in _VALID_MSG_TYPES:
         # Return invalid message type with None data instead of raising exception
         return message_type, None, b""
 
@@ -806,6 +903,13 @@ def deserialize(data: bytes) -> tuple[int, dict[str, Any] | None, bytes]:
             return message_type, _deserialize_client_var_set(data, offset), b""
         elif message_type == MSG_CLIENT_VAR_SYNC:
             return message_type, _deserialize_client_var_sync(data, offset), b""
+        elif message_type == MSG_CLIENT_OBJECTS:
+            header, obj_list = _deserialize_client_objects(data, offset)
+            return message_type, {"header": header, "objects": obj_list}, b""
+        elif message_type == MSG_ROOM_OBJECTS:
+            return message_type, _deserialize_room_objects(data, offset), b""
+        elif message_type == MSG_OBJECT_OWNER:
+            return message_type, _deserialize_object_owner(data, offset), b""
         else:
             # Should not reach here due to validation above
             return message_type, None, b""
@@ -1225,3 +1329,91 @@ def _deserialize_client_var_sync(data: bytes, offset: int) -> dict[str, Any]:
         result["clientVariables"][str(client_no)] = variables
 
     return result
+
+
+def _deserialize_client_objects(
+    data: bytes, offset: int
+) -> tuple[dict[str, Any], list[tuple[int, bytes]]]:
+    """Deserialize MSG_CLIENT_OBJECTS from client.
+
+    Returns:
+        Tuple of (header_dict, object_list).
+        header_dict contains poseSeq.
+        object_list is list of (objectId, body_bytes) where body_bytes is 13B opaque pose data.
+    """
+    protocol = data[offset]
+    offset += 1
+    if protocol != PROTOCOL_VERSION:
+        raise ValueError(f"Unsupported object protocol version: {protocol}")
+
+    pose_seq = struct.unpack("<H", data[offset : offset + 2])[0]
+    offset += 2
+    obj_count = data[offset]
+    offset += 1
+
+    header: dict[str, Any] = {"poseSeq": pose_seq}
+    objects: list[tuple[int, bytes]] = []
+
+    for _ in range(obj_count):
+        object_id = struct.unpack("<H", data[offset : offset + 2])[0]
+        offset += 2
+        # 13 bytes: 3x int24 position (9B) + uint32 quaternion (4B)
+        body_bytes = data[offset : offset + 13]
+        offset += 13
+        objects.append((object_id, body_bytes))
+
+    return header, objects
+
+
+def _deserialize_room_objects(data: bytes, offset: int) -> dict[str, Any]:
+    """Deserialize MSG_ROOM_OBJECTS broadcast."""
+    protocol = data[offset]
+    offset += 1
+    if protocol != PROTOCOL_VERSION:
+        raise ValueError(f"Unsupported object protocol version: {protocol}")
+
+    broadcast_time = struct.unpack("<d", data[offset : offset + 8])[0]
+    offset += 8
+    obj_count = data[offset]
+    offset += 1
+
+    objects: list[dict[str, Any]] = []
+    for _ in range(obj_count):
+        object_id = struct.unpack("<H", data[offset : offset + 2])[0]
+        offset += 2
+        owner_client_no = struct.unpack("<H", data[offset : offset + 2])[0]
+        offset += 2
+
+        # Decode position (3x int24 @ ABS_POS_SCALE)
+        px_q, offset = _unpack_int24_le(data, offset)
+        py_q, offset = _unpack_int24_le(data, offset)
+        pz_q, offset = _unpack_int24_le(data, offset)
+        px = _dequantize_signed(px_q, ABS_POS_SCALE)
+        py = _dequantize_signed(py_q, ABS_POS_SCALE)
+        pz = _dequantize_signed(pz_q, ABS_POS_SCALE)
+
+        # Decode rotation (uint32 smallest-three)
+        packed_rot = struct.unpack("<I", data[offset : offset + 4])[0]
+        offset += 4
+        rx, ry, rz, rw = _decompress_quaternion_smallest_three(packed_rot)
+
+        objects.append(
+            {
+                "objectId": object_id,
+                "ownerClientNo": owner_client_no,
+                "position": {"x": px, "y": py, "z": pz},
+                "rotation": {"x": rx, "y": ry, "z": rz, "w": rw},
+            }
+        )
+
+    return {"broadcastTime": broadcast_time, "objects": objects}
+
+
+def _deserialize_object_owner(data: bytes, offset: int) -> dict[str, Any]:
+    """Deserialize MSG_OBJECT_OWNER message."""
+    object_id = struct.unpack("<H", data[offset : offset + 2])[0]
+    offset += 2
+    new_owner = struct.unpack("<H", data[offset : offset + 2])[0]
+    offset += 2
+    seq = struct.unpack("<H", data[offset : offset + 2])[0]
+    return {"objectId": object_id, "newOwnerClientNo": new_owner, "seq": seq}

--- a/STYLY-NetSync-Server/src/styly_netsync/client.py
+++ b/STYLY-NetSync-Server/src/styly_netsync/client.py
@@ -39,6 +39,10 @@ from .adapters import (
     create_stealth_transform,
     is_stealth_transform,
 )
+from .binary_serializer import (
+    serialize_client_objects,
+    serialize_object_owner,
+)
 from .events import EventHandler
 from .types import client_transform_data, room_transform_data
 
@@ -235,6 +239,13 @@ class net_sync_manager:
         # Stealth mode heartbeat (mirrors Unity TransformSyncManager)
         self._is_stealth_mode: bool = False
         self._last_stealth_heartbeat_time: float = 0.0
+
+        # Object sync state
+        self._object_pose_seq: int = 0
+        self._ownership_seq: int = 0
+        self._latest_object_transform: OutboundPacket | None = None
+        self.on_room_objects: EventHandler = EventHandler()
+        self.on_object_owner_changed: EventHandler = EventHandler()
 
         # Statistics
         self._stats = {
@@ -541,9 +552,10 @@ class net_sync_manager:
             except Empty:
                 break
 
-        # Clear latest transform
+        # Clear latest transform and object transform
         with self._transform_lock:
             self._latest_transform = None
+            self._latest_object_transform = None
 
     def _receive_loop(self) -> None:
         """Main receive loop for processing server messages and flushing outgoing.
@@ -760,8 +772,10 @@ class net_sync_manager:
         # Priority-based send drain:
         # 1. Drain control messages first (higher priority)
         # 2. Then try to send latest transform (lower priority)
+        # 3. Then try to send latest object transform
         did_work |= self._drain_control_sends()
         did_work |= self._try_send_latest_transform()
+        did_work |= self._try_send_latest_object_transform()
 
         return did_work
 
@@ -850,6 +864,31 @@ class net_sync_manager:
                 logger.error(f"Fatal send error: {outcome.error}")
                 return False
 
+    def _try_send_latest_object_transform(self) -> bool:
+        """Try to send the latest object transform packet (latest-wins semantics).
+
+        Returns True if an object transform was sent.
+        """
+        if not self._dealer_socket:
+            return False
+
+        with self._transform_lock:
+            packet = self._latest_object_transform
+            if packet is None:
+                return False
+
+            outcome = self._try_send_dealer(packet.room_id, packet.payload)
+            if outcome.is_sent:
+                self._latest_object_transform = None
+                return True
+            elif outcome.is_backpressure:
+                with self._lock:
+                    self._stats["would_block_count"] += 1
+                return False
+            else:
+                logger.error(f"Fatal send error: {outcome.error}")
+                return False
+
     def _try_send_dealer(self, room_id: str, payload: bytes) -> SendOutcome:
         """Try to send a message via DEALER socket.
 
@@ -890,6 +929,10 @@ class net_sync_manager:
                 self._process_global_var_sync(msg_data)
             elif msg_type == binary_serializer.MSG_CLIENT_VAR_SYNC:
                 self._process_client_var_sync(msg_data)
+            elif msg_type == binary_serializer.MSG_ROOM_OBJECTS:
+                self._process_room_objects(msg_data)
+            elif msg_type == binary_serializer.MSG_OBJECT_OWNER:
+                self._process_object_owner(msg_data)
 
         except Exception as e:
             logger.error(f"Error processing message: {e}")
@@ -1069,6 +1112,22 @@ class net_sync_manager:
         except Exception as e:
             logger.error(f"Error processing client var sync: {e}")
 
+    def _process_room_objects(self, msg_data: dict[str, Any]) -> None:
+        """Process room objects broadcast."""
+        try:
+            if self._auto_dispatch:
+                self.on_room_objects.invoke(msg_data)
+        except Exception as e:
+            logger.error(f"Error processing room objects: {e}")
+
+    def _process_object_owner(self, msg_data: dict[str, Any]) -> None:
+        """Process object ownership change."""
+        try:
+            if self._auto_dispatch:
+                self.on_object_owner_changed.invoke(msg_data)
+        except Exception as e:
+            logger.error(f"Error processing object owner: {e}")
+
     # Transform API (pull-based)
     def get_room_transform_data(self) -> room_transform_data | None:
         """Get the latest room snapshot (pull-based consumption)."""
@@ -1159,6 +1218,104 @@ class net_sync_manager:
         if now - self._last_stealth_heartbeat_time >= STEALTH_HEARTBEAT_INTERVAL:
             self._last_stealth_heartbeat_time = now
             self._send_stealth_heartbeat()
+
+    # Object Sync API
+    def send_object_transforms(
+        self,
+        objects: list[tuple[int, float, float, float, float, float, float, float]],
+    ) -> bool:
+        """Queue object transforms to be sent (latest-wins semantics).
+
+        Args:
+            objects: List of (objectId, px, py, pz, rx, ry, rz, rw) tuples.
+
+        Returns:
+            True if enqueued successfully.
+        """
+        if not self._running or not self._dealer_socket:
+            return False
+
+        try:
+            self._object_pose_seq = (self._object_pose_seq + 1) & 0xFFFF
+            payload = serialize_client_objects(self._object_pose_seq, objects)
+
+            # Use latest-wins semantics like transform sending
+            with self._transform_lock:
+                self._latest_object_transform = OutboundPacket(
+                    lane=OutboundLane.TRANSFORM,
+                    room_id=self._room,
+                    payload=payload,
+                )
+            return True
+
+        except Exception as e:
+            logger.error(f"Error queueing object transforms: {e}")
+            return False
+
+    def request_ownership(self, object_id: int) -> bool:
+        """Request ownership of an object.
+
+        Args:
+            object_id: The object identifier.
+
+        Returns:
+            True if enqueued successfully.
+        """
+        if not self._running or not self._dealer_socket or self._client_no is None:
+            return False
+
+        try:
+            self._ownership_seq = (self._ownership_seq + 1) & 0xFFFF
+            payload = serialize_object_owner(
+                object_id, self._client_no, self._ownership_seq
+            )
+            return self._enqueue_control(self._room, payload, msg_type="object_owner")
+        except Exception as e:
+            logger.error(f"Error requesting ownership: {e}")
+            return False
+
+    def release_ownership(self, object_id: int) -> bool:
+        """Release ownership of an object.
+
+        Args:
+            object_id: The object identifier.
+
+        Returns:
+            True if enqueued successfully.
+        """
+        if not self._running or not self._dealer_socket:
+            return False
+
+        try:
+            self._ownership_seq = (self._ownership_seq + 1) & 0xFFFF
+            payload = serialize_object_owner(object_id, 0, self._ownership_seq)
+            return self._enqueue_control(self._room, payload, msg_type="object_owner")
+        except Exception as e:
+            logger.error(f"Error releasing ownership: {e}")
+            return False
+
+    def transfer_ownership(self, object_id: int, target_client_no: int) -> bool:
+        """Transfer ownership of an object to a specific client.
+
+        Args:
+            object_id: The object identifier.
+            target_client_no: New owner's client number.
+
+        Returns:
+            True if enqueued successfully.
+        """
+        if not self._running or not self._dealer_socket:
+            return False
+
+        try:
+            self._ownership_seq = (self._ownership_seq + 1) & 0xFFFF
+            payload = serialize_object_owner(
+                object_id, target_client_no, self._ownership_seq
+            )
+            return self._enqueue_control(self._room, payload, msg_type="object_owner")
+        except Exception as e:
+            logger.error(f"Error transferring ownership: {e}")
+            return False
 
     def rpc(
         self,

--- a/STYLY-NetSync-Server/src/styly_netsync/client_simulator.py
+++ b/STYLY-NetSync-Server/src/styly_netsync/client_simulator.py
@@ -45,12 +45,15 @@ import zmq
 
 # Import public APIs from styly_netsync module
 from styly_netsync.binary_serializer import (
+    MSG_CLIENT_OBJECTS,
     MSG_CLIENT_POSE,
     MSG_CLIENT_VAR_SET,
     MSG_CLIENT_VAR_SYNC,
     MSG_DEVICE_ID_MAPPING,
     MSG_GLOBAL_VAR_SET,
     MSG_GLOBAL_VAR_SYNC,
+    MSG_OBJECT_OWNER,
+    MSG_ROOM_OBJECTS,
     MSG_ROOM_POSE,
     MSG_RPC,
     deserialize,
@@ -84,12 +87,15 @@ def euler_to_quaternion(
 MESSAGE_TYPE_NAMES: dict[int, str] = {
     MSG_CLIENT_POSE: "CLIENT_POSE",
     MSG_ROOM_POSE: "ROOM_POSE",
+    MSG_CLIENT_OBJECTS: "CLIENT_OBJECTS",
+    MSG_ROOM_OBJECTS: "ROOM_OBJECTS",
     MSG_RPC: "RPC",
     MSG_DEVICE_ID_MAPPING: "DEVICE_ID_MAPPING",
     MSG_GLOBAL_VAR_SET: "GLOBAL_VAR_SET",
     MSG_GLOBAL_VAR_SYNC: "GLOBAL_VAR_SYNC",
     MSG_CLIENT_VAR_SET: "CLIENT_VAR_SET",
     MSG_CLIENT_VAR_SYNC: "CLIENT_VAR_SYNC",
+    MSG_OBJECT_OWNER: "OBJECT_OWNER",
 }
 
 # ============================================================================

--- a/STYLY-NetSync-Server/src/styly_netsync/server.py
+++ b/STYLY-NetSync-Server/src/styly_netsync/server.py
@@ -338,6 +338,11 @@ class NetSyncServer:
         self.MAX_VAR_NAME_LENGTH = config.max_var_name_length
         self.MAX_VAR_VALUE_LENGTH = config.max_var_value_length
 
+        # Object sync state per room
+        # room_id -> { object_id(int) -> { "owner_client_no": int, "body_bytes": bytes, "last_update": float } }
+        self.room_objects: dict[str, dict[int, dict[str, Any]]] = {}
+        self.room_objects_dirty: dict[str, bool] = {}
+
         # Thread synchronization
         self._rooms_lock = threading.RLock()  # Reentrant lock for nested access
         self._stats_lock = threading.Lock()  # Lock for statistics
@@ -781,6 +786,18 @@ class NetSyncServer:
                 return self.room_device_id_to_client_no[room_id].get(device_id, 0)
         return 0
 
+    def _get_client_no_from_identity(
+        self, client_identity: bytes, room_id: str
+    ) -> int | None:
+        """Get client number from ZMQ client identity by looking up the room entries.
+
+        Returns the client_no if found, or None if the identity is not in the room.
+        """
+        device_id = self._get_device_id_from_identity(client_identity, room_id)
+        if device_id is None:
+            return None
+        return self._get_client_no_for_device_id(room_id, device_id) or None
+
     def _find_reusable_client_no(self, room_id: str) -> int:
         """Find a client number that can be reused (from expired device IDs)"""
         current_time = time.monotonic()
@@ -1072,6 +1089,14 @@ class NetSyncServer:
                                 # Buffer client variable set request (no rate limit drops)
                                 self._buffer_client_var_set(room_id, data)
                                 self._monitor_nv_sliding_window(room_id)
+                            elif msg_type == binary_serializer.MSG_CLIENT_OBJECTS:
+                                self._handle_client_objects(
+                                    client_identity, room_id, data
+                                )
+                            elif msg_type == binary_serializer.MSG_OBJECT_OWNER:
+                                self._handle_object_owner(
+                                    client_identity, room_id, data
+                                )
                             else:
                                 logger.warning(f"Unknown binary msg_type: {msg_type}")
                         except Exception as e:
@@ -1244,6 +1269,114 @@ class NetSyncServer:
     def _extract_transform_body(self, raw_payload: bytes) -> bytes:
         """Extract the transform body without device ID from raw payload."""
         return raw_payload or b""
+
+    def _handle_client_objects(
+        self,
+        client_identity: bytes,
+        room_id: str,
+        data: dict[str, Any] | None,
+    ) -> None:
+        """Handle incoming MSG_CLIENT_OBJECTS from a client."""
+        if data is None:
+            return
+
+        objects: list[tuple[int, bytes]] = data.get("objects", [])
+
+        # Get sender's client_no from identity
+        sender_client_no = self._get_client_no_from_identity(client_identity, room_id)
+        if sender_client_no is None or sender_client_no <= 0:
+            return
+
+        now = time.monotonic()
+
+        with self._rooms_lock:
+            if room_id not in self.room_objects:
+                self.room_objects[room_id] = {}
+
+            room_objs = self.room_objects[room_id]
+
+            for object_id, body_bytes in objects:
+                # Validate ownership: only the owner can update
+                if object_id in room_objs:
+                    existing = room_objs[object_id]
+                    if (
+                        existing["owner_client_no"] != sender_client_no
+                        and existing["owner_client_no"] != 0
+                    ):
+                        continue  # Not the owner, skip
+
+                room_objs[object_id] = {
+                    "owner_client_no": sender_client_no,
+                    "body_bytes": body_bytes,
+                    "last_update": now,
+                }
+
+            self.room_objects_dirty[room_id] = True
+
+    def _handle_object_owner(
+        self,
+        client_identity: bytes,
+        room_id: str,
+        data: dict[str, Any] | None,
+    ) -> None:
+        """Handle ownership change request."""
+        if data is None:
+            return
+
+        object_id: int = data.get("objectId", 0)
+        new_owner: int = data.get("newOwnerClientNo", 0)
+        seq: int = data.get("seq", 0)
+
+        with self._rooms_lock:
+            if room_id not in self.room_objects:
+                self.room_objects[room_id] = {}
+
+            room_objs = self.room_objects[room_id]
+
+            if object_id not in room_objs:
+                room_objs[object_id] = {
+                    "owner_client_no": new_owner,
+                    "body_bytes": b"",
+                    "last_update": time.monotonic(),
+                }
+            else:
+                room_objs[object_id]["owner_client_no"] = new_owner
+
+        # Broadcast ownership change to all clients in the room
+        msg_bytes = binary_serializer.serialize_object_owner(object_id, new_owner, seq)
+        self._send_ctrl_to_room_via_router(room_id, msg_bytes)
+
+    def _broadcast_room_objects(self, room_id: str) -> None:
+        """Broadcast MSG_ROOM_OBJECTS for a room."""
+        with self._rooms_lock:
+            if not self.room_objects_dirty.get(room_id, False):
+                return
+
+            room_objs = self.room_objects.get(room_id, {})
+            if not room_objs:
+                self.room_objects_dirty[room_id] = False
+                return
+
+            # Build object list: (object_id, owner_client_no, body_bytes)
+            obj_list: list[tuple[int, int, bytes]] = []
+            for object_id, obj_data in room_objs.items():
+                body_bytes = obj_data.get("body_bytes", b"")
+                if len(body_bytes) == 13:  # Valid pose data
+                    obj_list.append(
+                        (object_id, obj_data["owner_client_no"], body_bytes)
+                    )
+
+            self.room_objects_dirty[room_id] = False
+
+        if not obj_list:
+            return
+
+        broadcast_time = time.monotonic()
+        msg_bytes = binary_serializer.serialize_room_objects(broadcast_time, obj_list)
+
+        # Broadcast via PUB socket with topic
+        topic = room_id.encode("utf-8")
+        self._enqueue_pub_latest(topic, msg_bytes)
 
     def _send_rpc_to_room(self, room_id: str, rpc_data: dict[str, Any]) -> None:
         """Send RPC to target clients in room via ROUTER unicast.
@@ -1820,6 +1953,7 @@ class NetSyncServer:
 
         for room_id, client_snapshot in rooms_to_broadcast:
             self._broadcast_room(room_id, client_snapshot)
+            self._broadcast_room_objects(room_id)
 
     def _enqueue_pub_latest(self, topic_bytes: bytes, message_bytes: bytes) -> None:
         """Latest-only coalescing enqueue for high-rate topics (e.g., room transforms)."""
@@ -1900,6 +2034,23 @@ class NetSyncServer:
                         # Clean up binary cache by client number
                         if client_no and client_no in self.client_transform_body_cache:
                             del self.client_transform_body_cache[client_no]
+                        # Release ownership of objects owned by this client
+                        if client_no:
+                            for obj_id, obj_data in list(
+                                self.room_objects.get(room_id, {}).items()
+                            ):
+                                if obj_data["owner_client_no"] == client_no:
+                                    obj_data["owner_client_no"] = 0
+                                    # Broadcast ownership release
+                                    msg_bytes = (
+                                        binary_serializer.serialize_object_owner(
+                                            obj_id, 0, 0
+                                        )
+                                    )
+                                    self._send_ctrl_to_room_via_router(
+                                        room_id, msg_bytes
+                                    )
+                            self.room_objects_dirty[room_id] = True
                         # Note: We don't remove device ID->clientNo mapping here
                         # It will be cleaned up after DEVICE_ID_EXPIRY_TIME
                         logger.info(

--- a/STYLY-NetSync-Server/src/styly_netsync/server.py
+++ b/STYLY-NetSync-Server/src/styly_netsync/server.py
@@ -1305,8 +1305,11 @@ class NetSyncServer:
                     ):
                         continue  # Not the owner, skip
 
+                prev = room_objs.get(object_id)
+                prev_seq: int = prev["owner_seq"] if prev else 0
                 room_objs[object_id] = {
                     "owner_client_no": sender_client_no,
+                    "owner_seq": prev_seq,
                     "body_bytes": body_bytes,
                     "last_update": now,
                 }
@@ -1336,11 +1339,13 @@ class NetSyncServer:
             if object_id not in room_objs:
                 room_objs[object_id] = {
                     "owner_client_no": new_owner,
+                    "owner_seq": seq,
                     "body_bytes": b"",
                     "last_update": time.monotonic(),
                 }
             else:
                 room_objs[object_id]["owner_client_no"] = new_owner
+                room_objs[object_id]["owner_seq"] = seq
 
         # Broadcast ownership change to all clients in the room
         msg_bytes = binary_serializer.serialize_object_owner(object_id, new_owner, seq)
@@ -2040,11 +2045,15 @@ class NetSyncServer:
                                 self.room_objects.get(room_id, {}).items()
                             ):
                                 if obj_data["owner_client_no"] == client_no:
+                                    release_seq = (
+                                        obj_data.get("owner_seq", 0) + 1
+                                    ) & 0xFFFF
                                     obj_data["owner_client_no"] = 0
-                                    # Broadcast ownership release
+                                    obj_data["owner_seq"] = release_seq
+                                    # Broadcast ownership release with incremented seq
                                     msg_bytes = (
                                         binary_serializer.serialize_object_owner(
-                                            obj_id, 0, 0
+                                            obj_id, 0, release_seq
                                         )
                                     )
                                     self._send_ctrl_to_room_via_router(
@@ -2111,6 +2120,12 @@ class NetSyncServer:
                     # Clean up empty room tracking
                     if room_id in self.room_empty_since:
                         del self.room_empty_since[room_id]
+
+                    # Clean up object sync structures
+                    if room_id in self.room_objects:
+                        del self.room_objects[room_id]
+                    if room_id in self.room_objects_dirty:
+                        del self.room_objects_dirty[room_id]
 
                     # Clean up NV-related structures
                     if room_id in self.global_variables:

--- a/STYLY-NetSync-Server/tests/test_object_sync.py
+++ b/STYLY-NetSync-Server/tests/test_object_sync.py
@@ -1,0 +1,345 @@
+"""Tests for object synchronization serialization and client API."""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from styly_netsync import binary_serializer
+from styly_netsync.binary_serializer import (
+    MSG_CLIENT_OBJECTS,
+    MSG_OBJECT_OWNER,
+    MSG_ROOM_OBJECTS,
+    serialize_client_objects,
+    serialize_object_owner,
+    serialize_room_objects,
+)
+
+
+def _quat_angle_error_deg(
+    qa: tuple[float, float, float, float], qb: tuple[float, float, float, float]
+) -> float:
+    """Get angular distance between quaternions in degrees."""
+    dot = qa[0] * qb[0] + qa[1] * qb[1] + qa[2] * qb[2] + qa[3] * qb[3]
+    dot = abs(dot)
+    dot = min(1.0, max(-1.0, dot))
+    return math.degrees(2.0 * math.acos(dot))
+
+
+class TestClientObjectsRoundTrip:
+    """Tests for MSG_CLIENT_OBJECTS serialization/deserialization round-trip."""
+
+    def test_single_object_round_trip(self) -> None:
+        """Single object round-trips with correct header and body."""
+        objects = [(1, 1.5, 2.0, -3.0, 0.0, 0.0, 0.0, 1.0)]
+        raw = serialize_client_objects(42, objects)
+        msg_type, data, _ = binary_serializer.deserialize(raw)
+
+        assert msg_type == MSG_CLIENT_OBJECTS
+        assert data is not None
+        header = data["header"]
+        assert header["poseSeq"] == 42
+        obj_list = data["objects"]
+        assert len(obj_list) == 1
+        assert obj_list[0][0] == 1  # objectId
+        assert len(obj_list[0][1]) == 13  # body_bytes length
+
+    def test_multiple_objects_round_trip(self) -> None:
+        """Multiple objects round-trip correctly."""
+        objects = [
+            (1, 1.0, 2.0, 3.0, 0.0, 0.0, 0.0, 1.0),
+            (2, -1.0, -2.0, -3.0, 0.0, 1.0, 0.0, 0.0),
+            (100, 10.5, 20.5, 30.5, 0.0, 0.0, 0.7071, 0.7071),
+        ]
+        raw = serialize_client_objects(999, objects)
+        msg_type, data, _ = binary_serializer.deserialize(raw)
+
+        assert msg_type == MSG_CLIENT_OBJECTS
+        assert data is not None
+        assert data["header"]["poseSeq"] == 999
+        assert len(data["objects"]) == 3
+        assert data["objects"][0][0] == 1
+        assert data["objects"][1][0] == 2
+        assert data["objects"][2][0] == 100
+
+    def test_empty_object_list(self) -> None:
+        """Empty object list round-trips correctly."""
+        raw = serialize_client_objects(0, [])
+        msg_type, data, _ = binary_serializer.deserialize(raw)
+
+        assert msg_type == MSG_CLIENT_OBJECTS
+        assert data is not None
+        assert data["header"]["poseSeq"] == 0
+        assert len(data["objects"]) == 0
+
+    def test_max_object_count_255(self) -> None:
+        """255 objects (max byte count) round-trips correctly."""
+        objects = [
+            (i, float(i), float(i), float(i), 0.0, 0.0, 0.0, 1.0) for i in range(255)
+        ]
+        raw = serialize_client_objects(1000, objects)
+        msg_type, data, _ = binary_serializer.deserialize(raw)
+
+        assert msg_type == MSG_CLIENT_OBJECTS
+        assert data is not None
+        assert len(data["objects"]) == 255
+        # Verify first and last object IDs
+        assert data["objects"][0][0] == 0
+        assert data["objects"][254][0] == 254
+
+    def test_pose_seq_wraps_at_16bit(self) -> None:
+        """Pose sequence wraps at 16-bit boundary."""
+        raw = serialize_client_objects(0xFFFF, [(1, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0)])
+        msg_type, data, _ = binary_serializer.deserialize(raw)
+
+        assert data is not None
+        assert data["header"]["poseSeq"] == 0xFFFF
+
+    def test_message_type_byte(self) -> None:
+        """First byte of serialized data is MSG_CLIENT_OBJECTS."""
+        raw = serialize_client_objects(1, [(1, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0)])
+        assert raw[0] == MSG_CLIENT_OBJECTS
+        assert raw[0] == 13
+
+
+class TestRoomObjectsRoundTrip:
+    """Tests for MSG_ROOM_OBJECTS serialization/deserialization round-trip."""
+
+    def _make_body_bytes(
+        self,
+        px: float,
+        py: float,
+        pz: float,
+        rx: float,
+        ry: float,
+        rz: float,
+        rw: float,
+    ) -> bytes:
+        """Create 13-byte body from object transforms via client objects serialization."""
+        # Serialize as client objects and extract the body bytes
+        raw = serialize_client_objects(0, [(0, px, py, pz, rx, ry, rz, rw)])
+        _, data, _ = binary_serializer.deserialize(raw)
+        assert data is not None
+        return data["objects"][0][1]
+
+    def test_single_object_round_trip(self) -> None:
+        """Single room object round-trips with position and rotation decoded."""
+        body = self._make_body_bytes(1.5, 2.0, -3.0, 0.0, 0.0, 0.0, 1.0)
+        raw = serialize_room_objects(100.0, [(10, 5, body)])
+        msg_type, data, _ = binary_serializer.deserialize(raw)
+
+        assert msg_type == MSG_ROOM_OBJECTS
+        assert data is not None
+        assert abs(data["broadcastTime"] - 100.0) < 1e-6
+        assert len(data["objects"]) == 1
+
+        obj = data["objects"][0]
+        assert obj["objectId"] == 10
+        assert obj["ownerClientNo"] == 5
+        assert abs(obj["position"]["x"] - 1.5) <= 0.01
+        assert abs(obj["position"]["y"] - 2.0) <= 0.01
+        assert abs(obj["position"]["z"] + 3.0) <= 0.01
+
+    def test_multiple_objects_round_trip(self) -> None:
+        """Multiple room objects round-trip correctly."""
+        body1 = self._make_body_bytes(1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0)
+        body2 = self._make_body_bytes(-5.0, 10.0, 3.0, 0.0, 0.0, 0.0, 1.0)
+        raw = serialize_room_objects(200.0, [(1, 10, body1), (2, 20, body2)])
+        msg_type, data, _ = binary_serializer.deserialize(raw)
+
+        assert msg_type == MSG_ROOM_OBJECTS
+        assert data is not None
+        assert len(data["objects"]) == 2
+        assert data["objects"][0]["objectId"] == 1
+        assert data["objects"][0]["ownerClientNo"] == 10
+        assert data["objects"][1]["objectId"] == 2
+        assert data["objects"][1]["ownerClientNo"] == 20
+
+    def test_empty_object_list(self) -> None:
+        """Empty room objects round-trips correctly."""
+        raw = serialize_room_objects(0.0, [])
+        msg_type, data, _ = binary_serializer.deserialize(raw)
+
+        assert msg_type == MSG_ROOM_OBJECTS
+        assert data is not None
+        assert len(data["objects"]) == 0
+
+    def test_rotation_fidelity(self) -> None:
+        """Rotation through room objects stays within 1 degree."""
+        # 45-degree rotation around Y
+        rw = math.cos(math.pi / 8)
+        ry = math.sin(math.pi / 8)
+        body = self._make_body_bytes(0.0, 0.0, 0.0, 0.0, ry, 0.0, rw)
+        raw = serialize_room_objects(0.0, [(1, 1, body)])
+        _, data, _ = binary_serializer.deserialize(raw)
+
+        assert data is not None
+        rot = data["objects"][0]["rotation"]
+        err = _quat_angle_error_deg(
+            (0.0, ry, 0.0, rw), (rot["x"], rot["y"], rot["z"], rot["w"])
+        )
+        assert err <= 1.0
+
+    def test_message_type_byte(self) -> None:
+        """First byte of serialized data is MSG_ROOM_OBJECTS."""
+        raw = serialize_room_objects(0.0, [])
+        assert raw[0] == MSG_ROOM_OBJECTS
+        assert raw[0] == 14
+
+
+class TestObjectOwnerRoundTrip:
+    """Tests for MSG_OBJECT_OWNER serialization/deserialization round-trip."""
+
+    def test_basic_round_trip(self) -> None:
+        """Basic ownership message round-trips correctly."""
+        raw = serialize_object_owner(10, 5, 1)
+        msg_type, data, _ = binary_serializer.deserialize(raw)
+
+        assert msg_type == MSG_OBJECT_OWNER
+        assert data is not None
+        assert data["objectId"] == 10
+        assert data["newOwnerClientNo"] == 5
+        assert data["seq"] == 1
+
+    def test_release_ownership(self) -> None:
+        """Releasing ownership (owner=0) round-trips correctly."""
+        raw = serialize_object_owner(42, 0, 100)
+        msg_type, data, _ = binary_serializer.deserialize(raw)
+
+        assert data is not None
+        assert data["objectId"] == 42
+        assert data["newOwnerClientNo"] == 0
+        assert data["seq"] == 100
+
+    def test_max_values(self) -> None:
+        """Maximum uint16 values round-trip correctly."""
+        raw = serialize_object_owner(0xFFFF, 0xFFFF, 0xFFFF)
+        msg_type, data, _ = binary_serializer.deserialize(raw)
+
+        assert data is not None
+        assert data["objectId"] == 0xFFFF
+        assert data["newOwnerClientNo"] == 0xFFFF
+        assert data["seq"] == 0xFFFF
+
+    def test_zero_values(self) -> None:
+        """All-zero values round-trip correctly."""
+        raw = serialize_object_owner(0, 0, 0)
+        _, data, _ = binary_serializer.deserialize(raw)
+
+        assert data is not None
+        assert data["objectId"] == 0
+        assert data["newOwnerClientNo"] == 0
+        assert data["seq"] == 0
+
+    def test_message_type_byte(self) -> None:
+        """First byte of serialized data is MSG_OBJECT_OWNER."""
+        raw = serialize_object_owner(1, 1, 1)
+        assert raw[0] == MSG_OBJECT_OWNER
+        assert raw[0] == 19
+
+    def test_serialized_length(self) -> None:
+        """MSG_OBJECT_OWNER should be exactly 7 bytes."""
+        raw = serialize_object_owner(1, 2, 3)
+        assert len(raw) == 7
+
+
+class TestObjectPositionBoundaryValues:
+    """Tests for boundary position values in object transforms."""
+
+    def test_large_positive_position(self) -> None:
+        """Large positive position values survive round-trip via room objects."""
+        # int24 max * 0.01 = 83886.07
+        objects = [(1, 5000.0, 5000.0, 5000.0, 0.0, 0.0, 0.0, 1.0)]
+        raw = serialize_client_objects(1, objects)
+        _, client_data, _ = binary_serializer.deserialize(raw)
+        assert client_data is not None
+
+        body = client_data["objects"][0][1]
+        room_raw = serialize_room_objects(0.0, [(1, 1, body)])
+        _, room_data, _ = binary_serializer.deserialize(room_raw)
+        assert room_data is not None
+
+        pos = room_data["objects"][0]["position"]
+        assert abs(pos["x"] - 5000.0) <= 0.01
+        assert abs(pos["y"] - 5000.0) <= 0.01
+        assert abs(pos["z"] - 5000.0) <= 0.01
+
+    def test_large_negative_position(self) -> None:
+        """Large negative position values survive round-trip."""
+        objects = [(1, -5000.0, -5000.0, -5000.0, 0.0, 0.0, 0.0, 1.0)]
+        raw = serialize_client_objects(1, objects)
+        _, client_data, _ = binary_serializer.deserialize(raw)
+        assert client_data is not None
+
+        body = client_data["objects"][0][1]
+        room_raw = serialize_room_objects(0.0, [(1, 1, body)])
+        _, room_data, _ = binary_serializer.deserialize(room_raw)
+        assert room_data is not None
+
+        pos = room_data["objects"][0]["position"]
+        assert abs(pos["x"] + 5000.0) <= 0.01
+        assert abs(pos["y"] + 5000.0) <= 0.01
+        assert abs(pos["z"] + 5000.0) <= 0.01
+
+    def test_zero_position(self) -> None:
+        """Zero position round-trips exactly."""
+        objects = [(1, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0)]
+        raw = serialize_client_objects(1, objects)
+        _, client_data, _ = binary_serializer.deserialize(raw)
+        assert client_data is not None
+
+        body = client_data["objects"][0][1]
+        room_raw = serialize_room_objects(0.0, [(1, 1, body)])
+        _, room_data, _ = binary_serializer.deserialize(room_raw)
+        assert room_data is not None
+
+        pos = room_data["objects"][0]["position"]
+        assert pos["x"] == 0.0
+        assert pos["y"] == 0.0
+        assert pos["z"] == 0.0
+
+    def test_position_quantization_precision(self) -> None:
+        """Position values are quantized to ABS_POS_SCALE (0.01m) precision."""
+        # Value that is exactly representable
+        objects = [(1, 1.23, -4.56, 7.89, 0.0, 0.0, 0.0, 1.0)]
+        raw = serialize_client_objects(1, objects)
+        _, client_data, _ = binary_serializer.deserialize(raw)
+        assert client_data is not None
+
+        body = client_data["objects"][0][1]
+        room_raw = serialize_room_objects(0.0, [(1, 1, body)])
+        _, room_data, _ = binary_serializer.deserialize(room_raw)
+        assert room_data is not None
+
+        pos = room_data["objects"][0]["position"]
+        assert abs(pos["x"] - 1.23) <= 0.01
+        assert abs(pos["y"] + 4.56) <= 0.01
+        assert abs(pos["z"] - 7.89) <= 0.01
+
+    @pytest.mark.parametrize(
+        "quat",
+        [
+            (0.0, 0.0, 0.0, 1.0),  # identity
+            (1.0, 0.0, 0.0, 0.0),  # 180 deg around X
+            (0.0, 1.0, 0.0, 0.0),  # 180 deg around Y
+            (0.0, 0.0, 1.0, 0.0),  # 180 deg around Z
+            (0.5, 0.5, 0.5, 0.5),  # 120 deg around (1,1,1)
+        ],
+    )
+    def test_various_rotations(self, quat: tuple[float, float, float, float]) -> None:
+        """Various canonical rotations survive round-trip within 1 degree."""
+        rx, ry, rz, rw = quat
+        objects = [(1, 0.0, 0.0, 0.0, rx, ry, rz, rw)]
+        raw = serialize_client_objects(1, objects)
+        _, client_data, _ = binary_serializer.deserialize(raw)
+        assert client_data is not None
+
+        body = client_data["objects"][0][1]
+        room_raw = serialize_room_objects(0.0, [(1, 1, body)])
+        _, room_data, _ = binary_serializer.deserialize(room_raw)
+        assert room_data is not None
+
+        rot = room_data["objects"][0]["rotation"]
+        err = _quat_angle_error_deg(quat, (rot["x"], rot["y"], rot["z"], rot["w"]))
+        assert err <= 1.0

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/BinarySerializer.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/BinarySerializer.cs
@@ -22,6 +22,9 @@ namespace Styly.NetSync
         public const byte MSG_CLIENT_VAR_SYNC = 10;  // Sync client variables
         public const byte MSG_CLIENT_POSE = 11;  // Client pose (quaternion + timestamps)
         public const byte MSG_ROOM_POSE = 12;  // Room pose snapshot (quaternion + timestamps)
+        public const byte MSG_CLIENT_OBJECTS = 13;  // Client object transforms (batch)
+        public const byte MSG_ROOM_OBJECTS = 14;    // Room object transforms broadcast
+        public const byte MSG_OBJECT_OWNER = 19;    // Object ownership change
 
         // Transform data type identifiers (deprecated - kept for reference)
         // Protocol v3 pose encoding constants
@@ -563,6 +566,85 @@ namespace Styly.NetSync
             writer.Write((byte)0);
         }
 
+        #region === Object Sync Serialization ===
+
+        // Maximum allowed synced objects per batch
+        private const int MAX_SYNCED_OBJECTS = 255;
+
+        /// <summary>
+        /// Serialize client object transforms into an existing BinaryWriter.
+        /// Wire format: [1B msgType=13][1B protocol=3][2B poseSeq][1B objectCount]
+        ///   per object: [2B objectId][3B posX_i24][3B posY_i24][3B posZ_i24][4B rot_u32]
+        /// </summary>
+        public static void SerializeClientObjectsInto(BinaryWriter writer, ushort poseSeq, List<ObjectTransformEntry> objects)
+        {
+            writer.Write(MSG_CLIENT_OBJECTS);
+            writer.Write(PROTOCOL_VERSION);
+            writer.Write(poseSeq);
+
+            var count = objects != null ? Mathf.Min(objects.Count, MAX_SYNCED_OBJECTS) : 0;
+            writer.Write((byte)count);
+
+            for (int i = 0; i < count; i++)
+            {
+                var obj = objects[i];
+                writer.Write(obj.objectId);
+                var rot = NormalizeQuaternionSafe(obj.rotation);
+                WriteInt24(writer, QuantizeSignedInt24(obj.position.x, ABS_POS_SCALE));
+                WriteInt24(writer, QuantizeSignedInt24(obj.position.y, ABS_POS_SCALE));
+                WriteInt24(writer, QuantizeSignedInt24(obj.position.z, ABS_POS_SCALE));
+                writer.Write(CompressQuaternionSmallestThree(rot));
+            }
+        }
+
+        /// <summary>
+        /// Serialize ownership change into an existing BinaryWriter.
+        /// Wire format: [1B msgType=19][2B objectId][2B newOwnerClientNo][2B seq]
+        /// </summary>
+        public static void SerializeOwnershipChangeInto(BinaryWriter writer, ushort objectId, ushort newOwnerClientNo, ushort seq)
+        {
+            writer.Write(MSG_OBJECT_OWNER);
+            writer.Write(objectId);
+            writer.Write(newOwnerClientNo);
+            writer.Write(seq);
+        }
+
+        /// <summary>
+        /// Serialize ownership change into a new byte array.
+        /// </summary>
+        public static byte[] SerializeOwnershipChange(ushort objectId, ushort newOwnerClientNo, ushort seq)
+        {
+            using (var ms = new MemoryStream(7))
+            using (var writer = new BinaryWriter(ms))
+            {
+                SerializeOwnershipChangeInto(writer, objectId, newOwnerClientNo, seq);
+                return ms.ToArray();
+            }
+        }
+
+        /// <summary>
+        /// Compute FNV-1a 64-bit signature hash for a batch of object transforms.
+        /// Returns 0 if objects is null or empty.
+        /// </summary>
+        internal static ulong ComputeObjectPoseSignature(List<ObjectTransformEntry> objects)
+        {
+            if (objects == null || objects.Count == 0) return 0;
+
+            ulong hash = 14695981039346656037UL;
+            for (int i = 0; i < objects.Count; i++)
+            {
+                var obj = objects[i];
+                HashShort(ref hash, (short)obj.objectId);
+                HashInt24(ref hash, QuantizeSignedInt24(obj.position.x, ABS_POS_SCALE));
+                HashInt24(ref hash, QuantizeSignedInt24(obj.position.y, ABS_POS_SCALE));
+                HashInt24(ref hash, QuantizeSignedInt24(obj.position.z, ABS_POS_SCALE));
+                HashUInt(ref hash, CompressQuaternionSmallestThree(NormalizeQuaternionSafe(obj.rotation)));
+            }
+            return hash;
+        }
+
+        #endregion
+
         #region === Deserialization ===
 
         public static (byte messageType, object data) Deserialize(byte[] bytes)
@@ -577,35 +659,24 @@ namespace Styly.NetSync
             {
                 var messageType = reader.ReadByte();
 
-                // Validate message type is within valid range
-                if (messageType < MSG_CLIENT_TRANSFORM || messageType > MSG_ROOM_POSE)
-                {
-                    // Don't throw exception, just return invalid type with null data
-                    // This allows the caller to handle it gracefully
-                    return (messageType, null);
-                }
-
+                // Validate known message types
                 switch (messageType)
                 {
-                    // case MSG_CLIENT_TRANSFORM:
-                    //     return (messageType, DeserializeClientTransform(reader));
                     case MSG_ROOM_POSE:
                         return (messageType, DeserializeRoomTransform(reader));
                     case MSG_RPC:
-                        // RPC message
                         return (messageType, DeserializeRPCMessage(reader));
-                    // MSG_RPC_SERVER and MSG_RPC_CLIENT are reserved for future use
                     case MSG_DEVICE_ID_MAPPING:
-                        // Device ID mapping notification
                         return (messageType, DeserializeDeviceIdMapping(reader));
                     case MSG_GLOBAL_VAR_SYNC:
-                        // Global variables sync from server
                         return (messageType, DeserializeGlobalVarSync(reader));
                     case MSG_CLIENT_VAR_SYNC:
-                        // Client variables sync from server
                         return (messageType, DeserializeClientVarSync(reader));
+                    case MSG_ROOM_OBJECTS:
+                        return (messageType, DeserializeRoomObjects(reader));
+                    case MSG_OBJECT_OWNER:
+                        return (messageType, DeserializeOwnershipChange(reader));
                     default:
-                        // This should not happen due to validation above, but keep as safety
                         return (messageType, null);
                 }
             }
@@ -1046,6 +1117,56 @@ namespace Styly.NetSync
 
             data["variables"] = variables.ToArray();
             return data;
+        }
+
+        /// <summary>
+        /// Deserialize MSG_ROOM_OBJECTS broadcast from server.
+        /// Wire format: [1B protocol=3][8B broadcastTime][1B objectCount]
+        ///   per object: [2B objectId][2B ownerClientNo][3B posX_i24][3B posY_i24][3B posZ_i24][4B rot_u32]
+        /// </summary>
+        private static RoomObjectData DeserializeRoomObjects(BinaryReader reader)
+        {
+            var data = new RoomObjectData();
+
+            var protocolVersion = reader.ReadByte();
+            if (protocolVersion != PROTOCOL_VERSION)
+            {
+                throw new InvalidDataException($"Unsupported object protocol version: {protocolVersion}");
+            }
+
+            data.broadcastTime = reader.ReadDouble();
+            var objectCount = reader.ReadByte();
+            data.objects = new List<ObjectTransformEntry>(objectCount);
+
+            for (int i = 0; i < objectCount; i++)
+            {
+                var objectId = reader.ReadUInt16();
+                var ownerClientNo = reader.ReadUInt16();
+                int px = ReadInt24(reader);
+                int py = ReadInt24(reader);
+                int pz = ReadInt24(reader);
+                uint packedRot = reader.ReadUInt32();
+                var position = QuantizedToVector3(px, py, pz, ABS_POS_SCALE);
+                var rotation = DecompressQuaternionSmallestThree(packedRot);
+
+                data.objects.Add(new ObjectTransformEntry(objectId, ownerClientNo, position, rotation));
+            }
+
+            return data;
+        }
+
+        /// <summary>
+        /// Deserialize MSG_OBJECT_OWNER ownership change.
+        /// Wire format: [2B objectId][2B newOwnerClientNo][2B seq]
+        /// </summary>
+        private static OwnershipChangeData DeserializeOwnershipChange(BinaryReader reader)
+        {
+            return new OwnershipChangeData
+            {
+                objectId = reader.ReadUInt16(),
+                newOwnerClientNo = reader.ReadUInt16(),
+                seq = reader.ReadUInt16()
+            };
         }
 
         /// <summary>

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/ConnectionManager.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/ConnectionManager.cs
@@ -80,6 +80,12 @@ namespace Styly.NetSync
         private volatile OutboundPacket _latestTransform;
 
         /// <summary>
+        /// Latest object transform packet to send (latest-wins semantics).
+        /// Separate from avatar transforms to prevent mutual overwrite.
+        /// </summary>
+        private volatile OutboundPacket _latestObjectTransform;
+
+        /// <summary>
         /// Counter for tracking backpressure events (EAGAIN/would-block).
         /// Incremented when a send fails due to HWM being reached.
         /// </summary>
@@ -215,6 +221,27 @@ namespace Styly.NetSync
 
             // Atomic overwrite - latest-wins semantics
             Volatile.Write(ref _latestTransform, packet);
+        }
+
+        /// <summary>
+        /// Set the latest object transform packet to send (latest-wins semantics).
+        /// Separate slot from avatar transforms so they don't overwrite each other.
+        /// </summary>
+        public void SetLatestObjectTransform(string roomId, byte[] payload)
+        {
+            if (_receiveThread == null || _shouldStop || _connectionError) { return; }
+            if (_dealerSocket == null) { return; }
+
+            var packet = new OutboundPacket
+            {
+                Lane = OutboundLane.Transform,
+                RoomId = roomId,
+                Payload = payload,
+                EnqueuedAt = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() / 1000.0,
+                Attempts = 0
+            };
+
+            Volatile.Write(ref _latestObjectTransform, packet);
         }
 
         /// <summary>
@@ -380,11 +407,13 @@ namespace Styly.NetSync
             bool didWork = false;
 
             // Priority-based send drain:
-            // 1. Drain control messages first (higher priority)
-            // 2. Then try to send latest transform (lower priority)
+            // 1. Drain control messages first (highest priority)
+            // 2. Send latest avatar transform
+            // 3. Send latest object transforms
 
             didWork |= DrainControlSends(dealer, maxBatch: 64);
             didWork |= TrySendLatestTransform(dealer);
+            didWork |= TrySendLatestObjectTransform(dealer);
 
             return didWork;
         }
@@ -472,6 +501,30 @@ namespace Styly.NetSync
             }
         }
 
+        /// <summary>
+        /// Try to send the latest object transform packet.
+        /// Uses latest-wins semantics identical to avatar transforms.
+        /// </summary>
+        private bool TrySendLatestObjectTransform(DealerSocket dealer)
+        {
+            var packet = Volatile.Read(ref _latestObjectTransform);
+            if (packet == null)
+            {
+                return false;
+            }
+
+            if (TrySendDealer(dealer, packet.RoomId, packet.Payload))
+            {
+                Interlocked.CompareExchange(ref _latestObjectTransform, null, packet);
+                return true;
+            }
+            else
+            {
+                Interlocked.Increment(ref _wouldBlockCount);
+                return false;
+            }
+        }
+
         private static bool TrySendDealer(DealerSocket dealer, string roomId, byte[] payload)
         {
             var msg = new NetMQMessage();
@@ -508,6 +561,7 @@ namespace Styly.NetSync
 
             // Clear latest transform
             Volatile.Write(ref _latestTransform, null);
+            Volatile.Write(ref _latestObjectTransform, null);
         }
 
         private static void WaitThreadExit(Thread t, int ms)

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/DataStructure.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/DataStructure.cs
@@ -103,6 +103,47 @@ namespace Styly.NetSync
     }
 
 
+    // Object ownership modes for NetSyncObject
+    public enum ObjectOwnershipMode
+    {
+        /// Ownership transfers to whoever interacts (grabs) the object.
+        LastTouch,
+        /// Ownership transfers only via explicit API call.
+        Explicit
+    }
+
+    // Object transform entry for batch serialization/deserialization
+    internal struct ObjectTransformEntry
+    {
+        public ushort objectId;
+        public ushort ownerClientNo;
+        public Vector3 position;
+        public Quaternion rotation;
+
+        public ObjectTransformEntry(ushort objectId, ushort ownerClientNo, Vector3 position, Quaternion rotation)
+        {
+            this.objectId = objectId;
+            this.ownerClientNo = ownerClientNo;
+            this.position = position;
+            this.rotation = rotation;
+        }
+    }
+
+    // Ownership change data for MSG_OBJECT_OWNER
+    internal struct OwnershipChangeData
+    {
+        public ushort objectId;
+        public ushort newOwnerClientNo;
+        public ushort seq;
+    }
+
+    // Room object data from server (MSG_ROOM_OBJECTS)
+    internal class RoomObjectData
+    {
+        public double broadcastTime;
+        public List<ObjectTransformEntry> objects;
+    }
+
     // Device ID mapping data
     [Serializable]
     internal class DeviceIdMapping

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/IConnectionManager.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/IConnectionManager.cs
@@ -21,6 +21,7 @@ namespace Styly.NetSync
         // Sending
         bool TryEnqueueControl(string roomId, byte[] payload);
         void SetLatestTransform(string roomId, byte[] payload);
+        void SetLatestObjectTransform(string roomId, byte[] payload);
 
         // Discovery
         void StartDiscovery(ServerDiscoveryManager discoveryManager, string roomId);

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/MessageProcessor.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/MessageProcessor.cs
@@ -124,7 +124,16 @@ namespace Styly.NetSync
                     case BinarySerializer.MSG_CLIENT_VAR_SYNC when data is Dictionary<string, object> clientVarData:
                         _messageQueue.Enqueue(new NetworkMessage { type = "client_var_sync", dataObj = clientVarData });
                         _messagesReceived++;
-                        // Client variable sync data received
+                        break;
+
+                    case BinarySerializer.MSG_ROOM_OBJECTS when data is RoomObjectData roomObjects:
+                        _messageQueue.Enqueue(new NetworkMessage { type = "room_objects", dataObj = roomObjects });
+                        _messagesReceived++;
+                        break;
+
+                    case BinarySerializer.MSG_OBJECT_OWNER when data is OwnershipChangeData ownerData:
+                        _messageQueue.Enqueue(new NetworkMessage { type = "object_owner", dataObj = ownerData });
+                        _messagesReceived++;
                         break;
 
                     default:
@@ -218,6 +227,20 @@ namespace Styly.NetSync
                         else
                         {
                             Debug.LogError("[MessageProcessor] id_mapping without valid dataObj (unexpected)");
+                        }
+                        break;
+
+                    case "room_objects":
+                        if (msg.dataObj is RoomObjectData roomObjects && _netSyncManager != null)
+                        {
+                            _netSyncManager.ProcessRoomObjects(roomObjects);
+                        }
+                        break;
+
+                    case "object_owner":
+                        if (msg.dataObj is OwnershipChangeData ownerData && _netSyncManager != null)
+                        {
+                            _netSyncManager.ProcessOwnershipChange(ownerData);
                         }
                         break;
                 }

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/ObjectSyncManager.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/ObjectSyncManager.cs
@@ -1,7 +1,6 @@
 // ObjectSyncManager.cs - Manages high-frequency transform synchronization for non-avatar objects
 using System;
 using System.Collections.Generic;
-using System.IO;
 using UnityEngine;
 
 namespace Styly.NetSync
@@ -22,7 +21,6 @@ namespace Styly.NetSync
         private readonly List<ObjectTransformEntry> _dirtyEntries = new List<ObjectTransformEntry>(64);
 
         // Send rate control
-        private float _lastSendTime;
         private ushort _poseSeq;
         private bool _hasLastSignature;
         private ulong _lastSignature;
@@ -86,6 +84,14 @@ namespace Styly.NetSync
         {
             _registry.TryGetValue(objectId, out var obj);
             return obj;
+        }
+
+        /// <summary>
+        /// Returns true if enough time has elapsed since the last send to respect the configured SendRate.
+        /// </summary>
+        public bool ShouldSend(float currentTime)
+        {
+            return currentTime - _lastSentTime >= 1f / SendRate;
         }
 
         /// <summary>

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/ObjectSyncManager.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/ObjectSyncManager.cs
@@ -1,0 +1,237 @@
+// ObjectSyncManager.cs - Manages high-frequency transform synchronization for non-avatar objects
+using System;
+using System.Collections.Generic;
+using System.IO;
+using UnityEngine;
+
+namespace Styly.NetSync
+{
+    /// <summary>
+    /// Internal manager responsible for collecting, sending, and receiving object transforms.
+    /// Analogous to TransformSyncManager for avatars.
+    /// </summary>
+    internal class ObjectSyncManager
+    {
+        private readonly IConnectionManager _connectionManager;
+        private readonly ReusableBufferWriter _buf;
+
+        // Object registry: objectId -> NetSyncObject
+        private readonly Dictionary<ushort, NetSyncObject> _registry = new Dictionary<ushort, NetSyncObject>();
+
+        // Reusable list for collecting dirty objects each frame
+        private readonly List<ObjectTransformEntry> _dirtyEntries = new List<ObjectTransformEntry>(64);
+
+        // Send rate control
+        private float _lastSendTime;
+        private ushort _poseSeq;
+        private bool _hasLastSignature;
+        private ulong _lastSignature;
+        private float _lastSentTime;
+        private int _messagesSent;
+
+        private const int INITIAL_BUFFER_CAPACITY = 1024;
+        private const float HEARTBEAT_INTERVAL_SECONDS = 1f;
+
+        // 5 bytes header + 15 bytes per object
+        private const int HEADER_SIZE = 5;
+        private const int BYTES_PER_OBJECT = 15;
+
+        public float SendRate { get; set; } = 10f;
+        public int MessagesSent => _messagesSent;
+
+        /// <summary>
+        /// Read-only access to the object registry for iteration.
+        /// </summary>
+        public IReadOnlyDictionary<ushort, NetSyncObject> Registry => _registry;
+
+        public ObjectSyncManager(IConnectionManager connectionManager, float sendRate)
+        {
+            _connectionManager = connectionManager;
+            SendRate = sendRate;
+            _buf = new ReusableBufferWriter(INITIAL_BUFFER_CAPACITY);
+        }
+
+        /// <summary>
+        /// Register a NetSyncObject. Called by NetSyncObject.OnEnable.
+        /// </summary>
+        public void Register(NetSyncObject obj)
+        {
+            if (obj == null) return;
+            var id = obj.ObjectId;
+            if (id == 0)
+            {
+                Debug.LogWarning("[ObjectSyncManager] Cannot register object with ObjectId=0 (unassigned).");
+                return;
+            }
+            if (_registry.ContainsKey(id))
+            {
+                Debug.LogWarning($"[ObjectSyncManager] Duplicate ObjectId={id}. Overwriting.");
+            }
+            _registry[id] = obj;
+        }
+
+        /// <summary>
+        /// Unregister a NetSyncObject. Called by NetSyncObject.OnDisable.
+        /// </summary>
+        public void Unregister(NetSyncObject obj)
+        {
+            if (obj == null) return;
+            _registry.Remove(obj.ObjectId);
+        }
+
+        /// <summary>
+        /// Get a registered object by ID.
+        /// </summary>
+        public NetSyncObject GetObject(ushort objectId)
+        {
+            _registry.TryGetValue(objectId, out var obj);
+            return obj;
+        }
+
+        /// <summary>
+        /// Collect locally-owned dirty objects, serialize, and send to server.
+        /// Called from NetSyncManager.Update() at the configured send rate.
+        /// </summary>
+        public SendOutcome SendOwnedObjects(string roomId, int localClientNo)
+        {
+            if (localClientNo <= 0) return SendOutcome.Sent();
+
+            try
+            {
+                _dirtyEntries.Clear();
+                foreach (var kv in _registry)
+                {
+                    var obj = kv.Value;
+                    if (obj == null) continue;
+                    if (obj.OwnerClientNo != localClientNo) continue;
+
+                    var t = obj.SyncSpace == NetSyncTransformApplier.SpaceMode.World
+                        ? obj.transform.position
+                        : obj.transform.localPosition;
+                    var r = obj.SyncSpace == NetSyncTransformApplier.SpaceMode.World
+                        ? obj.transform.rotation
+                        : obj.transform.localRotation;
+
+                    _dirtyEntries.Add(new ObjectTransformEntry(obj.ObjectId, (ushort)localClientNo, t, r));
+                }
+
+                if (_dirtyEntries.Count == 0) return SendOutcome.Sent();
+
+                // Only-on-change filtering with heartbeat
+                var signature = BinarySerializer.ComputeObjectPoseSignature(_dirtyEntries);
+                var now = Time.time;
+                if (_hasLastSignature &&
+                    signature == _lastSignature &&
+                    now - _lastSentTime < HEARTBEAT_INTERVAL_SECONDS)
+                {
+                    return SendOutcome.Sent();
+                }
+
+                _poseSeq++;
+
+                // Serialize
+                var required = HEADER_SIZE + _dirtyEntries.Count * BYTES_PER_OBJECT;
+                _buf.EnsureCapacity(required);
+                _buf.Stream.Position = 0;
+
+                BinarySerializer.SerializeClientObjectsInto(_buf.Writer, _poseSeq, _dirtyEntries);
+                _buf.Writer.Flush();
+
+                var length = (int)_buf.Stream.Position;
+                var payload = new byte[length];
+                Buffer.BlockCopy(_buf.GetBufferUnsafe(), 0, payload, 0, length);
+
+                _connectionManager.SetLatestObjectTransform(roomId, payload);
+                _hasLastSignature = true;
+                _lastSignature = signature;
+                _lastSentTime = now;
+                _messagesSent++;
+                return SendOutcome.Sent();
+            }
+            catch (Exception ex)
+            {
+                Debug.LogError($"[ObjectSyncManager] SendOwnedObjects: {ex.Message}");
+                return SendOutcome.Fatal(ex.Message);
+            }
+        }
+
+        /// <summary>
+        /// Process incoming room object data from server.
+        /// Routes transforms to matching NetSyncObject instances.
+        /// </summary>
+        public void ProcessRoomObjects(RoomObjectData roomData)
+        {
+            if (roomData == null || roomData.objects == null) return;
+
+            for (int i = 0; i < roomData.objects.Count; i++)
+            {
+                var entry = roomData.objects[i];
+                if (!_registry.TryGetValue(entry.objectId, out var obj)) continue;
+                if (obj == null) continue;
+
+                // Update ownership from server broadcast
+                obj.ApplyOwnershipFromServer(entry.ownerClientNo);
+
+                // Only apply transform for remote objects (not locally owned)
+                if (!obj.IsLocallyOwned)
+                {
+                    obj.ApplyRemoteTransform(roomData.broadcastTime, entry.position, entry.rotation);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Process incoming ownership change from server.
+        /// </summary>
+        public void ProcessOwnershipChange(OwnershipChangeData data)
+        {
+            if (!_registry.TryGetValue(data.objectId, out var obj)) return;
+            if (obj == null) return;
+            obj.ApplyOwnershipChange(data.newOwnerClientNo, data.seq);
+        }
+
+        /// <summary>
+        /// Send an ownership change request to the server via control queue.
+        /// </summary>
+        public bool SendOwnershipChange(string roomId, ushort objectId, ushort newOwnerClientNo, ushort seq)
+        {
+            var payload = BinarySerializer.SerializeOwnershipChange(objectId, newOwnerClientNo, seq);
+            return _connectionManager.TryEnqueueControl(roomId, payload);
+        }
+
+        /// <summary>
+        /// Release all objects owned by a disconnected client.
+        /// Called by the host (lowest alive clientNo) when a peer disconnects.
+        /// </summary>
+        public void HandleClientDisconnect(int disconnectedClientNo, string roomId, int localClientNo, int[] aliveClients)
+        {
+            if (aliveClients == null || aliveClients.Length == 0) return;
+
+            // Only the host (lowest alive clientNo) performs cleanup
+            int hostClientNo = aliveClients[0];
+            for (int i = 1; i < aliveClients.Length; i++)
+            {
+                if (aliveClients[i] < hostClientNo)
+                    hostClientNo = aliveClients[i];
+            }
+            if (localClientNo != hostClientNo) return;
+
+            foreach (var kv in _registry)
+            {
+                var obj = kv.Value;
+                if (obj == null) continue;
+                if (obj.OwnerClientNo == disconnectedClientNo)
+                {
+                    var newSeq = (ushort)(obj.OwnershipSeq + 1);
+                    obj.ApplyOwnershipChange(0, newSeq);
+                    SendOwnershipChange(roomId, obj.ObjectId, 0, newSeq);
+                }
+            }
+        }
+
+        public void Dispose()
+        {
+            _buf?.Dispose();
+        }
+    }
+}

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/ObjectSyncManager.cs.meta
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/ObjectSyncManager.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 35aa5acffab4d447f9d993a66d071bf5

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/OfflineConnectionManager.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/OfflineConnectionManager.cs
@@ -32,6 +32,7 @@ namespace Styly.NetSync
         public void ClearConnectionError() { }
         public bool TryEnqueueControl(string roomId, byte[] payload) => true;
         public void SetLatestTransform(string roomId, byte[] payload) { }
+        public void SetLatestObjectTransform(string roomId, byte[] payload) { }
         public void StartDiscovery(ServerDiscoveryManager discoveryManager, string roomId) { }
         public void ProcessDiscoveredServer(string serverAddress, int dealerPort, int subPort) { }
     }

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/NetSyncManager.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/NetSyncManager.cs
@@ -766,13 +766,8 @@ namespace Styly.NetSync
         private void OnRemoteAvatarDisconnected(int clientNo)
         {
             OnAvatarDisconnected?.Invoke(clientNo);
-
-            // Release objects owned by the disconnected client (host-only cleanup)
-            if (_objectSyncManager != null)
-            {
-                var aliveClients = GetAliveClients(true);
-                _objectSyncManager.HandleClientDisconnect(clientNo, _roomId, _clientNo, aliveClients);
-            }
+            // Object ownership cleanup on disconnect is handled server-side
+            // with proper seq incrementing (MSG_OBJECT_OWNER broadcast).
         }
 
         private void OnRPCReceivedHandler(int senderClientNo, string functionName, string[] args)
@@ -1026,6 +1021,7 @@ namespace Styly.NetSync
         {
             if (!_connectionManager.IsConnected || _connectionManager.IsConnectionError) return;
             if (_objectSyncManager == null || _clientNo <= 0) return;
+            if (!_objectSyncManager.ShouldSend(Time.time)) return;
 
             _objectSyncManager.SendOwnedObjects(_roomId, _clientNo);
         }

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/NetSyncManager.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/NetSyncManager.cs
@@ -214,6 +214,34 @@ namespace Styly.NetSync
             return arr;
         }
 
+        // === Object Sync Public API ===
+
+        /// <summary>
+        /// Register a NetSyncObject with the object sync system.
+        /// Called automatically by NetSyncObject.OnEnable.
+        /// </summary>
+        public void RegisterNetSyncObject(NetSyncObject obj)
+        {
+            _objectSyncManager?.Register(obj);
+        }
+
+        /// <summary>
+        /// Unregister a NetSyncObject from the object sync system.
+        /// Called automatically by NetSyncObject.OnDisable.
+        /// </summary>
+        public void UnregisterNetSyncObject(NetSyncObject obj)
+        {
+            _objectSyncManager?.Unregister(obj);
+        }
+
+        /// <summary>
+        /// Get a registered NetSyncObject by its object ID.
+        /// </summary>
+        public NetSyncObject GetNetSyncObject(ushort objectId)
+        {
+            return _objectSyncManager?.GetObject(objectId);
+        }
+
         /// <summary>
         /// Set the room ID at runtime and reconnect to the new room.
         /// This performs a hard reconnection, clearing all room-scoped state and
@@ -271,6 +299,7 @@ namespace Styly.NetSync
         private AvatarManager _avatarManager;
         private RPCManager _rpcManager;
         private TransformSyncManager _transformSyncManager;
+        private ObjectSyncManager _objectSyncManager;
         private MessageProcessor _messageProcessor;
         private ServerDiscoveryManager _discoveryManager;
         private NetworkVariableManager _networkVariableManager;
@@ -536,6 +565,9 @@ namespace Styly.NetSync
 
                 // Send transform updates (lower priority, can be dropped if backpressured)
                 SendTransformUpdates();
+
+                // Send object transform updates (same priority as avatar, after avatar)
+                SendObjectTransformUpdates();
             }
 
             // Check for initial sync timeout (important for rooms with no variables)
@@ -601,6 +633,7 @@ namespace Styly.NetSync
             _avatarManager = new AvatarManager(_enableDebugLogs);
             _rpcManager = new RPCManager(_connectionManager, _deviceId, this);
             _transformSyncManager = new TransformSyncManager(_connectionManager, _deviceId, _transformSendRate);
+            _objectSyncManager = new ObjectSyncManager(_connectionManager, _transformSendRate);
             _discoveryManager = new ServerDiscoveryManager(_enableDebugLogs);
             _discoveryManager.SetServerDiscoveryPort(ServerDiscoveryPort);
             _networkVariableManager = new NetworkVariableManager(_connectionManager, _deviceId, this);
@@ -733,6 +766,13 @@ namespace Styly.NetSync
         private void OnRemoteAvatarDisconnected(int clientNo)
         {
             OnAvatarDisconnected?.Invoke(clientNo);
+
+            // Release objects owned by the disconnected client (host-only cleanup)
+            if (_objectSyncManager != null)
+            {
+                var aliveClients = GetAliveClients(true);
+                _objectSyncManager.HandleClientDisconnect(clientNo, _roomId, _clientNo, aliveClients);
+            }
         }
 
         private void OnRPCReceivedHandler(int senderClientNo, string functionName, string[] args)
@@ -980,6 +1020,41 @@ namespace Styly.NetSync
             }
         }
 
+        // === Object Sync Internal Methods ===
+
+        private void SendObjectTransformUpdates()
+        {
+            if (!_connectionManager.IsConnected || _connectionManager.IsConnectionError) return;
+            if (_objectSyncManager == null || _clientNo <= 0) return;
+
+            _objectSyncManager.SendOwnedObjects(_roomId, _clientNo);
+        }
+
+        /// <summary>
+        /// Send an ownership change to the server. Called by NetSyncObject.
+        /// </summary>
+        internal void SendObjectOwnershipChange(ushort objectId, ushort newOwnerClientNo, ushort seq)
+        {
+            if (_objectSyncManager == null) return;
+            _objectSyncManager.SendOwnershipChange(_roomId, objectId, newOwnerClientNo, seq);
+        }
+
+        /// <summary>
+        /// Process incoming room object transforms from server. Called by MessageProcessor.
+        /// </summary>
+        internal void ProcessRoomObjects(RoomObjectData roomData)
+        {
+            _objectSyncManager?.ProcessRoomObjects(roomData);
+        }
+
+        /// <summary>
+        /// Process incoming ownership change from server. Called by MessageProcessor.
+        /// </summary>
+        internal void ProcessOwnershipChange(OwnershipChangeData data)
+        {
+            _objectSyncManager?.ProcessOwnershipChange(data);
+        }
+
         private void LogStatistics()
         {
             // Statistics logging is currently disabled
@@ -1129,6 +1204,8 @@ namespace Styly.NetSync
             _rpcManager = null;
             _transformSyncManager?.Dispose();
             _transformSyncManager = null;
+            _objectSyncManager?.Dispose();
+            _objectSyncManager = null;
             _networkVariableManager?.Dispose();
             _networkVariableManager = null;
         }

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/NetSyncObject.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/NetSyncObject.cs
@@ -1,0 +1,260 @@
+// NetSyncObject.cs - High-frequency transform synchronization component for non-avatar objects
+using System;
+using UnityEngine;
+using UnityEngine.Events;
+
+namespace Styly.NetSync
+{
+    /// <summary>
+    /// Attach to any scene-placed GameObject to synchronize its transform across the network.
+    /// Supports configurable ownership (LastTouch / Explicit) and smooth interpolation for remote objects.
+    /// </summary>
+    public class NetSyncObject : MonoBehaviour
+    {
+        [Header("Network Settings")]
+        [Tooltip("Unique object ID within the scene (1-1023). Must be unique across all NetSyncObjects.")]
+        [SerializeField] private ushort _objectId;
+
+        [Tooltip("Ownership mode: LastTouch = grab to own, Explicit = transfer via API only.")]
+        [SerializeField] private ObjectOwnershipMode _ownershipMode = ObjectOwnershipMode.LastTouch;
+
+        [Tooltip("Whether to sync in world space or local space.")]
+        [SerializeField] private NetSyncTransformApplier.SpaceMode _syncSpace = NetSyncTransformApplier.SpaceMode.World;
+
+        [Header("Events")]
+        [Tooltip("Fired when ownership changes. Args: (oldOwnerClientNo, newOwnerClientNo)")]
+        public UnityEvent<int, int> OnOwnershipChanged;
+
+        // Runtime state
+        private int _ownerClientNo;
+        private ushort _ownershipSeq;
+        private NetSyncManager _netSyncManager;
+        private NetSyncTransformApplier _applier;
+        private bool _applierInitialized;
+
+        /// <summary>
+        /// Unique object ID for network identification.
+        /// </summary>
+        public ushort ObjectId => _objectId;
+
+        /// <summary>
+        /// Current owner's client number. 0 = unowned.
+        /// </summary>
+        public int OwnerClientNo => _ownerClientNo;
+
+        /// <summary>
+        /// Monotonically increasing sequence number for ownership conflict resolution.
+        /// </summary>
+        internal ushort OwnershipSeq => _ownershipSeq;
+
+        /// <summary>
+        /// True if the local client is the current owner.
+        /// </summary>
+        public bool IsLocallyOwned
+        {
+            get
+            {
+                var mgr = NetSyncManager.Instance;
+                return mgr != null && _ownerClientNo > 0 && _ownerClientNo == mgr.ClientNo;
+            }
+        }
+
+        /// <summary>
+        /// True if no client currently owns this object.
+        /// </summary>
+        public bool IsUnowned => _ownerClientNo == 0;
+
+        /// <summary>
+        /// Configured ownership mode.
+        /// </summary>
+        public ObjectOwnershipMode OwnershipMode => _ownershipMode;
+
+        /// <summary>
+        /// Configured sync space.
+        /// </summary>
+        internal NetSyncTransformApplier.SpaceMode SyncSpace => _syncSpace;
+
+        /// <summary>
+        /// Request ownership of this object.
+        /// In LastTouch mode, ownership is claimed immediately (optimistic).
+        /// In Explicit mode, the current owner must transfer ownership instead.
+        /// </summary>
+        /// <returns>True if ownership was claimed or already owned locally.</returns>
+        public bool RequestOwnership()
+        {
+            if (IsLocallyOwned) return true;
+
+            var mgr = NetSyncManager.Instance;
+            if (mgr == null || mgr.ClientNo <= 0) return false;
+
+            if (_ownershipMode == ObjectOwnershipMode.Explicit && _ownerClientNo > 0)
+            {
+                // In Explicit mode, cannot claim if already owned by someone else
+                return false;
+            }
+
+            var newSeq = (ushort)(_ownershipSeq + 1);
+            SetOwnership(mgr.ClientNo, newSeq);
+            mgr.SendObjectOwnershipChange(_objectId, (ushort)mgr.ClientNo, newSeq);
+            return true;
+        }
+
+        /// <summary>
+        /// Release ownership, setting the object to unowned.
+        /// Only succeeds if the local client is the current owner.
+        /// </summary>
+        public void ReleaseOwnership()
+        {
+            if (!IsLocallyOwned) return;
+
+            var mgr = NetSyncManager.Instance;
+            if (mgr == null) return;
+
+            var newSeq = (ushort)(_ownershipSeq + 1);
+            SetOwnership(0, newSeq);
+            mgr.SendObjectOwnershipChange(_objectId, 0, newSeq);
+        }
+
+        /// <summary>
+        /// Transfer ownership to a specific client.
+        /// Only succeeds if the local client is the current owner.
+        /// </summary>
+        public void TransferOwnership(int targetClientNo)
+        {
+            if (!IsLocallyOwned) return;
+            if (targetClientNo <= 0) return;
+
+            var mgr = NetSyncManager.Instance;
+            if (mgr == null) return;
+
+            var newSeq = (ushort)(_ownershipSeq + 1);
+            SetOwnership(targetClientNo, newSeq);
+            mgr.SendObjectOwnershipChange(_objectId, (ushort)targetClientNo, newSeq);
+        }
+
+        /// <summary>
+        /// Apply an ownership change from the server broadcast.
+        /// Updates ownerClientNo if the incoming data is authoritative.
+        /// </summary>
+        internal void ApplyOwnershipFromServer(ushort ownerClientNo)
+        {
+            if (_ownerClientNo != ownerClientNo)
+            {
+                // Server broadcast is informational; ownership change messages are authoritative
+                // Only update if we don't have a pending local ownership claim
+            }
+        }
+
+        /// <summary>
+        /// Apply an ownership change message (MSG_OBJECT_OWNER).
+        /// Uses conflict resolution: higher seq wins; on tie, lower clientNo wins.
+        /// </summary>
+        internal void ApplyOwnershipChange(int newOwnerClientNo, ushort newSeq)
+        {
+            if (newSeq > _ownershipSeq)
+            {
+                SetOwnership(newOwnerClientNo, newSeq);
+            }
+            else if (newSeq == _ownershipSeq && newOwnerClientNo != _ownerClientNo)
+            {
+                // Conflict: same seq, different owner. Lower clientNo wins.
+                if (newOwnerClientNo > 0 && (newOwnerClientNo < _ownerClientNo || _ownerClientNo == 0))
+                {
+                    SetOwnership(newOwnerClientNo, newSeq);
+                }
+                else if (IsLocallyOwned)
+                {
+                    // We win the conflict — re-assert with seq+1
+                    var mgr = NetSyncManager.Instance;
+                    if (mgr != null)
+                    {
+                        var reassertSeq = (ushort)(_ownershipSeq + 1);
+                        _ownershipSeq = reassertSeq;
+                        mgr.SendObjectOwnershipChange(_objectId, (ushort)_ownerClientNo, reassertSeq);
+                    }
+                }
+            }
+            // else newSeq < _ownershipSeq: stale update, ignore
+        }
+
+        /// <summary>
+        /// Apply a remote transform snapshot for interpolation.
+        /// Called by ObjectSyncManager when receiving MSG_ROOM_OBJECTS.
+        /// </summary>
+        internal void ApplyRemoteTransform(double poseTime, Vector3 position, Quaternion rotation)
+        {
+            EnsureApplierInitialized();
+            if (_applier != null)
+            {
+                _applier.AddSingleSnapshot(poseTime, 0, position, rotation);
+            }
+        }
+
+        private void SetOwnership(int newOwnerClientNo, ushort newSeq)
+        {
+            var oldOwner = _ownerClientNo;
+            _ownerClientNo = newOwnerClientNo;
+            _ownershipSeq = newSeq;
+
+            if (oldOwner != newOwnerClientNo)
+            {
+                if (OnOwnershipChanged != null)
+                {
+                    OnOwnershipChanged.Invoke(oldOwner, newOwnerClientNo);
+                }
+            }
+        }
+
+        private void EnsureApplierInitialized()
+        {
+            if (_applierInitialized) return;
+            _applierInitialized = true;
+
+            var mgr = NetSyncManager.Instance;
+            if (mgr == null) return;
+
+            _applier = new NetSyncTransformApplier();
+            _applier.InitializeForSingle(
+                transform,
+                _syncSpace,
+                mgr.TimeEstimator,
+                null, // Use default smoothing settings
+                mgr.TransformSendRate);
+        }
+
+        private void OnEnable()
+        {
+            var mgr = NetSyncManager.Instance;
+            if (mgr != null)
+            {
+                mgr.RegisterNetSyncObject(this);
+            }
+        }
+
+        private void OnDisable()
+        {
+            var mgr = NetSyncManager.Instance;
+            if (mgr != null)
+            {
+                mgr.UnregisterNetSyncObject(this);
+            }
+        }
+
+        private void Update()
+        {
+            // For remote objects: apply interpolated transform
+            if (!IsLocallyOwned && _applier != null)
+            {
+                _applier.Tick(Time.deltaTime, Time.timeAsDouble);
+            }
+        }
+
+        private void OnValidate()
+        {
+            if (_objectId == 0)
+            {
+                Debug.LogWarning($"[NetSyncObject] ObjectId is 0 on '{gameObject.name}'. Assign a unique ID (1-1023).", this);
+            }
+        }
+    }
+}

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/NetSyncObject.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/NetSyncObject.cs
@@ -23,7 +23,7 @@ namespace Styly.NetSync
 
         [Header("Events")]
         [Tooltip("Fired when ownership changes. Args: (oldOwnerClientNo, newOwnerClientNo)")]
-        public UnityEvent<int, int> OnOwnershipChanged;
+        public UnityEvent<int, int> OnOwnershipChanged = new UnityEvent<int, int>();
 
         // Runtime state
         private int _ownerClientNo;
@@ -140,8 +140,13 @@ namespace Styly.NetSync
         {
             if (_ownerClientNo != ownerClientNo)
             {
-                // Server broadcast is informational; ownership change messages are authoritative
-                // Only update if we don't have a pending local ownership claim
+                // Server room broadcast acts as a fallback reconciliation path.
+                // Accept if we have no local ownership (unowned or not locally owned).
+                // This ensures late-joining clients converge on the correct owner.
+                if (!IsLocallyOwned)
+                {
+                    SetOwnership(ownerClientNo, _ownershipSeq);
+                }
             }
         }
 

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/NetSyncObject.cs.meta
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/NetSyncObject.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 80232c5c0430a416ca8f0b4ef8d3a8ca


### PR DESCRIPTION
- Added BinarySerializer methods for serializing and deserializing object transforms and ownership changes.
- Introduced ObjectSyncManager to manage object transform synchronization and ownership.
- Created NetSyncObject component for scene objects to synchronize their transforms and manage ownership.
- Updated ConnectionManager and IConnectionManager to handle object transform packets.
- Enhanced MessageProcessor to process room object data and ownership changes.
- Implemented methods in NetSyncManager for registering, unregistering, and processing object synchronization.
- Added support for LastTouch and Explicit ownership modes for objects.