### PR TITLE
Add device id provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,8 @@ The uvx command automatically downloads the package, creates an isolated virtual
   </tbody>
 </table>
 
+> **Note:** On HMD, a media access permission dialog may appear on the first launch. This is required by [Device-ID-Provider](https://github.com/styly-dev/Device-ID-Provider) to generate a stable device ID that persists across app reinstalls and remains consistent across different app vendors on the same device. The ID is stored as a small file in MediaStore. If permission is denied, the system falls back to `SystemInfo.deviceUniqueIdentifier`.
+
 
 ## Unity C# API Reference
 

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/DeviceIdResolver.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/DeviceIdResolver.cs
@@ -18,6 +18,10 @@ namespace Styly.NetSync.Internal
         /// </summary>
         private const string PermissionDeniedKey = "DeviceIdProvider_PermissionDenied";
 
+        // Android permission strings required by Device-ID-Provider
+        private const string PermissionReadExternalStorage = "android.permission.READ_EXTERNAL_STORAGE";
+        private const string PermissionReadMediaImages = "android.permission.READ_MEDIA_IMAGES";
+
         /// <summary>
         /// True once the device ID has been resolved (either successfully or via fallback).
         /// </summary>
@@ -96,14 +100,6 @@ namespace Styly.NetSync.Internal
 
         private void ResolveAndroid()
         {
-            // If the user previously denied permission, skip straight to fallback
-            if (PlayerPrefs.GetInt(PermissionDeniedKey, 0) == 1)
-            {
-                Log("Android: permission was previously denied, using fallback");
-                ResolveWithFallback();
-                return;
-            }
-
             // Determine which permission is needed based on Android SDK version
             string permission = GetRequiredAndroidPermission();
             if (permission == null)
@@ -114,11 +110,26 @@ namespace Styly.NetSync.Internal
                 return;
             }
 
-            // Check if permission is already granted
+            // Check if permission is already granted (e.g., user granted it later in system settings)
             if (UnityEngine.Android.Permission.HasUserAuthorizedPermission(permission))
             {
+                // Clear any stale denial flag so we don't skip the provider path next time
+                if (PlayerPrefs.GetInt(PermissionDeniedKey, 0) == 1)
+                {
+                    PlayerPrefs.DeleteKey(PermissionDeniedKey);
+                    PlayerPrefs.Save();
+                }
                 Log("Android: permission already granted, calling Device-ID-Provider");
                 ResolveWithDeviceIdProvider();
+                return;
+            }
+
+            // If the user previously denied permission, skip straight to fallback
+            // (don't show the dialog again until the app is reinstalled or permission is granted externally)
+            if (PlayerPrefs.GetInt(PermissionDeniedKey, 0) == 1)
+            {
+                Log("Android: permission was previously denied, using fallback");
+                ResolveWithFallback();
                 return;
             }
 
@@ -158,8 +169,8 @@ namespace Styly.NetSync.Internal
                     int sdk = versionClass.GetStatic<int>("SDK_INT");
                     if (sdk < 29) return null;
                     return sdk >= 33
-                        ? "android.permission.READ_MEDIA_IMAGES"
-                        : "android.permission.READ_EXTERNAL_STORAGE";
+                        ? PermissionReadMediaImages
+                        : PermissionReadExternalStorage;
                 }
             }
             catch (Exception ex)

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/DeviceIdResolver.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/DeviceIdResolver.cs
@@ -1,0 +1,212 @@
+// DeviceIdResolver.cs
+using System;
+using UnityEngine;
+
+namespace Styly.NetSync.Internal
+{
+    /// <summary>
+    /// Resolves a stable device ID asynchronously.
+    /// In Unity Editor: returns a random GUID immediately.
+    /// On real devices: attempts Device-ID-Provider first, falls back to SystemInfo.deviceUniqueIdentifier.
+    /// On Android, handles the permission dialog without blocking the main thread.
+    /// </summary>
+    internal sealed class DeviceIdResolver
+    {
+        /// <summary>
+        /// PlayerPrefs key to remember that the user denied the media permission.
+        /// Cleared automatically on app reinstall (PlayerPrefs is wiped).
+        /// </summary>
+        private const string PermissionDeniedKey = "DeviceIdProvider_PermissionDenied";
+
+        /// <summary>
+        /// True once the device ID has been resolved (either successfully or via fallback).
+        /// </summary>
+        public bool IsResolved { get; private set; }
+
+        /// <summary>
+        /// The resolved device ID. Only valid when <see cref="IsResolved"/> is true.
+        /// </summary>
+        public string DeviceId { get; private set; }
+
+        private readonly bool _enableDebugLogs;
+
+        // Thread-safe flags set by PermissionCallbacks (may fire on Java UI thread).
+        // Actual Unity API work is deferred to the main thread via Tick().
+        private volatile bool _permissionGranted;
+        private volatile bool _permissionDenied;
+
+        public DeviceIdResolver(bool enableDebugLogs)
+        {
+            _enableDebugLogs = enableDebugLogs;
+        }
+
+        /// <summary>
+        /// Begin device ID resolution. May complete synchronously or asynchronously
+        /// depending on platform and permission state.
+        /// </summary>
+        public void Resolve()
+        {
+#if UNITY_EDITOR
+            DeviceId = Guid.NewGuid().ToString();
+            Log($"Unity Editor: using generated GUID: {DeviceId}");
+            IsResolved = true;
+#else
+            ResolveRuntime();
+#endif
+        }
+
+        /// <summary>
+        /// Must be called from Update() on the main thread.
+        /// Completes deferred permission results that arrived from the Java UI thread.
+        /// In Editor mode this is a no-op since resolution is always synchronous.
+        /// </summary>
+        public void Tick()
+        {
+#if !UNITY_EDITOR
+            if (_permissionGranted)
+            {
+                _permissionGranted = false;
+                Log("Android: permission granted (deferred), calling Device-ID-Provider");
+                ResolveWithDeviceIdProvider();
+            }
+            else if (_permissionDenied)
+            {
+                _permissionDenied = false;
+                Log("Android: permission denied (deferred), saving denial and using fallback");
+                PlayerPrefs.SetInt(PermissionDeniedKey, 1);
+                PlayerPrefs.Save();
+                ResolveWithFallback();
+            }
+#endif
+        }
+
+#if !UNITY_EDITOR
+        private void ResolveRuntime()
+        {
+            // Android-specific: check permission state before calling Device-ID-Provider
+            if (Application.platform == RuntimePlatform.Android)
+            {
+                ResolveAndroid();
+                return;
+            }
+
+            // Non-Android platforms: try Device-ID-Provider synchronously (no permission needed)
+            ResolveWithDeviceIdProvider();
+        }
+
+        private void ResolveAndroid()
+        {
+            // If the user previously denied permission, skip straight to fallback
+            if (PlayerPrefs.GetInt(PermissionDeniedKey, 0) == 1)
+            {
+                Log("Android: permission was previously denied, using fallback");
+                ResolveWithFallback();
+                return;
+            }
+
+            // Determine which permission is needed based on Android SDK version
+            string permission = GetRequiredAndroidPermission();
+            if (permission == null)
+            {
+                // SDK < 29: Device-ID-Provider doesn't support this, use fallback
+                Log("Android: SDK < 29, Device-ID-Provider not supported, using fallback");
+                ResolveWithFallback();
+                return;
+            }
+
+            // Check if permission is already granted
+            if (UnityEngine.Android.Permission.HasUserAuthorizedPermission(permission))
+            {
+                Log("Android: permission already granted, calling Device-ID-Provider");
+                ResolveWithDeviceIdProvider();
+                return;
+            }
+
+            // Permission not yet granted — request it asynchronously (non-blocking).
+            // Callbacks may fire on the Java UI thread, so we only set volatile flags here.
+            // Actual Unity API work is deferred to Tick() on the main thread.
+            Log($"Android: requesting permission {permission}");
+            var callbacks = new UnityEngine.Android.PermissionCallbacks();
+            callbacks.PermissionGranted += OnPermissionGranted;
+            callbacks.PermissionDenied += OnPermissionDenied;
+            callbacks.PermissionDeniedAndDontAskAgain += OnPermissionDenied;
+            UnityEngine.Android.Permission.RequestUserPermission(permission, callbacks);
+        }
+
+        private void OnPermissionGranted(string permission)
+        {
+            // Only set a flag — do NOT call Unity APIs here (may be off main thread)
+            _permissionGranted = true;
+        }
+
+        private void OnPermissionDenied(string permission)
+        {
+            // Only set a flag — do NOT call Unity APIs here (may be off main thread)
+            _permissionDenied = true;
+        }
+
+        /// <summary>
+        /// Returns the Android permission string required by Device-ID-Provider,
+        /// or null if the current SDK version is below 29 (unsupported).
+        /// </summary>
+        private static string GetRequiredAndroidPermission()
+        {
+            try
+            {
+                using (var versionClass = new AndroidJavaClass("android.os.Build$VERSION"))
+                {
+                    int sdk = versionClass.GetStatic<int>("SDK_INT");
+                    if (sdk < 29) return null;
+                    return sdk >= 33
+                        ? "android.permission.READ_MEDIA_IMAGES"
+                        : "android.permission.READ_EXTERNAL_STORAGE";
+                }
+            }
+            catch (Exception ex)
+            {
+                Debug.LogWarning($"[DeviceIdResolver] Failed to get Android SDK version: {ex.Message}");
+                return null;
+            }
+        }
+
+        private void ResolveWithDeviceIdProvider()
+        {
+            try
+            {
+                DeviceId = Styly.Device.DeviceIdProvider.GetDeviceID();
+                Log($"Using Device-ID-Provider: {DeviceId}");
+                IsResolved = true;
+            }
+            catch (Exception ex)
+            {
+                Debug.LogWarning($"[DeviceIdResolver] Device-ID-Provider failed ({ex.GetType().Name}: {ex.Message}), using fallback");
+                ResolveWithFallback();
+            }
+        }
+
+        private void ResolveWithFallback()
+        {
+            string deviceId = SystemInfo.deviceUniqueIdentifier;
+            if (!string.IsNullOrEmpty(deviceId) && deviceId != SystemInfo.unsupportedIdentifier)
+            {
+                DeviceId = deviceId;
+                Log($"Fallback: using SystemInfo.deviceUniqueIdentifier: {DeviceId}");
+            }
+            else
+            {
+                DeviceId = Guid.NewGuid().ToString();
+                Log($"Fallback: SystemInfo.deviceUniqueIdentifier not available, using generated GUID: {DeviceId}");
+            }
+            IsResolved = true;
+        }
+#endif
+
+        private void Log(string message)
+        {
+            if (_enableDebugLogs)
+            {
+                Debug.Log($"[DeviceIdResolver] {message}");
+            }
+        }
+    }
+}

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/DeviceIdResolver.cs.meta
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/DeviceIdResolver.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 282e625bdc77749639091f091d9c6707

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/NetSyncManager.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/NetSyncManager.cs
@@ -1,6 +1,7 @@
 // NetSyncManager.cs
 using System;
 using System.Collections.Generic;
