### PR TITLE
feat: implement thread-safe logging and main thread action draining in connection management

### DIFF
--- a/STYLY-NetSync-Server/src/styly_netsync/server.py
+++ b/STYLY-NetSync-Server/src/styly_netsync/server.py
@@ -979,11 +979,17 @@ class NetSyncServer:
         self._rest_server = None
 
         if self.receive_thread:
-            self.receive_thread.join()
-            logger.info("Receive thread stopped")
+            self.receive_thread.join(timeout=5.0)
+            if self.receive_thread.is_alive():
+                logger.warning("Receive thread did not stop within timeout")
+            else:
+                logger.info("Receive thread stopped")
         if self.periodic_thread:
-            self.periodic_thread.join()
-            logger.info("Periodic thread stopped")
+            self.periodic_thread.join(timeout=5.0)
+            if self.periodic_thread.is_alive():
+                logger.warning("Periodic thread did not stop within timeout")
+            else:
+                logger.info("Periodic thread stopped")
 
         # Stop Publisher thread
         self._publisher_running = False
@@ -1000,8 +1006,11 @@ class NetSyncServer:
             except Full:
                 pass
         if self._publisher_thread:
-            self._publisher_thread.join()
-            logger.info("Publisher thread stopped")
+            self._publisher_thread.join(timeout=5.0)
+            if self._publisher_thread.is_alive():
+                logger.warning("Publisher thread did not stop within timeout")
+            else:
+                logger.info("Publisher thread stopped")
 
         if self.router:
             self.router.close()
@@ -1743,19 +1752,26 @@ class NetSyncServer:
                 # Log status periodically
                 if current_time - last_log >= self.STATUS_LOG_INTERVAL:
                     # Count normal and stealth clients separately
+                    # Take snapshot under lock to avoid RuntimeError from concurrent mutation
+                    with self._rooms_lock:
+                        rooms_snapshot = {
+                            rid: list(clients.values())
+                            for rid, clients in self.rooms.items()
+                        }
+                        total_device_ids = len(self.device_id_last_seen)
+                        num_rooms = len(self.rooms)
+
                     normal_clients = 0
                     stealth_clients = 0
-                    for room in self.rooms.values():
-                        for client in room.values():
+                    for clients in rooms_snapshot.values():
+                        for client in clients:
                             if client.get("is_stealth", False):
                                 stealth_clients += 1
                             else:
                                 normal_clients += 1
 
-                    total_device_ids = len(self.device_id_last_seen)
-
                     logger.info(
-                        f"Status: {len(self.rooms)} rooms, {normal_clients} normal clients, "
+                        f"Status: {num_rooms} rooms, {normal_clients} normal clients, "
                         f"{stealth_clients} stealth clients, "
                         f"{total_device_ids} tracked device IDs"
                     )

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/ConnectionManager.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/ConnectionManager.cs
@@ -603,7 +603,14 @@ namespace Styly.NetSync
 
             while (_pendingMainThreadActions.TryDequeue(out var action))
             {
-                action();
+                try
+                {
+                    action();
+                }
+                catch (Exception ex)
+                {
+                    Debug.LogException(ex);
+                }
             }
         }
     }

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/ConnectionManager.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/ConnectionManager.cs
@@ -27,6 +27,13 @@ namespace Styly.NetSync
         private volatile Exception _lastException;
         private long _lastExceptionAtUnixMs;
 
+        // Thread-safe queues for cross-thread logging and callbacks
+        // Network thread enqueues; main thread drains via DrainMainThreadActions()
+        private readonly ConcurrentQueue<(LogLevel level, string message)> _pendingLogs = new();
+        private readonly ConcurrentQueue<Action> _pendingMainThreadActions = new();
+
+        private enum LogLevel { Info, Warning, Error }
+
         public SubscriberSocket SubSocket => _subSocket;
         public bool IsConnected => _dealerSocket != null && _subSocket != null && !_connectionError;
         public bool IsConnectionError => _connectionError;
@@ -129,24 +136,16 @@ namespace Styly.NetSync
             _shouldStop = true;
             ClearOutgoingBuffers();
 
-            // Dispose sockets
-            if (_subSocket != null)
-            {
-                _subSocket.Dispose();
-            }
-            if (_dealerSocket != null)
-            {
-                _dealerSocket.Dispose();
-            }
-
-            _subSocket = null;
-            _dealerSocket = null;
-
-            // Wait for receive thread to exit (unless we're on the receive thread)
+            // Wait for receive thread to exit first — the using-var blocks inside
+            // NetworkLoop will dispose the sockets safely when the thread exits.
+            // Do NOT dispose sockets here; the network thread may still be using them.
             if (Thread.CurrentThread != _receiveThread)
             {
                 WaitThreadExit(_receiveThread, 1000);
             }
