### PR TITLE
refactor(HandPoseNormalizer): remove debug log output to clean up console messages

### DIFF
--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/HandPoseNormalizer.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/HandPoseNormalizer.cs
@@ -172,10 +172,6 @@ namespace Styly.NetSync.Internal
                 _selfTransform.localPosition = _handTransform.localPosition;
                 _selfTransform.localRotation = _handTransform.localRotation;
 
-                if (_enableDebugLog)
-                {
-                    Debug.Log($"[HandPoseNormalizer] {_handedness}: pos={_selfTransform.localPosition:F4}, rot={_selfTransform.localRotation.eulerAngles:F2}");
-                }
             }
             else
             {


### PR DESCRIPTION
This pull request makes a minor update to the `HandPoseNormalizer` class by removing a debug log statement from the `LateUpdate` method. This change helps to clean up the console output during runtime. 

- Removed a conditional debug log that printed the hand's position and rotation, reducing unnecessary log noise in production (`HandPoseNormalizer.cs`)