+using Styly.NetSync.Internal;
 using Unity.XR.CoreUtils;
 using UnityEngine;
 using UnityEngine.Events;
@@ -331,6 +332,10 @@ namespace Styly.NetSync
         private long _transformBackpressureCount;
         private float _lastBackpressureWarnAt;
         private const float BackpressureWarnCooldown = 1f; // Log backpressure warning at most once per second
+
+        // Async device ID resolution
+        private DeviceIdResolver _deviceIdResolver;
+        private bool _networkingPending;
         #endregion ------------------------------------------------------------------------
 
         #region === Public Properties ===
@@ -391,21 +396,21 @@ namespace Styly.NetSync
 
             if (!_netMqInit) { AsyncIO.ForceDotNet.Force(); _netMqInit = true; }
 
-            // Generate device ID - use Android device ID if available, otherwise generate GUID
-            _deviceId = GenerateDeviceId();
             _instance = this;
-
-            // UnityEvents are initialized at declaration time (no runtime initialization needed)
 
             // Detect stealth mode based on local avatar prefab
             _isStealthMode = (_localAvatarPrefab == null);
 
-            InitializeManagers();
-            DebugLog($"Device ID: {_deviceId}");
-            if (_isStealthMode)
+            // Resolve device ID (may complete asynchronously on Android when permission dialog is shown)
+            _deviceIdResolver = new DeviceIdResolver(_enableDebugLogs);
+            _deviceIdResolver.Resolve();
+
+            if (_deviceIdResolver.IsResolved)
             {
-                DebugLog("Stealth mode enabled (no local avatar prefab)");
+                CompleteDeviceIdResolution();
+                _networkingPending = false; // Prevent double-init if OnEnable ran before Awake
             }