+
+            _subSocket = null;
+            _dealerSocket = null;
             _receiveThread = null;
 
             // OS-specific cleanup
@@ -246,7 +245,7 @@ namespace Styly.NetSync
                 dealer.Connect(dealerAddr);
                 _dealerSocket = dealer;
 
-                DebugLog($"[Thread] DEALER connected → {dealerAddr}");
+                if (_enableDebugLogs) _pendingLogs.Enqueue((LogLevel.Info, $"[ConnectionManager] [Thread] DEALER connected → {dealerAddr}"));
 
                 // Subscriber (for receiving)
                 using var sub = new SubscriberSocket();
@@ -259,15 +258,12 @@ namespace Styly.NetSync
                 sub.Subscribe(roomId);
                 _subSocket = sub;
 
-                DebugLog($"[Thread] SUB connected    → {subAddr}");
+                if (_enableDebugLogs) _pendingLogs.Enqueue((LogLevel.Info, $"[ConnectionManager] [Thread] SUB connected    → {subAddr}"));
 
                 var roomIdBytes = Encoding.UTF8.GetBytes(roomId);
 
-                // Notify connection established
-                if (OnConnectionEstablished != null)
-                {
-                    OnConnectionEstablished.Invoke();
-                }
+                // Queue connection callback for main thread instead of invoking directly
+                _pendingMainThreadActions.Enqueue(() => OnConnectionEstablished?.Invoke());
 
                 while (!_shouldStop)
                 {
@@ -304,7 +300,7 @@ namespace Styly.NetSync
                         }
                         catch (Exception ex)
                         {
-                            Debug.LogError($"Transform parse error: {ex.Message}");
+                            _pendingLogs.Enqueue((LogLevel.Error, $"Transform parse error: {ex.Message}"));
                         }
                         receivedAny = true;
                     }
@@ -329,7 +325,7 @@ namespace Styly.NetSync
                             }
                             catch (Exception ex)
                             {
-                                Debug.LogError($"Control message parse error: {ex.Message}");
+                                _pendingLogs.Enqueue((LogLevel.Error, $"Control message parse error: {ex.Message}"));
                             }
                         }
                         receivedAny = true;
@@ -353,24 +349,24 @@ namespace Styly.NetSync
                     Volatile.Write(ref _lastExceptionAtUnixMs, timestamp);
                     _lastException = ex_local;
                     
-                    // Log detailed exception context
+                    // Queue log for main thread (Debug.Log* is not safe from background threads)
                     var threadId = Thread.CurrentThread.ManagedThreadId;
                     var endpoint = $"{serverAddress}:{dealerPort}/{subPort}";
-                    Debug.LogError($"[ConnectionManager] Network thread error. " +
-                                   $"Type={ex_local.GetType().Name} Message={ex_local.Message} " +
-                                   $"Endpoint={endpoint} ThreadId={threadId} " +
-                                   $"Time={timestamp}");
-                    
+                    _pendingLogs.Enqueue((LogLevel.Error,
+                        $"[ConnectionManager] Network thread error. " +
+                        $"Type={ex_local.GetType().Name} Message={ex_local.Message} " +
+                        $"Endpoint={endpoint} ThreadId={threadId} " +
+                        $"Time={timestamp}"));
+
 #if NETSYNC_DEBUG_CONNECTION
-                    // Verbose logging: include stack trace
-                    Debug.LogError($"[ConnectionManager] Stack trace: {ex_local.StackTrace}");
+                    _pendingLogs.Enqueue((LogLevel.Error,
+                        $"[ConnectionManager] Stack trace: {ex_local.StackTrace}"));
 #endif
-                    
+
                     _connectionError = true;
-                    if (OnConnectionError != null)
-                    {
-                        OnConnectionError.Invoke(ex_local.Message);
-                    }
+                    // Queue callback for main thread instead of invoking directly
+                    var errorMessage = ex_local.Message;
+                    _pendingMainThreadActions.Enqueue(() => OnConnectionError?.Invoke(errorMessage));
                 }
             }
         }
@@ -409,7 +405,7 @@ namespace Styly.NetSync
                 // TTL check - skip expired packets
                 if (now - packet.EnqueuedAt > CTRL_TTL_SECONDS)
                 {
-                    Debug.LogWarning($"[ConnectionManager] Control packet expired (TTL {CTRL_TTL_SECONDS}s exceeded)");
+                    _pendingLogs.Enqueue((LogLevel.Warning, $"[ConnectionManager] Control packet expired (TTL {CTRL_TTL_SECONDS}s exceeded)"));
                     continue;
                 }
 
