### PR TITLE
fix(NetSyncManagerEditor): prevent editing advanced properties while playing

### DIFF
--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Editor/NetSyncManagerEditor.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Editor/NetSyncManagerEditor.cs
@@ -87,24 +87,27 @@ namespace Styly.NetSync.Editor
                 {
                     EditorGUI.indentLevel++;
 
-                    foreach (var propertyName in AdvancedPropertyOrder)
+                    using (new EditorGUI.DisabledScope(EditorApplication.isPlaying))
                     {
-                        if (!advancedPropertyPaths.Contains(propertyName))
+                        foreach (var propertyName in AdvancedPropertyOrder)
                         {
-                            continue;
-                        }
-
-                        var property = serializedObject.FindProperty(propertyName);
-                        if (property != null)
-                        {
-                            // Custom label for transform send rate
-                            if (propertyName == "_transformSendRate")
+                            if (!advancedPropertyPaths.Contains(propertyName))
                             {
-                                EditorGUILayout.PropertyField(property, new GUIContent("Transform Send Rate (Hz)", property.tooltip), true);
+                                continue;
                             }
-                            else
+
+                            var property = serializedObject.FindProperty(propertyName);
+                            if (property != null)
                             {
-                                EditorGUILayout.PropertyField(property, true);
+                                // Custom label for transform send rate
+                                if (propertyName == "_transformSendRate")
+                                {
+                                    EditorGUILayout.PropertyField(property, new GUIContent("Transform Send Rate (Hz)", property.tooltip), true);
+                                }
+                                else
+                                {
+                                    EditorGUILayout.PropertyField(property, true);
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
This pull request introduces a small but important change to the `DrawAdvancedSection` method in `NetSyncManagerEditor.cs`. The main update ensures that the advanced properties section in the Unity Editor is disabled (read-only) while the application is playing, preventing unintended edits during play mode.

- **Editor usability and safety:**
  * Wrapped the advanced properties UI in an `EditorGUI.DisabledScope` that is active during play mode, making the section read-only when the application is running. [[1]](diffhunk://#diff-e4c9c20a4fde9a7f949afaf096dee68dd4e5cbaf55d67c2b4a8ec8a67c09775dR90-R91) [[2]](diffhunk://#diff-e4c9c20a4fde9a7f949afaf096dee68dd4e5cbaf55d67c2b4a8ec8a67c09775dR113)