+            // Otherwise, Update() will complete initialization when the resolver finishes
         }
 
         void Start()
@@ -423,14 +428,29 @@ namespace Styly.NetSync
 
         private void OnEnable()
         {
-            _avatarManager.InitializeLocalAvatar(_localAvatarPrefab, _deviceId, this);
-            StartNetworking();
+            if (_deviceIdResolver != null && _deviceIdResolver.IsResolved)
+            {
+                _avatarManager.InitializeLocalAvatar(_localAvatarPrefab, _deviceId, this);
+                StartNetworking();
+            }
+            else
+            {
+                // Device ID not yet resolved (async permission dialog on Android).
+                // Networking will start once the resolver completes.
+                _networkingPending = true;
+            }
         }
 
         private void OnDisable()
         {
-            StopNetworking();
-            _avatarManager.CleanupRemoteAvatars();
+            _networkingPending = false;
+
+            if (_connectionManager != null)
+            {
+                StopNetworking();
+            }
+
+            if (_avatarManager != null) { _avatarManager.CleanupRemoteAvatars(); }
             if (_humanPresenceManager != null) { _humanPresenceManager.CleanupAll(); }
 
             // Dispose pooled serialization resources to return buffers to ArrayPool
@@ -441,7 +461,10 @@ namespace Styly.NetSync
 
         private void OnApplicationQuit()
         {
-            StopNetworking();
+            if (_connectionManager != null)
+            {
+                StopNetworking();
+            }
             // Be explicit on quit as well in case OnDisable order varies
             DisposeManagers();
         }
@@ -450,6 +473,9 @@ namespace Styly.NetSync
         {
             // This is a wourkaround to ignore initial pause for ANdroid devices
             if (Time.time < 1) { return; }
+
+            // Managers not yet initialized (async device ID resolution in progress)
+            if (_connectionManager == null) { return; }
 
             if (paused)
             {
@@ -484,7 +510,7 @@ namespace Styly.NetSync
             else
             {
                 DebugLog("Application gained focus");
-                if (!_connectionManager.IsConnected && !_isDiscovering)
+                if (_connectionManager != null && !_connectionManager.IsConnected && !_isDiscovering)
                 {
                     StartNetworking();
                 }
@@ -493,6 +519,24 @@ namespace Styly.NetSync
 
         private void Update()
         {
+            // Process deferred permission callbacks on main thread (safe for Unity APIs)
+            if (_deviceIdResolver != null)
+            {
+                _deviceIdResolver.Tick();
+            }
+
+            // Complete deferred device ID resolution (async Android permission path)
+            if (_networkingPending && _deviceIdResolver != null && _deviceIdResolver.IsResolved)
+            {
+                _networkingPending = false;
+                CompleteDeviceIdResolution();
+                _avatarManager.InitializeLocalAvatar(_localAvatarPrefab, _deviceId, this);
+                StartNetworking();
+            }
+
+            // Skip main loop until managers are initialized
+            if (_connectionManager == null) { return; }
+
             // Check ready state on main thread
             if (_shouldCheckReady)
             {
@@ -567,29 +611,22 @@ namespace Styly.NetSync
         #endregion ------------------------------------------------------------------------
 
         #region === Initialization ===
-        private string GenerateDeviceId()
+        /// <summary>
+        /// Completes device ID resolution by reading the result from the resolver
+        /// and initializing all managers. Called either synchronously from Awake()
+        /// or deferred from Update() when the Android permission dialog was shown.
+        /// </summary>
+        private void CompleteDeviceIdResolution()
         {
-#if UNITY_EDITOR
-            // Always use GUID in Unity Editor for development
-            var guid = Guid.NewGuid().ToString();
-            DebugLog($"Unity Editor: using generated GUID: {guid}");
-            return guid;
-#else
-            // Try to get Unity's device unique identifier on actual devices
-            string deviceId = SystemInfo.deviceUniqueIdentifier;
+            _deviceId = _deviceIdResolver.DeviceId;
+            DebugLog($"Device ID: {_deviceId}");
 
-            // Check if the device ID is valid
-            if (!string.IsNullOrEmpty(deviceId) && deviceId != SystemInfo.unsupportedIdentifier)
+            InitializeManagers();
+
+            if (_isStealthMode)
             {
-                DebugLog($"Using SystemInfo.deviceUniqueIdentifier: {deviceId}");
-                return deviceId;
+                DebugLog("Stealth mode enabled (no local avatar prefab)");
             }
-
-            // Fallback to GUID if SystemInfo.deviceUniqueIdentifier is not available
-            var fallbackGuid = Guid.NewGuid().ToString();
-            DebugLog($"SystemInfo.deviceUniqueIdentifier not available, using generated GUID: {fallbackGuid}");
-            return fallbackGuid;
-#endif
         }
 
         private void InitializeManagers()

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/NetSyncManager.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/NetSyncManager.cs
@@ -408,7 +408,7 @@ namespace Styly.NetSync
             if (_deviceIdResolver.IsResolved)
             {
                 CompleteDeviceIdResolution();
-                _networkingPending = false; // Prevent double-init if OnEnable ran before Awake
+                _networkingPending = false; // Prevent double-init by disabling the deferred Update() initialization path
             }
             // Otherwise, Update() will complete initialization when the resolver finishes
         }

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/com.styly.styly-netsync.asmdef
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/com.styly.styly-netsync.asmdef
@@ -6,7 +6,8 @@
         "GUID:75469ad4d38634e559750d17036d5f7c",
         "GUID:fe685ec1767f73d42b749ea8045bfe43",
         "GUID:3755b4bd67fe24030815e9baccb497e7",
-        "GUID:ce522b6ed64c8be4c989a1d26d0e3275"
+        "GUID:ce522b6ed64c8be4c989a1d26d0e3275",
+        "GUID:0693fda0efa2649ef974b5cc8d9bb996"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/package.json
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/package.json
@@ -5,7 +5,7 @@
   "unity": "6000.0",
   "description": "STYLY NetSync",
   "dependencies": {
-    "com.styly.device-id-provider": "0.2.0",
+    "com.styly.device-id-provider": "0.3.0",
     "com.styly.shader-collection.urp": "0.0.5",
     "org.nuget.netmq": "4.0.2",
     "com.unity.xr.core-utils": "2.1.1",

--- a/STYLY-NetSync-Unity/Packages/packages-lock.json
+++ b/STYLY-NetSync-Unity/Packages/packages-lock.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "com.styly.device-id-provider": {
-      "version": "0.2.0",
+      "version": "0.3.0",
       "depth": 1,
       "source": "registry",
       "dependencies": {},
@@ -19,7 +19,7 @@
       "depth": 0,
       "source": "embedded",
       "dependencies": {
-        "com.styly.device-id-provider": "0.2.0",
+        "com.styly.device-id-provider": "0.3.0",
         "com.styly.shader-collection.urp": "0.0.5",
         "org.nuget.netmq": "4.0.2",
         "com.unity.xr.core-utils": "2.1.1",


### PR DESCRIPTION
This pull request introduces robust, asynchronous device ID resolution to support Android permission dialogs and improve cross-platform consistency in device identification. The main changes include adding a new `DeviceIdResolver` class, refactoring `NetSyncManager` to use it, and updating dependencies for improved device ID support.

**Device ID Resolution Improvements:**

* Added the new `DeviceIdResolver` class, which handles asynchronous device ID resolution, Android permission requests, and appropriate fallbacks for all platforms. This ensures device IDs are stable, permission-safe, and consistent across Editor, Android, and other devices. [[1]](diffhunk://#diff-be1064783ec2c2cfeccd39a3dfbbb9888ba20590dbc2a4898ecc7e4bdbf35112R1-R212) [[2]](diffhunk://#diff-8d5ca832eea4582c2dd4626c3cb9191b729c06eff6d34f0bca968931842ecb48R1-R2)
* Refactored `NetSyncManager` to use `DeviceIdResolver` instead of generating device IDs directly, handling asynchronous resolution and deferring networking initialization until the device ID is available. This includes changes to the initialization flow in `Awake`, `OnEnable`, `Update`, and related lifecycle methods. [[1]](diffhunk://#diff-85fbaac67340cd0e7530de3718988af88b85f2a51179892204c6e280b6d8506dR4) [[2]](diffhunk://#diff-85fbaac67340cd0e7530de3718988af88b85f2a51179892204c6e280b6d8506dR335-R338) [[3]](diffhunk://#diff-85fbaac67340cd0e7530de3718988af88b85f2a51179892204c6e280b6d8506dL394-R413) [[4]](diffhunk://#diff-85fbaac67340cd0e7530de3718988af88b85f2a51179892204c6e280b6d8506dR430-R453) [[5]](diffhunk://#diff-85fbaac67340cd0e7530de3718988af88b85f2a51179892204c6e280b6d8506dR463-R467) [[6]](diffhunk://#diff-85fbaac67340cd0e7530de3718988af88b85f2a51179892204c6e280b6d8506dR477-R479) [[7]](diffhunk://#diff-85fbaac67340cd0e7530de3718988af88b85f2a51179892204c6e280b6d8506dL487-R513) [[8]](diffhunk://#diff-85fbaac67340cd0e7530de3718988af88b85f2a51179892204c6e280b6d8506dR522-R539) [[9]](diffhunk://#diff-85fbaac67340cd0e7530de3718988af88b85f2a51179892204c6e280b6d8506dL570-L592)

**Dependency Updates:**

* Updated `com.styly.device-id-provider` dependency to version 0.3.0 in both `package.json` and `packages-lock.json` to support the new device ID resolution features and permissions handling. [[1]](diffhunk://#diff-c048c88725c85d2f28e120b10b054559ed59a262cb4c7c021c751f21fe49d35bL8-R8) [[2]](diffhunk://#diff-066d9509e08bf27d90a446f2479f944fa9fa16c0c14011a83ebb8fce1f5224e9L4-R4) [[3]](diffhunk://#diff-066d9509e08bf27d90a446f2479f944fa9fa16c0c14011a83ebb8fce1f5224e9L22-R22)
* Registered the new internal script in the assembly definition to ensure proper compilation and usage.