@@ -587,6 +583,28 @@ namespace Styly.NetSync
             // (NetSyncManager has already copied it to _pendingConnectionException)
             _lastException = null;
             // Keep timestamp for basic diagnostics
+        }
+
+        /// <summary>
+        /// Drain pending logs and callbacks queued by the network thread.
+        /// Must be called from the main Unity thread (e.g., in Update).
+        /// </summary>
+        public void DrainMainThreadActions()
+        {
+            while (_pendingLogs.TryDequeue(out var entry))
+            {
+                switch (entry.level)
+                {
+                    case LogLevel.Error: Debug.LogError(entry.message); break;
+                    case LogLevel.Warning: Debug.LogWarning(entry.message); break;
+                    default: Debug.Log(entry.message); break;
+                }
+            }
+
+            while (_pendingMainThreadActions.TryDequeue(out var action))
+            {
+                action();
+            }
         }
     }
 }

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/IConnectionManager.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/IConnectionManager.cs
@@ -14,6 +14,9 @@ namespace Styly.NetSync
         bool IsConnectionError { get; }
         void ClearConnectionError();
 
+        // Main-thread drain for logs and callbacks queued by the network thread
+        void DrainMainThreadActions();
+
         // Exception diagnostics
         Exception LastException { get; }
         long LastExceptionAtUnixMs { get; }

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/MessageProcessor.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/MessageProcessor.cs
@@ -10,6 +10,9 @@ namespace Styly.NetSync
 {
     internal class MessageProcessor
     {
+        // Thread-safe log queue: network thread enqueues, main thread drains in ProcessMessageQueue
+        private readonly ConcurrentQueue<(bool isError, string message)> _pendingLogs = new();
+
         // General-purpose message queue (RPC, variable sync, etc.)
         private readonly ConcurrentQueue<NetworkMessage> _messageQueue = new();
 
@@ -80,7 +83,7 @@ namespace Styly.NetSync
                 var (msgType, data) = BinarySerializer.Deserialize(payload);
                 if (data == null)
                 {
-                    if (_logNetworkTraffic) { Debug.LogWarning("Deserialize => null"); }
+                    if (_logNetworkTraffic) { _pendingLogs.Enqueue((false, "Deserialize => null")); }
                     return;
                 }
 
@@ -128,25 +131,23 @@ namespace Styly.NetSync
                         break;
 
                     default:
-                        if (_logNetworkTraffic) { Debug.LogWarning($"Unhandled type: {msgType}"); }
+                        if (_logNetworkTraffic) { _pendingLogs.Enqueue((false, $"Unhandled type: {msgType}")); }
                         break;
                 }
             }
             catch (Exception ex)
             {
-                // Log error with more context for debugging
-                Debug.LogError($"Binary parse error: {ex.Message}");
+                // Queue logs for main thread (Debug.Log* is not safe from background threads)
+                _pendingLogs.Enqueue((true, $"Binary parse error: {ex.Message}"));
 
-                // Log first few bytes of payload for debugging
                 if (payload != null && payload.Length > 0)
                 {
                     var hexDump = BitConverter.ToString(payload.Take(Math.Min(32, payload.Length)).ToArray());
-                    Debug.LogError($"First bytes of problematic payload: {hexDump} (length: {payload.Length})");
+                    _pendingLogs.Enqueue((true, $"First bytes of problematic payload: {hexDump} (length: {payload.Length})"));
 
-                    // Log the message type byte specifically
                     if (payload.Length >= 1)
                     {
-                        Debug.LogError($"Message type byte: {payload[0]} (0x{payload[0]:X2})");
+                        _pendingLogs.Enqueue((true, $"Message type byte: {payload[0]} (0x{payload[0]:X2})"));
                     }
                 }
             }
@@ -154,6 +155,15 @@ namespace Styly.NetSync
 
         public void ProcessMessageQueue(AvatarManager avatarManager, RPCManager rpcManager, string localDeviceId, NetSyncManager netSyncManager = null, NetworkVariableManager networkVariableManager = null)
         {
+            // Drain logs queued by the network thread
+            while (_pendingLogs.TryDequeue(out var logEntry))
+            {
+                if (logEntry.isError)
+                    Debug.LogError(logEntry.message);
+                else
+                    Debug.LogWarning(logEntry.message);
+            }
+
             // First, flush room transforms (bounded by MaxRoomTransformUpdatesQueueSize)
             // Purpose: ensure latest room state is applied promptly without starving other messages.
             while (_roomTransformQueue.TryDequeue(out var room))

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/OfflineConnectionManager.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/OfflineConnectionManager.cs
@@ -30,6 +30,7 @@ namespace Styly.NetSync
         }
 
         public void ClearConnectionError() { }
+        public void DrainMainThreadActions() { }
         public bool TryEnqueueControl(string roomId, byte[] payload) => true;
         public void SetLatestTransform(string roomId, byte[] payload) { }
         public void StartDiscovery(ServerDiscoveryManager discoveryManager, string roomId) { }

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/NetSyncManager.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/NetSyncManager.cs
@@ -515,6 +515,12 @@ namespace Styly.NetSync
 
             HandleDiscovery();
 
+            // Drain network-thread logs and callbacks on main thread
+            if (_connectionManager != null)
+            {
+                _connectionManager.DrainMainThreadActions();
+            }
+
             // Process pending connection errors BEFORE reconnection logic
             ProcessPendingConnectionErrorOnMainThread();
 


### PR DESCRIPTION
This pull request introduces significant improvements to thread safety and reliability in both the server and Unity client for STYLY-NetSync. The main focus is on ensuring that background threads interact safely with Unity's main thread, especially for logging and event callbacks, and on making thread shutdowns more robust and observable.

**Key improvements include:**

### Unity Client: Thread-Safe Logging & Callbacks

* Introduced thread-safe queues (`_pendingLogs`, `_pendingMainThreadActions`) in `ConnectionManager` and `MessageProcessor` to collect logs and callbacks from network threads, which are then safely drained and executed on the main Unity thread via the new `DrainMainThreadActions` method. This prevents unsafe cross-thread calls to Unity APIs and ensures logs and events are handled correctly. [[1]](diffhunk://#diff-e2a34189387c9d6ec51288bf3c40c9f3d0e9898592e7738c1643344e5b2060cfR30-R36) [[2]](diffhunk://#diff-e2a34189387c9d6ec51288bf3c40c9f3d0e9898592e7738c1643344e5b2060cfL249-R248) [[3]](diffhunk://#diff-e2a34189387c9d6ec51288bf3c40c9f3d0e9898592e7738c1643344e5b2060cfL262-R266) [[4]](diffhunk://#diff-e2a34189387c9d6ec51288bf3c40c9f3d0e9898592e7738c1643344e5b2060cfL307-R303) [[5]](diffhunk://#diff-e2a34189387c9d6ec51288bf3c40c9f3d0e9898592e7738c1643344e5b2060cfL332-R328) [[6]](diffhunk://#diff-e2a34189387c9d6ec51288bf3c40c9f3d0e9898592e7738c1643344e5b2060cfL356-R369) [[7]](diffhunk://#diff-e2a34189387c9d6ec51288bf3c40c9f3d0e9898592e7738c1643344e5b2060cfL412-R408) [[8]](diffhunk://#diff-e2a34189387c9d6ec51288bf3c40c9f3d0e9898592e7738c1643344e5b2060cfR587-R608) [[9]](diffhunk://#diff-785a65cf10cb75819103fcff428587ba88958d950759e1200e47d01fb603b475R17-R19) [[10]](diffhunk://#diff-682b16d439879d7ab0d27a7243fb498aa5018d2cea6a785900ce9273b3d2c094R13-R15) [[11]](diffhunk://#diff-682b16d439879d7ab0d27a7243fb498aa5018d2cea6a785900ce9273b3d2c094L83-R86) [[12]](diffhunk://#diff-682b16d439879d7ab0d27a7243fb498aa5018d2cea6a785900ce9273b3d2c094L131-R166) [[13]](diffhunk://#diff-e55dd58d4b14d8442afc0515dce09d5d38678cf35607b94a8e027367131c40f4R33) [[14]](diffhunk://#diff-85fbaac67340cd0e7530de3718988af88b85f2a51179892204c6e280b6d8506dR518-R523)

### Unity Client: Socket and Thread Lifecycle Management

* Changed `Disconnect` in `ConnectionManager` to avoid disposing sockets from the main thread while the network thread may still be using them, reducing the risk of race conditions and crashes. Now, the main thread waits for the network thread to exit before cleanup.

### Server: Robust Thread Shutdown

* Updated the server's `stop` method to use timeouts when joining threads (`receive_thread`, `periodic_thread`, `publisher_thread`). If a thread does not stop within the timeout, a warning is logged, improving observability and robustness during shutdown. [[1]](diffhunk://#diff-e88eea98ef9a164151fc1fdd4bf5ed9a273abbfd449f658a8d82ff1b636df45dL982-R991) [[2]](diffhunk://#diff-e88eea98ef9a164151fc1fdd4bf5ed9a273abbfd449f658a8d82ff1b636df45dL1003-R1012)

### Server: Thread-Safe Status Logging

* Modified the periodic status logger to take a snapshot of the `rooms` dictionary under a lock before counting clients, preventing potential runtime errors due to concurrent modification.

---

These changes collectively enhance the stability, debuggability, and correctness of both the server and Unity client, especially in multithreaded scenarios.