### PR TITLE
feat: support byte[] values in NetworkVariable with sample scene

### DIFF
--- a/STYLY-NetSync-Server/src/styly_netsync/binary_serializer.py
+++ b/STYLY-NetSync-Server/src/styly_netsync/binary_serializer.py
@@ -20,6 +20,10 @@ MSG_CLIENT_VAR_SYNC = 10  # Sync client variables
 MSG_CLIENT_POSE = 11
 MSG_ROOM_POSE = 12
 
+# Network Variable value type tags
+VAR_TYPE_STRING = 0x00
+VAR_TYPE_BYTES = 0x01
+
 # Transform data type identifiers (deprecated - kept for reference)
 
 # Maximum allowed virtual transforms to prevent memory issues
@@ -112,6 +116,23 @@ def _unpack_string(
         offset += 1
     string = data[offset : offset + length].decode("utf-8")
     return string, offset + length
+
+
+def _pack_nv_value(buffer: bytearray, type_tag: int, raw_bytes: bytes) -> None:
+    """Pack a typed NV value: [1B type_tag][4B uint32 length][N bytes payload]"""
+    buffer.append(type_tag)
+    buffer.extend(struct.pack("<I", len(raw_bytes)))
+    buffer.extend(raw_bytes)
+
+
+def _unpack_nv_value(data: bytes, offset: int) -> tuple[int, bytes, int]:
+    """Unpack a typed NV value. Returns (type_tag, raw_bytes, new_offset)."""
+    type_tag = data[offset]
+    offset += 1
+    length = struct.unpack("<I", data[offset : offset + 4])[0]
+    offset += 4
+    raw_bytes = data[offset : offset + length]
+    return type_tag, raw_bytes, offset + length
 
 
 def _transform_get_position(transform: dict[str, Any]) -> tuple[float, float, float]:
@@ -651,7 +672,9 @@ def serialize_global_var_set(data: dict[str, Any]) -> bytes:
     """Serialize global variable set message
 
     Args:
-        data: Dictionary with senderClientNo, variableName, variableValue, timestamp
+        data: Dictionary with senderClientNo, variableName,
+              variableValue (str) or variableValueBytes (bytes),
+              variableValueType (0=string, 1=bytes), timestamp
     """
     buffer = bytearray()
 
@@ -665,9 +688,13 @@ def serialize_global_var_set(data: dict[str, Any]) -> bytes:
     name = data.get("variableName", "")[:64]
     _pack_string(buffer, name)
 
-    # Variable value (max 1024 bytes)
-    value = data.get("variableValue", "")[:1024]
-    _pack_string(buffer, value, use_ushort=True)
+    # Variable value: [1B type_tag][4B uint32 length][N bytes payload]
+    value_type = data.get("variableValueType", VAR_TYPE_STRING)
+    if value_type == VAR_TYPE_BYTES:
+        raw_bytes = data.get("variableValueBytes", b"")
+    else:
+        raw_bytes = data.get("variableValue", "").encode("utf-8")
+    _pack_nv_value(buffer, value_type, raw_bytes)
 
     # Timestamp (8 bytes double)
     buffer.extend(struct.pack("<d", data.get("timestamp", 0.0)))
@@ -679,7 +706,9 @@ def serialize_global_var_sync(data: dict[str, Any]) -> bytes:
     """Serialize global variable sync message
 
     Args:
-        data: Dictionary with variables list
+        data: Dictionary with variables list. Each variable has name,
+              valueType (0=string, 1=bytes), valueBytes (bytes),
+              timestamp, lastWriterClientNo.
     """
     buffer = bytearray()
 
@@ -693,7 +722,9 @@ def serialize_global_var_sync(data: dict[str, Any]) -> bytes:
     # Each variable
     for var in variables:
         _pack_string(buffer, var.get("name", "")[:64])
-        _pack_string(buffer, var.get("value", "")[:1024], use_ushort=True)
+        value_type = var.get("valueType", VAR_TYPE_STRING)
+        raw_bytes = var.get("valueBytes", b"")
+        _pack_nv_value(buffer, value_type, raw_bytes)
         buffer.extend(struct.pack("<d", var.get("timestamp", 0.0)))
         buffer.extend(struct.pack("<H", var.get("lastWriterClientNo", 0)))
 
@@ -704,7 +735,9 @@ def serialize_client_var_set(data: dict[str, Any]) -> bytes:
     """Serialize client variable set message
 
     Args:
-        data: Dictionary with senderClientNo, targetClientNo, variableName, variableValue, timestamp
+        data: Dictionary with senderClientNo, targetClientNo, variableName,
+              variableValue (str) or variableValueBytes (bytes),
+              variableValueType (0=string, 1=bytes), timestamp
     """
     buffer = bytearray()
 
@@ -721,9 +754,13 @@ def serialize_client_var_set(data: dict[str, Any]) -> bytes:
     name = data.get("variableName", "")[:64]
     _pack_string(buffer, name)
 
-    # Variable value (max 1024 bytes)
-    value = data.get("variableValue", "")[:1024]
-    _pack_string(buffer, value, use_ushort=True)
+    # Variable value: [1B type_tag][4B uint32 length][N bytes payload]
+    value_type = data.get("variableValueType", VAR_TYPE_STRING)
+    if value_type == VAR_TYPE_BYTES:
+        raw_bytes = data.get("variableValueBytes", b"")
+    else:
+        raw_bytes = data.get("variableValue", "").encode("utf-8")
+    _pack_nv_value(buffer, value_type, raw_bytes)
 
     # Timestamp (8 bytes double)
     buffer.extend(struct.pack("<d", data.get("timestamp", 0.0)))
@@ -735,7 +772,9 @@ def serialize_client_var_sync(data: dict[str, Any]) -> bytes:
     """Serialize client variable sync message
 
     Args:
-        data: Dictionary with clientVariables dict
+        data: Dictionary with clientVariables dict. Each variable has name,
+              valueType (0=string, 1=bytes), valueBytes (bytes),
+              timestamp, lastWriterClientNo.
     """
     buffer = bytearray()
 
@@ -755,7 +794,9 @@ def serialize_client_var_sync(data: dict[str, Any]) -> bytes:
         # Each variable for this client
         for var in variables:
             _pack_string(buffer, var.get("name", "")[:64])
-            _pack_string(buffer, var.get("value", "")[:1024], use_ushort=True)
+            value_type = var.get("valueType", VAR_TYPE_STRING)
+            raw_bytes = var.get("valueBytes", b"")
+            _pack_nv_value(buffer, value_type, raw_bytes)
             buffer.extend(struct.pack("<d", var.get("timestamp", 0.0)))
             buffer.extend(struct.pack("<H", var.get("lastWriterClientNo", 0)))
 
@@ -1136,8 +1177,12 @@ def _deserialize_global_var_set(data: bytes, offset: int) -> dict[str, Any]:
     # Variable name
     result["variableName"], offset = _unpack_string(data, offset)
 
-    # Variable value
-    result["variableValue"], offset = _unpack_string(data, offset, use_ushort=True)
+    # Variable value: [1B type_tag][4B uint32 length][N bytes payload]
+    value_type, raw_bytes, offset = _unpack_nv_value(data, offset)
+    result["variableValueType"] = value_type
+    result["variableValueBytes"] = raw_bytes
+    if value_type == VAR_TYPE_STRING:
+        result["variableValue"] = raw_bytes.decode("utf-8")
 
     # Timestamp (8 bytes double)
     result["timestamp"] = struct.unpack("<d", data[offset : offset + 8])[0]
@@ -1156,9 +1201,13 @@ def _deserialize_global_var_sync(data: bytes, offset: int) -> dict[str, Any]:
 
     # Each variable
     for _ in range(count):
-        var = {}
+        var: dict[str, Any] = {}
         var["name"], offset = _unpack_string(data, offset)
-        var["value"], offset = _unpack_string(data, offset, use_ushort=True)
+        value_type, raw_bytes, offset = _unpack_nv_value(data, offset)
+        var["valueType"] = value_type
+        var["valueBytes"] = raw_bytes
+        if value_type == VAR_TYPE_STRING:
+            var["value"] = raw_bytes.decode("utf-8")
         var["timestamp"] = struct.unpack("<d", data[offset : offset + 8])[0]
         offset += 8
         var["lastWriterClientNo"] = struct.unpack("<H", data[offset : offset + 2])[0]
@@ -1183,8 +1232,12 @@ def _deserialize_client_var_set(data: bytes, offset: int) -> dict[str, Any]:
     # Variable name
     result["variableName"], offset = _unpack_string(data, offset)
 
-    # Variable value
-    result["variableValue"], offset = _unpack_string(data, offset, use_ushort=True)
+    # Variable value: [1B type_tag][4B uint32 length][N bytes payload]
+    value_type, raw_bytes, offset = _unpack_nv_value(data, offset)
+    result["variableValueType"] = value_type
+    result["variableValueBytes"] = raw_bytes
+    if value_type == VAR_TYPE_STRING:
+        result["variableValue"] = raw_bytes.decode("utf-8")
 
     # Timestamp (8 bytes double)
     result["timestamp"] = struct.unpack("<d", data[offset : offset + 8])[0]
@@ -1209,11 +1262,15 @@ def _deserialize_client_var_sync(data: bytes, offset: int) -> dict[str, Any]:
         var_count = struct.unpack("<H", data[offset : offset + 2])[0]
         offset += 2
 
-        variables = []
+        variables: list[dict[str, Any]] = []
         for _ in range(var_count):
-            var = {}
+            var: dict[str, Any] = {}
             var["name"], offset = _unpack_string(data, offset)
-            var["value"], offset = _unpack_string(data, offset, use_ushort=True)
+            value_type, raw_bytes, offset = _unpack_nv_value(data, offset)
+            var["valueType"] = value_type
+            var["valueBytes"] = raw_bytes
+            if value_type == VAR_TYPE_STRING:
+                var["value"] = raw_bytes.decode("utf-8")
             var["timestamp"] = struct.unpack("<d", data[offset : offset + 8])[0]
             offset += 8
             var["lastWriterClientNo"] = struct.unpack("<H", data[offset : offset + 2])[

--- a/STYLY-NetSync-Server/src/styly_netsync/client.py
+++ b/STYLY-NetSync-Server/src/styly_netsync/client.py
@@ -194,9 +194,9 @@ class net_sync_manager:
         self._client_to_device: dict[int, str] = {}
         self._client_stealth_flags: dict[int, bool] = {}
 
-        # Network Variables (local cache)
-        self._global_variables: dict[str, str] = {}
-        self._client_variables: dict[int, dict[str, str]] = {}
+        # Network Variables (local cache): name -> (value_type, raw_bytes)
+        self._global_variables: dict[str, tuple[int, bytes]] = {}
+        self._client_variables: dict[int, dict[str, tuple[int, bytes]]] = {}
 
         # Event queues and handlers
         self._rpc_queue: Queue = Queue(maxsize=queue_max)
@@ -206,6 +206,8 @@ class net_sync_manager:
         self.on_rpc_received = EventHandler()
         self.on_global_variable_changed = EventHandler()
         self.on_client_variable_changed = EventHandler()
+        self.on_global_bytes_variable_changed = EventHandler()
+        self.on_client_bytes_variable_changed = EventHandler()
         self.on_avatar_connected = EventHandler()
         self.on_client_disconnected = EventHandler()
         self.on_server_discovered = EventHandler()
@@ -1001,30 +1003,50 @@ class net_sync_manager:
 
             for var in variables:
                 name = var.get("name", "")
-                value = var.get("value", "")
-                old_value = self._global_variables.get(name)
+                value_type = var.get("valueType", binary_serializer.VAR_TYPE_STRING)
+                value_bytes = var.get("valueBytes", b"")
+                new_entry = (value_type, value_bytes)
+                old_entry = self._global_variables.get(name)
 
-                self._global_variables[name] = value
+                self._global_variables[name] = new_entry
 
-                if old_value != value:
+                if old_entry != new_entry:
                     with self._lock:
                         self._stats["nv_updates"] += 1
 
-                    event = ("global", name, old_value, value)
-                    if self._auto_dispatch:
-                        self.on_global_variable_changed.invoke(name, old_value, value)
+                    if value_type == binary_serializer.VAR_TYPE_BYTES:
+                        old_bytes = old_entry[1] if old_entry else None
+                        if self._auto_dispatch:
+                            self.on_global_bytes_variable_changed.invoke(
+                                name, old_bytes, value_bytes
+                            )
+                        else:
+                            self._enqueue_nv_event(
+                                ("global_bytes", name, old_bytes, value_bytes)
+                            )
                     else:
-                        try:
-                            self._nv_queue.put_nowait(event)
-                        except Full:
-                            try:
-                                self._nv_queue.get_nowait()
-                                self._nv_queue.put_nowait(event)
-                            except Empty:
-                                pass
+                        old_str = old_entry[1].decode("utf-8") if old_entry else None
+                        new_str = value_bytes.decode("utf-8")
+                        if self._auto_dispatch:
+                            self.on_global_variable_changed.invoke(
+                                name, old_str, new_str
+                            )
+                        else:
+                            self._enqueue_nv_event(("global", name, old_str, new_str))
 
         except Exception as e:
             logger.error(f"Error processing global var sync: {e}")
+
+    def _enqueue_nv_event(self, event: tuple) -> None:
+        """Enqueue an NV event, dropping oldest on overflow."""
+        try:
+            self._nv_queue.put_nowait(event)
+        except Full:
+            try:
+                self._nv_queue.get_nowait()
+                self._nv_queue.put_nowait(event)
+            except Empty:
+                pass
 
     def _process_client_var_sync(self, msg_data: dict[str, Any]) -> None:
         """Process client variable sync."""
@@ -1042,29 +1064,46 @@ class net_sync_manager:
 
                 for var in variables:
                     name = var.get("name", "")
-                    value = var.get("value", "")
-                    old_value = self._client_variables[client_no].get(name)
+                    value_type = var.get("valueType", binary_serializer.VAR_TYPE_STRING)
+                    value_bytes = var.get("valueBytes", b"")
+                    new_entry = (value_type, value_bytes)
+                    old_entry = self._client_variables[client_no].get(name)
 
-                    self._client_variables[client_no][name] = value
+                    self._client_variables[client_no][name] = new_entry
 
-                    if old_value != value:
+                    if old_entry != new_entry:
                         with self._lock:
                             self._stats["nv_updates"] += 1
 
-                        event = ("client", client_no, name, old_value, value)
-                        if self._auto_dispatch:
-                            self.on_client_variable_changed.invoke(
-                                client_no, name, old_value, value
-                            )
+                        if value_type == binary_serializer.VAR_TYPE_BYTES:
+                            old_bytes = old_entry[1] if old_entry else None
+                            if self._auto_dispatch:
+                                self.on_client_bytes_variable_changed.invoke(
+                                    client_no, name, old_bytes, value_bytes
+                                )
+                            else:
+                                self._enqueue_nv_event(
+                                    (
+                                        "client_bytes",
+                                        client_no,
+                                        name,
+                                        old_bytes,
+                                        value_bytes,
+                                    )
+                                )
                         else:
-                            try:
-                                self._nv_queue.put_nowait(event)
-                            except Full:
-                                try:
-                                    self._nv_queue.get_nowait()
-                                    self._nv_queue.put_nowait(event)
-                                except Empty:
-                                    pass
+                            old_str = (
+                                old_entry[1].decode("utf-8") if old_entry else None
+                            )
+                            new_str = value_bytes.decode("utf-8")
+                            if self._auto_dispatch:
+                                self.on_client_variable_changed.invoke(
+                                    client_no, name, old_str, new_str
+                                )
+                            else:
+                                self._enqueue_nv_event(
+                                    ("client", client_no, name, old_str, new_str)
+                                )
 
         except Exception as e:
             logger.error(f"Error processing client var sync: {e}")
@@ -1198,10 +1237,11 @@ class net_sync_manager:
             return False
 
         try:
-            var_data = {
+            var_data: dict[str, Any] = {
                 "senderClientNo": self._client_no,
                 "variableName": name,
                 "variableValue": value,
+                "variableValueType": binary_serializer.VAR_TYPE_STRING,
                 "timestamp": time.time(),
             }
             message = binary_serializer.serialize_global_var_set(var_data)
@@ -1213,17 +1253,40 @@ class net_sync_manager:
             logger.error(f"Error queueing global variable: {e}")
             return False
 
+    def set_global_variable_bytes(self, name: str, value: bytes) -> bool:
+        """Queue global variable update with binary value (via control queue)."""
+        if not self._running or not self._dealer_socket or self._client_no is None:
+            return False
+
+        try:
+            var_data: dict[str, Any] = {
+                "senderClientNo": self._client_no,
+                "variableName": name,
+                "variableValueType": binary_serializer.VAR_TYPE_BYTES,
+                "variableValueBytes": value,
+                "timestamp": time.time(),
+            }
+            message = binary_serializer.serialize_global_var_set(var_data)
+            return self._enqueue_control(
+                self._room, message, msg_type="global_variable"
+            )
+
+        except Exception as e:
+            logger.error(f"Error queueing global variable bytes: {e}")
+            return False
+
     def set_client_variable(self, target_client_no: int, name: str, value: str) -> bool:
         """Queue client variable update (via control queue)."""
         if not self._running or not self._dealer_socket or self._client_no is None:
             return False
 
         try:
-            var_data = {
+            var_data: dict[str, Any] = {
                 "senderClientNo": self._client_no,
                 "targetClientNo": target_client_no,
                 "variableName": name,
                 "variableValue": value,
+                "variableValueType": binary_serializer.VAR_TYPE_STRING,
                 "timestamp": time.time(),
             }
             message = binary_serializer.serialize_client_var_set(var_data)
@@ -1233,6 +1296,31 @@ class net_sync_manager:
 
         except Exception as e:
             logger.error(f"Error queueing client variable: {e}")
+            return False
+
+    def set_client_variable_bytes(
+        self, target_client_no: int, name: str, value: bytes
+    ) -> bool:
+        """Queue client variable update with binary value (via control queue)."""
+        if not self._running or not self._dealer_socket or self._client_no is None:
+            return False
+
+        try:
+            var_data: dict[str, Any] = {
+                "senderClientNo": self._client_no,
+                "targetClientNo": target_client_no,
+                "variableName": name,
+                "variableValueType": binary_serializer.VAR_TYPE_BYTES,
+                "variableValueBytes": value,
+                "timestamp": time.time(),
+            }
+            message = binary_serializer.serialize_client_var_set(var_data)
+            return self._enqueue_control(
+                self._room, message, msg_type="client_variable"
+            )
+
+        except Exception as e:
+            logger.error(f"Error queueing client variable bytes: {e}")
             return False
 
     def _enqueue_control(
@@ -1266,15 +1354,39 @@ class net_sync_manager:
             return False
 
     def get_global_variable(self, name: str, default: str | None = None) -> str | None:
-        """Get global variable from local cache."""
-        return self._global_variables.get(name, default)
+        """Get global string variable from local cache."""
+        entry = self._global_variables.get(name)
+        if entry is not None and entry[0] == binary_serializer.VAR_TYPE_STRING:
+            return entry[1].decode("utf-8")
+        return default
+
+    def get_global_variable_bytes(
+        self, name: str, default: bytes | None = None
+    ) -> bytes | None:
+        """Get global binary variable from local cache."""
+        entry = self._global_variables.get(name)
+        if entry is not None and entry[0] == binary_serializer.VAR_TYPE_BYTES:
+            return entry[1]
+        return default
 
     def get_client_variable(
         self, client_no: int, name: str, default: str | None = None
     ) -> str | None:
-        """Get client variable from local cache."""
+        """Get client string variable from local cache."""
         if client_no in self._client_variables:
-            return self._client_variables[client_no].get(name, default)
+            entry = self._client_variables[client_no].get(name)
+            if entry is not None and entry[0] == binary_serializer.VAR_TYPE_STRING:
+                return entry[1].decode("utf-8")
+        return default
+
+    def get_client_variable_bytes(
+        self, client_no: int, name: str, default: bytes | None = None
+    ) -> bytes | None:
+        """Get client binary variable from local cache."""
+        if client_no in self._client_variables:
+            entry = self._client_variables[client_no].get(name)
+            if entry is not None and entry[0] == binary_serializer.VAR_TYPE_BYTES:
+                return entry[1]
         return default
 
     # Device mapping API
@@ -1287,12 +1399,20 @@ class net_sync_manager:
         return self._client_to_device.get(client_no)
 
     def get_all_global_variables(self) -> dict[str, str]:
-        """Return a copy of all global variables."""
-        return self._global_variables.copy()
+        """Return a copy of all string-typed global variables."""
+        result: dict[str, str] = {}
+        for name, (vtype, vbytes) in self._global_variables.items():
+            if vtype == binary_serializer.VAR_TYPE_STRING:
+                result[name] = vbytes.decode("utf-8")
+        return result
 
     def get_all_client_variables(self, client_no: int) -> dict[str, str]:
-        """Return a copy of all variables for the given client."""
-        return self._client_variables.get(client_no, {}).copy()
+        """Return a copy of all string-typed variables for the given client."""
+        result: dict[str, str] = {}
+        for name, (vtype, vbytes) in self._client_variables.get(client_no, {}).items():
+            if vtype == binary_serializer.VAR_TYPE_STRING:
+                result[name] = vbytes.decode("utf-8")
+        return result
 
     def is_client_stealth_mode(self, client_no: int) -> bool:
         """Check if the client is in stealth mode."""
@@ -1323,9 +1443,19 @@ class net_sync_manager:
                 if event[0] == "global":
                     _, name, old_value, new_value = event
                     self.on_global_variable_changed.invoke(name, old_value, new_value)
+                elif event[0] == "global_bytes":
+                    _, name, old_value, new_value = event
+                    self.on_global_bytes_variable_changed.invoke(
+                        name, old_value, new_value
+                    )
                 elif event[0] == "client":
                     _, client_no, name, old_value, new_value = event
                     self.on_client_variable_changed.invoke(
+                        client_no, name, old_value, new_value
+                    )
+                elif event[0] == "client_bytes":
+                    _, client_no, name, old_value, new_value = event
+                    self.on_client_bytes_variable_changed.invoke(
                         client_no, name, old_value, new_value
                     )
                 dispatched += 1

--- a/STYLY-NetSync-Server/src/styly_netsync/default.toml
+++ b/STYLY-NetSync-Server/src/styly_netsync/default.toml
@@ -70,8 +70,8 @@ max_client_vars = 100
 # Maximum variable name length in bytes
 max_var_name_length = 64
 
-# Maximum variable value length in bytes
-max_var_value_length = 1024
+# Maximum variable value length in bytes (supports byte[] values up to this size)
+max_var_value_length = 65536
 
 # Network variable flush interval in seconds (50ms default)
 nv_flush_interval = 0.05

--- a/STYLY-NetSync-Server/src/styly_netsync/server.py
+++ b/STYLY-NetSync-Server/src/styly_netsync/server.py
@@ -142,6 +142,18 @@ def get_version() -> str:
     return "unknown"
 
 
+def _format_nv_value_for_log(value_type: int, value_bytes: bytes | None) -> str:
+    """Format an NV value for log output."""
+    if value_bytes is None:
+        return "None"
+    if value_type == binary_serializer.VAR_TYPE_BYTES:
+        return f"<binary:{len(value_bytes)} bytes>"
+    try:
+        return value_bytes.decode("utf-8")
+    except (UnicodeDecodeError, AttributeError):
+        return f"<binary:{len(value_bytes)} bytes>"
+
+
 class NetSyncServer:
     # Note: All default values are defined in default.toml, not in code.
     # The BROADCAST_CHECK_INTERVAL is derived from transform_broadcast_rate in config.
@@ -1316,7 +1328,10 @@ class NetSyncServer:
         """Buffer global variable set request for later processing"""
         sender_client_no = data.get("senderClientNo", 0)
         var_name = data.get("variableName", "")[: self.MAX_VAR_NAME_LENGTH]
-        var_value = data.get("variableValue", "")[: self.MAX_VAR_VALUE_LENGTH]
+        value_type = data.get("variableValueType", binary_serializer.VAR_TYPE_STRING)
+        value_bytes = data.get("variableValueBytes", b"")
+        if len(value_bytes) > self.MAX_VAR_VALUE_LENGTH:
+            value_bytes = value_bytes[: self.MAX_VAR_VALUE_LENGTH]
         timestamp = data.get("timestamp", time.monotonic())
 
         if not var_name:
@@ -1328,7 +1343,8 @@ class NetSyncServer:
             # Buffer the update (latest-wins per key)
             self.pending_global_nv[room_id][var_name] = (
                 sender_client_no,
-                var_value,
+                value_type,
+                value_bytes,
                 timestamp,
             )
 
@@ -1337,7 +1353,8 @@ class NetSyncServer:
         room_id: str,
         sender_client_no: int,
         var_name: str,
-        var_value: str,
+        value_type: int,
+        value_bytes: bytes,
         timestamp: float,
     ) -> bool:
         """Apply global variable update (used by flush, returns True if applied)"""
@@ -1352,7 +1369,10 @@ class NetSyncServer:
             if var_name in global_vars:
                 existing = global_vars[var_name]
                 # Skip if value unchanged (no-op)
-                if existing.get("value") == var_value:
+                if (
+                    existing.get("valueBytes") == value_bytes
+                    and existing.get("valueType") == value_type
+                ):
                     return False
                 if timestamp < existing["timestamp"] or (
                     timestamp == existing["timestamp"]
@@ -1360,18 +1380,23 @@ class NetSyncServer:
                 ):
                     return False  # Ignore older or lower priority update
 
-            # Store old value for logging
-            old_value = global_vars.get(var_name, {}).get("value", None)
+            # Log change
+            old_entry = global_vars.get(var_name, {})
+            old_display = _format_nv_value_for_log(
+                old_entry.get("valueType", 0), old_entry.get("valueBytes")
+            )
+            new_display = _format_nv_value_for_log(value_type, value_bytes)
 
             # Update variable
             global_vars[var_name] = {
-                "value": var_value,
+                "valueType": value_type,
+                "valueBytes": value_bytes,
                 "timestamp": timestamp,
                 "lastWriterClientNo": sender_client_no,
             }
 
             logger.info(
-                f"Global Variable Changed: room={room_id}, client={sender_client_no}, name='{var_name}', old='{old_value}', new='{var_value}'"
+                f"Global Variable Changed: room={room_id}, client={sender_client_no}, name='{var_name}', old='{old_display}', new='{new_display}'"
             )
             return True
 
@@ -1379,14 +1404,17 @@ class NetSyncServer:
         """Handle global variable set request (for backward compat - immediate apply+broadcast)"""
         sender_client_no = data.get("senderClientNo", 0)
         var_name = data.get("variableName", "")[: self.MAX_VAR_NAME_LENGTH]
-        var_value = data.get("variableValue", "")[: self.MAX_VAR_VALUE_LENGTH]
+        value_type = data.get("variableValueType", binary_serializer.VAR_TYPE_STRING)
+        value_bytes = data.get("variableValueBytes", b"")
+        if len(value_bytes) > self.MAX_VAR_VALUE_LENGTH:
+            value_bytes = value_bytes[: self.MAX_VAR_VALUE_LENGTH]
         timestamp = data.get("timestamp", time.monotonic())
 
         if not var_name:
             return
 
         if self._apply_global_var_set(
-            room_id, sender_client_no, var_name, var_value, timestamp
+            room_id, sender_client_no, var_name, value_type, value_bytes, timestamp
         ):
             # Broadcast sync to all clients
             self._broadcast_global_var_sync(room_id)
@@ -1396,7 +1424,10 @@ class NetSyncServer:
         sender_client_no = data.get("senderClientNo", 0)
         target_client_no = data.get("targetClientNo", 0)
         var_name = data.get("variableName", "")[: self.MAX_VAR_NAME_LENGTH]
-        var_value = data.get("variableValue", "")[: self.MAX_VAR_VALUE_LENGTH]
+        value_type = data.get("variableValueType", binary_serializer.VAR_TYPE_STRING)
+        value_bytes = data.get("variableValueBytes", b"")
+        if len(value_bytes) > self.MAX_VAR_VALUE_LENGTH:
+            value_bytes = value_bytes[: self.MAX_VAR_VALUE_LENGTH]
         timestamp = data.get("timestamp", time.monotonic())
 
         if not var_name:
@@ -1409,7 +1440,8 @@ class NetSyncServer:
             key = (target_client_no, var_name)
             self.pending_client_nv[room_id][key] = (
                 sender_client_no,
-                var_value,
+                value_type,
+                value_bytes,
                 timestamp,
             )
 
@@ -1419,7 +1451,8 @@ class NetSyncServer:
         sender_client_no: int,
         target_client_no: int,
         var_name: str,
-        var_value: str,
+        value_type: int,
+        value_bytes: bytes,
         timestamp: float,
     ) -> bool:
         """Apply client variable update (used by flush, returns True if applied)"""
@@ -1441,7 +1474,10 @@ class NetSyncServer:
             if var_name in client_vars:
                 existing = client_vars[var_name]
                 # Skip if value unchanged (no-op)
-                if existing.get("value") == var_value:
+                if (
+                    existing.get("valueBytes") == value_bytes
+                    and existing.get("valueType") == value_type
+                ):
                     return False
                 if timestamp < existing["timestamp"] or (
                     timestamp == existing["timestamp"]
@@ -1449,18 +1485,23 @@ class NetSyncServer:
                 ):
                     return False  # Ignore older or lower priority update
 
-            # Store old value for logging
-            old_value = client_vars.get(var_name, {}).get("value", None)
+            # Log change
+            old_entry = client_vars.get(var_name, {})
+            old_display = _format_nv_value_for_log(
+                old_entry.get("valueType", 0), old_entry.get("valueBytes")
+            )
+            new_display = _format_nv_value_for_log(value_type, value_bytes)
 
             # Update variable
             client_vars[var_name] = {
-                "value": var_value,
+                "valueType": value_type,
+                "valueBytes": value_bytes,
                 "timestamp": timestamp,
                 "lastWriterClientNo": sender_client_no,
             }
 
             logger.info(
-                f"Client Variable Changed: room={room_id}, target={target_client_no}, sender={sender_client_no}, name='{var_name}', old='{old_value}', new='{var_value}'"
+                f"Client Variable Changed: room={room_id}, target={target_client_no}, sender={sender_client_no}, name='{var_name}', old='{old_display}', new='{new_display}'"
             )
             return True
 
@@ -1469,14 +1510,23 @@ class NetSyncServer:
         sender_client_no = data.get("senderClientNo", 0)
         target_client_no = data.get("targetClientNo", 0)
         var_name = data.get("variableName", "")[: self.MAX_VAR_NAME_LENGTH]
-        var_value = data.get("variableValue", "")[: self.MAX_VAR_VALUE_LENGTH]
+        value_type = data.get("variableValueType", binary_serializer.VAR_TYPE_STRING)
+        value_bytes = data.get("variableValueBytes", b"")
+        if len(value_bytes) > self.MAX_VAR_VALUE_LENGTH:
+            value_bytes = value_bytes[: self.MAX_VAR_VALUE_LENGTH]
         timestamp = data.get("timestamp", time.monotonic())
 
         if not var_name:
             return
 
         if self._apply_client_var_set(
-            room_id, sender_client_no, target_client_no, var_name, var_value, timestamp
+            room_id,
+            sender_client_no,
+            target_client_no,
+            var_name,
+            value_type,
+            value_bytes,
+            timestamp,
         ):
             # Broadcast sync to all clients
             self._broadcast_client_var_sync(room_id)
@@ -1493,14 +1543,16 @@ class NetSyncServer:
 
         variables = []
         for var_name, var_data in self.global_variables[room_id].items():
-            variables.append(
-                {
-                    "name": var_name,
-                    "value": var_data["value"],
-                    "timestamp": var_data["timestamp"],
-                    "lastWriterClientNo": var_data["lastWriterClientNo"],
-                }
-            )
+            entry: dict[str, Any] = {
+                "name": var_name,
+                "valueType": var_data.get(
+                    "valueType", binary_serializer.VAR_TYPE_STRING
+                ),
+                "valueBytes": var_data.get("valueBytes", b""),
+                "timestamp": var_data["timestamp"],
+                "lastWriterClientNo": var_data["lastWriterClientNo"],
+            }
+            variables.append(entry)
 
         if not variables:
             return None
@@ -1520,14 +1572,16 @@ class NetSyncServer:
         for client_no, variables in self.client_variables[room_id].items():
             client_vars: list[dict[str, object]] = []
             for var_name, var_data in variables.items():
-                client_vars.append(
-                    {
-                        "name": var_name,
-                        "value": var_data["value"],
-                        "timestamp": var_data["timestamp"],
-                        "lastWriterClientNo": var_data["lastWriterClientNo"],
-                    }
-                )
+                entry: dict[str, object] = {
+                    "name": var_name,
+                    "valueType": var_data.get(
+                        "valueType", binary_serializer.VAR_TYPE_STRING
+                    ),
+                    "valueBytes": var_data.get("valueBytes", b""),
+                    "timestamp": var_data["timestamp"],
+                    "lastWriterClientNo": var_data["lastWriterClientNo"],
+                }
+                client_vars.append(entry)
             if client_vars:
                 client_variables[str(client_no)] = client_vars
 
@@ -1601,19 +1655,25 @@ class NetSyncServer:
             self.pending_client_nv[room_id] = {}
 
         applied_globals: list[str] = []
-        for var_name, (sender, value, ts) in globals_to_apply:
-            if self._apply_global_var_set(room_id, sender, var_name, value, ts):
+        for var_name, (sender, vtype, vbytes, ts) in globals_to_apply:
+            if self._apply_global_var_set(room_id, sender, var_name, vtype, vbytes, ts):
                 applied_globals.append(var_name)
 
         applied_clients: dict[int, list[dict[str, Any]]] = {}
-        for (target_client_no, var_name), (sender, value, ts) in clients_to_apply:
+        for (target_client_no, var_name), (
+            sender,
+            vtype,
+            vbytes,
+            ts,
+        ) in clients_to_apply:
             if self._apply_client_var_set(
-                room_id, sender, target_client_no, var_name, value, ts
+                room_id, sender, target_client_no, var_name, vtype, vbytes, ts
             ):
                 applied_clients.setdefault(target_client_no, []).append(
                     {
                         "name": var_name,
-                        "value": value,
+                        "valueType": vtype,
+                        "valueBytes": vbytes,
                         "timestamp": ts,
                         "lastWriterClientNo": sender,
                     }
@@ -1621,14 +1681,17 @@ class NetSyncServer:
 
         # Send NV syncs via ROUTER unicast for reliable delivery
         if applied_globals:
-            vars_payload = []
+            vars_payload: list[dict[str, Any]] = []
             with self._rooms_lock:
                 for name in applied_globals:
                     d = self.global_variables[room_id][name]
                     vars_payload.append(
                         {
                             "name": name,
-                            "value": d["value"],
+                            "valueType": d.get(
+                                "valueType", binary_serializer.VAR_TYPE_STRING
+                            ),
+                            "valueBytes": d.get("valueBytes", b""),
                             "timestamp": d["timestamp"],
                             "lastWriterClientNo": d["lastWriterClientNo"],
                         }

--- a/STYLY-NetSync-Server/tests/test_binary_serializer.py
+++ b/STYLY-NetSync-Server/tests/test_binary_serializer.py
@@ -867,3 +867,155 @@ class TestRPCMessageSerialization:
         _, result, _ = binary_serializer.deserialize(serialized)
 
         assert result["functionName"] == "OnDamage_テスト"
+
+
+class TestNetworkVariableSerialization:
+    """Tests for NV serialization with typed values (string and bytes)."""
+
+    def test_global_var_set_string_roundtrip(self) -> None:
+        """String global var set should round-trip correctly."""
+        data = {
+            "senderClientNo": 1,
+            "variableName": "score",
+            "variableValue": "hello world",
+            "variableValueType": binary_serializer.VAR_TYPE_STRING,
+            "timestamp": 1234.5,
+        }
+        serialized = binary_serializer.serialize_global_var_set(data)
+        msg_type, result, _ = binary_serializer.deserialize(serialized)
+
+        assert msg_type == binary_serializer.MSG_GLOBAL_VAR_SET
+        assert result["senderClientNo"] == 1
+        assert result["variableName"] == "score"
+        assert result["variableValueType"] == binary_serializer.VAR_TYPE_STRING
+        assert result["variableValue"] == "hello world"
+        assert result["variableValueBytes"] == b"hello world"
+
+    def test_global_var_set_bytes_roundtrip(self) -> None:
+        """Binary global var set should round-trip correctly."""
+        raw = bytes(range(256))
+        data = {
+            "senderClientNo": 2,
+            "variableName": "image",
+            "variableValueType": binary_serializer.VAR_TYPE_BYTES,
+            "variableValueBytes": raw,
+            "timestamp": 5678.9,
+        }
+        serialized = binary_serializer.serialize_global_var_set(data)
+        msg_type, result, _ = binary_serializer.deserialize(serialized)
+
+        assert msg_type == binary_serializer.MSG_GLOBAL_VAR_SET
+        assert result["variableValueType"] == binary_serializer.VAR_TYPE_BYTES
+        assert result["variableValueBytes"] == raw
+        assert "variableValue" not in result  # bytes type has no string key
+
+    def test_global_var_sync_mixed_types(self) -> None:
+        """Sync with both string and bytes variables should round-trip."""
+        data = {
+            "variables": [
+                {
+                    "name": "text_var",
+                    "valueType": binary_serializer.VAR_TYPE_STRING,
+                    "valueBytes": b"hello",
+                    "timestamp": 1.0,
+                    "lastWriterClientNo": 1,
+                },
+                {
+                    "name": "bin_var",
+                    "valueType": binary_serializer.VAR_TYPE_BYTES,
+                    "valueBytes": b"\x00\x01\x02\xff",
+                    "timestamp": 2.0,
+                    "lastWriterClientNo": 2,
+                },
+            ]
+        }
+        serialized = binary_serializer.serialize_global_var_sync(data)
+        msg_type, result, _ = binary_serializer.deserialize(serialized)
+
+        assert msg_type == binary_serializer.MSG_GLOBAL_VAR_SYNC
+        variables = result["variables"]
+        assert len(variables) == 2
+
+        assert variables[0]["name"] == "text_var"
+        assert variables[0]["valueType"] == binary_serializer.VAR_TYPE_STRING
+        assert variables[0]["value"] == "hello"
+        assert variables[0]["valueBytes"] == b"hello"
+
+        assert variables[1]["name"] == "bin_var"
+        assert variables[1]["valueType"] == binary_serializer.VAR_TYPE_BYTES
+        assert variables[1]["valueBytes"] == b"\x00\x01\x02\xff"
+        assert "value" not in variables[1]
+
+    def test_client_var_set_bytes_roundtrip(self) -> None:
+        """Binary client var set should round-trip correctly."""
+        raw = b"\xde\xad\xbe\xef"
+        data = {
+            "senderClientNo": 1,
+            "targetClientNo": 3,
+            "variableName": "data",
+            "variableValueType": binary_serializer.VAR_TYPE_BYTES,
+            "variableValueBytes": raw,
+            "timestamp": 100.0,
+        }
+        serialized = binary_serializer.serialize_client_var_set(data)
+        msg_type, result, _ = binary_serializer.deserialize(serialized)
+
+        assert msg_type == binary_serializer.MSG_CLIENT_VAR_SET
+        assert result["senderClientNo"] == 1
+        assert result["targetClientNo"] == 3
+        assert result["variableValueType"] == binary_serializer.VAR_TYPE_BYTES
+        assert result["variableValueBytes"] == raw
+
+    def test_client_var_sync_mixed_types(self) -> None:
+        """Client var sync with both string and bytes should round-trip."""
+        data = {
+            "clientVariables": {
+                "1": [
+                    {
+                        "name": "status",
+                        "valueType": binary_serializer.VAR_TYPE_STRING,
+                        "valueBytes": b"ready",
+                        "timestamp": 1.0,
+                        "lastWriterClientNo": 1,
+                    },
+                ],
+                "2": [
+                    {
+                        "name": "payload",
+                        "valueType": binary_serializer.VAR_TYPE_BYTES,
+                        "valueBytes": b"\x00" * 100,
+                        "timestamp": 2.0,
+                        "lastWriterClientNo": 2,
+                    },
+                ],
+            }
+        }
+        serialized = binary_serializer.serialize_client_var_sync(data)
+        msg_type, result, _ = binary_serializer.deserialize(serialized)
+
+        assert msg_type == binary_serializer.MSG_CLIENT_VAR_SYNC
+        client_vars = result["clientVariables"]
+
+        assert client_vars["1"][0]["name"] == "status"
+        assert client_vars["1"][0]["valueType"] == binary_serializer.VAR_TYPE_STRING
+        assert client_vars["1"][0]["value"] == "ready"
+
+        assert client_vars["2"][0]["name"] == "payload"
+        assert client_vars["2"][0]["valueType"] == binary_serializer.VAR_TYPE_BYTES
+        assert client_vars["2"][0]["valueBytes"] == b"\x00" * 100
+
+    def test_large_binary_value(self) -> None:
+        """Large binary value (64KB) should serialize and deserialize correctly."""
+        raw = bytes(range(256)) * 256  # 64KB
+        data = {
+            "senderClientNo": 1,
+            "variableName": "big",
+            "variableValueType": binary_serializer.VAR_TYPE_BYTES,
+            "variableValueBytes": raw,
+            "timestamp": 0.0,
+        }
+        serialized = binary_serializer.serialize_global_var_set(data)
+        msg_type, result, _ = binary_serializer.deserialize(serialized)
+
+        assert result["variableValueBytes"] == raw
+        assert len(result["variableValueBytes"]) == 65536

--- a/STYLY-NetSync-Server/tests/test_config.py
+++ b/STYLY-NetSync-Server/tests/test_config.py
@@ -57,7 +57,7 @@ class TestLoadDefaultConfig:
         assert config.max_global_vars == 100
         assert config.max_client_vars == 100
         assert config.max_var_name_length == 64
-        assert config.max_var_value_length == 1024
+        assert config.max_var_value_length == 65536
         assert config.nv_flush_interval == 0.05
         assert config.nv_monitor_window_size == 1.0
         assert config.nv_monitor_threshold == 200

--- a/STYLY-NetSync-Unity/Assets/Samples_Dev/BinaryVariable.meta
+++ b/STYLY-NetSync-Unity/Assets/Samples_Dev/BinaryVariable.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 2d60096f66d934b64940df10fe39bf11
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/STYLY-NetSync-Unity/Assets/Samples_Dev/BinaryVariable/BinaryPrimitiveSync.cs
+++ b/STYLY-NetSync-Unity/Assets/Samples_Dev/BinaryVariable/BinaryPrimitiveSync.cs
@@ -1,0 +1,87 @@
+using UnityEngine;
+
+namespace Styly.NetSync.Samples.BinaryVariable
+{
+    /// <summary>
+    /// Binary approach: syncs all three primitives' parameters via a single byte[] NetworkVariable.
+    /// A PrimitiveParams ScriptableObject is serialized/deserialized as a whole,
+    /// replacing 6 individual string variables with 1 binary variable.
+    /// </summary>
+    public class BinaryPrimitiveSync : MonoBehaviour
+    {
+        private const string VariableName = "binary_primitives";
+
+        [Header("Primitives")]
+        [SerializeField] private Transform _primitive0;
+        [SerializeField] private Transform _primitive1;
+        [SerializeField] private Transform _primitive2;
+
+        [Header("Parameters (edit and press Send)")]
+        [SerializeField] private PrimitiveParams _params;
+
+        private NetSyncManager _nsm;
+        private bool _ready;
+
+        private void Start()
+        {
+            _nsm = NetSyncManager.Instance;
+            if (_nsm == null) return;
+
+            if (_params == null)
+            {
+                _params = ScriptableObject.CreateInstance<PrimitiveParams>();
+            }
+
+            _nsm.OnReady.AddListener(OnReady);
+            _nsm.OnGlobalBytesVariableChanged.AddListener(OnGlobalBytesVariableChanged);
+        }
+
+        private void OnDestroy()
+        {
+            if (_nsm == null) return;
+            _nsm.OnReady.RemoveListener(OnReady);
+            _nsm.OnGlobalBytesVariableChanged.RemoveListener(OnGlobalBytesVariableChanged);
+        }
+
+        private void OnReady()
+        {
+            _ready = true;
+            // Apply initial values from network if they exist
+            byte[] existing = _nsm.GetGlobalVariableBytes(VariableName);
+            if (existing != null)
+            {
+                _params.Deserialize(existing);
+                ApplyParams();
+            }
+        }
+
+        [ContextMenu("Send")]
+        public void Send()
+        {
+            if (!_ready) return;
+            _nsm.SetGlobalVariable(VariableName, _params.Serialize());
+        }
+
+        private void OnGlobalBytesVariableChanged(string name, byte[] newValue, byte[] oldValue)
+        {
+            if (name != VariableName) return;
+            _params.Deserialize(newValue);
+            ApplyParams();
+        }
+
+        private void ApplyParams()
+        {
+            ApplyEntry(_primitive0, _params.primitive0);
+            ApplyEntry(_primitive1, _params.primitive1);
+            ApplyEntry(_primitive2, _params.primitive2);
+        }
+
+        private static void ApplyEntry(Transform t, PrimitiveParams.Entry entry)
+        {
+            if (t == null) return;
+            t.localScale = Vector3.one * entry.size;
+            var renderer = t.GetComponent<Renderer>();
+            if (renderer != null) renderer.material.color = entry.color;
+        }
+    }
+}

--- a/STYLY-NetSync-Unity/Assets/Samples_Dev/BinaryVariable/BinaryPrimitiveSync.cs.meta
+++ b/STYLY-NetSync-Unity/Assets/Samples_Dev/BinaryVariable/BinaryPrimitiveSync.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 5b2fbf967453e49e4b763c1becfe55c6

--- a/STYLY-NetSync-Unity/Assets/Samples_Dev/BinaryVariable/BinaryVariable.unity
+++ b/STYLY-NetSync-Unity/Assets/Samples_Dev/BinaryVariable/BinaryVariable.unity
@@ -1,0 +1,1530 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!29 &1
+OcclusionCullingSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_OcclusionBakeSettings:
+    smallestOccluder: 5
+    smallestHole: 0.25
+    backfaceThreshold: 100
+  m_SceneGUID: 00000000000000000000000000000000
+  m_OcclusionCullingData: {fileID: 0}
+--- !u!104 &2
+RenderSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 10
+  m_Fog: 0
+  m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+  m_FogMode: 3
+  m_FogDensity: 0.01
+  m_LinearFogStart: 0
+  m_LinearFogEnd: 300
+  m_AmbientSkyColor: {r: 0.212, g: 0.227, b: 0.259, a: 1}
+  m_AmbientEquatorColor: {r: 0.114, g: 0.125, b: 0.133, a: 1}
+  m_AmbientGroundColor: {r: 0.047, g: 0.043, b: 0.035, a: 1}
+  m_AmbientIntensity: 1
+  m_AmbientMode: 0
+  m_SubtractiveShadowColor: {r: 0.42, g: 0.478, b: 0.627, a: 1}
+  m_SkyboxMaterial: {fileID: 10304, guid: 0000000000000000f000000000000000, type: 0}
+  m_HaloStrength: 0.5
+  m_FlareStrength: 1
+  m_FlareFadeSpeed: 3
+  m_HaloTexture: {fileID: 0}
+  m_SpotCookie: {fileID: 10001, guid: 0000000000000000e000000000000000, type: 0}
+  m_DefaultReflectionMode: 0
+  m_DefaultReflectionResolution: 128
+  m_ReflectionBounces: 1
+  m_ReflectionIntensity: 1
+  m_CustomReflection: {fileID: 0}
+  m_Sun: {fileID: 0}
+  m_UseRadianceAmbientProbe: 0
+--- !u!157 &3
+LightmapSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 13
+  m_BakeOnSceneLoad: 0
+  m_GISettings:
+    serializedVersion: 2
+    m_BounceScale: 1
+    m_IndirectOutputScale: 1
+    m_AlbedoBoost: 1
+    m_EnvironmentLightingMode: 0
+    m_EnableBakedLightmaps: 1
+    m_EnableRealtimeLightmaps: 0
+  m_LightmapEditorSettings:
+    serializedVersion: 12
+    m_Resolution: 2
+    m_BakeResolution: 40
+    m_AtlasSize: 1024
+    m_AO: 0
+    m_AOMaxDistance: 1
+    m_CompAOExponent: 1
+    m_CompAOExponentDirect: 0
+    m_ExtractAmbientOcclusion: 0
+    m_Padding: 2
+    m_LightmapParameters: {fileID: 0}
+    m_LightmapsBakeMode: 1
+    m_TextureCompression: 1
+    m_ReflectionCompression: 2
+    m_MixedBakeMode: 2
+    m_BakeBackend: 1
+    m_PVRSampling: 1
+    m_PVRDirectSampleCount: 32
+    m_PVRSampleCount: 512
+    m_PVRBounces: 2
+    m_PVREnvironmentSampleCount: 256
+    m_PVREnvironmentReferencePointCount: 2048
+    m_PVRFilteringMode: 1
+    m_PVRDenoiserTypeDirect: 1
+    m_PVRDenoiserTypeIndirect: 1
+    m_PVRDenoiserTypeAO: 1
+    m_PVRFilterTypeDirect: 0
+    m_PVRFilterTypeIndirect: 0
+    m_PVRFilterTypeAO: 0
+    m_PVREnvironmentMIS: 1
+    m_PVRCulling: 1
+    m_PVRFilteringGaussRadiusDirect: 1
+    m_PVRFilteringGaussRadiusIndirect: 1
+    m_PVRFilteringGaussRadiusAO: 1
+    m_PVRFilteringAtrousPositionSigmaDirect: 0.5
+    m_PVRFilteringAtrousPositionSigmaIndirect: 2
+    m_PVRFilteringAtrousPositionSigmaAO: 1
+    m_ExportTrainingData: 0
+    m_TrainingDataDestination: TrainingData
+    m_LightProbeSampleCountMultiplier: 4
+  m_LightingDataAsset: {fileID: 20201, guid: 0000000000000000f000000000000000, type: 0}
+  m_LightingSettings: {fileID: 0}
+--- !u!196 &4
+NavMeshSettings:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_BuildSettings:
+    serializedVersion: 3
+    agentTypeID: 0
+    agentRadius: 0.5
+    agentHeight: 2
+    agentSlope: 45
+    agentClimb: 0.4
+    ledgeDropHeight: 0
+    maxJumpAcrossDistance: 0
+    minRegionArea: 2
+    manualCellSize: 0
+    cellSize: 0.16666667
+    manualTileSize: 0
+    tileSize: 256
+    buildHeightMesh: 0
+    maxJobWorkers: 0
+    preserveTilesOutsideBounds: 0
+    debug:
+      m_Flags: 0
+  m_NavMeshData: {fileID: 0}
+--- !u!1 &25876973
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 25876974}
+  - component: {fileID: 25876977}
+  - component: {fileID: 25876976}
+  - component: {fileID: 25876975}
+  m_Layer: 0
+  m_Name: Primitive_2_Cylinder
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &25876974
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 25876973}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 2.5, y: -1.05, z: 3}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1475274255}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!23 &25876975
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 25876973}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 1327652960}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 1
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!136 &25876976
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 25876973}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Radius: 0.5
+  m_Height: 2
+  m_Direction: 1
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!33 &25876977
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 25876973}
+  m_Mesh: {fileID: 10206, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!21 &114328649
+Material:
+  serializedVersion: 8
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Universal Render Pipeline/Lit
+  m_Shader: {fileID: 4800000, guid: 933532a4fcc9baf4fa0491de14d08ed7, type: 3}
+  m_Parent: {fileID: 0}
+  m_ModifiedSerializedProperties: 0
+  m_ValidKeywords: []
+  m_InvalidKeywords: []
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap:
+    RenderType: Opaque
+  disabledShaderPasses:
+  - MOTIONVECTORS
+  m_LockedProperties: 
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _BaseMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _BumpMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailAlbedoMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailMask:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailNormalMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _EmissionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MetallicGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _OcclusionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _ParallaxMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _SpecGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_Lightmaps:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_LightmapsInd:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_ShadowMasks:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Ints: []
+    m_Floats:
+    - _AddPrecomputedVelocity: 0
+    - _AlphaClip: 0
+    - _AlphaToMask: 0
+    - _Blend: 0
+    - _BlendModePreserveSpecular: 1
+    - _BumpScale: 1
+    - _ClearCoatMask: 0
+    - _ClearCoatSmoothness: 0
+    - _Cull: 2
+    - _Cutoff: 0.5
+    - _DetailAlbedoMapScale: 1
+    - _DetailNormalMapScale: 1
+    - _DstBlend: 0
+    - _DstBlendAlpha: 0
+    - _EnvironmentReflections: 1
+    - _GlossMapScale: 0
+    - _Glossiness: 0
+    - _GlossyReflections: 0
+    - _Metallic: 0
+    - _OcclusionStrength: 1
+    - _Parallax: 0.005
+    - _QueueOffset: 0
+    - _ReceiveShadows: 1
+    - _Smoothness: 0.5
+    - _SmoothnessTextureChannel: 0
+    - _SpecularHighlights: 1
+    - _SrcBlend: 1
+    - _SrcBlendAlpha: 1
+    - _Surface: 0
+    - _WorkflowMode: 1
+    - _ZWrite: 1
+    m_Colors:
+    - _BaseColor: {r: 0, g: 1, b: 0, a: 1}
+    - _Color: {r: 0, g: 1, b: 0, a: 1}
+    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
+    - _SpecColor: {r: 0.19999996, g: 0.19999996, b: 0.19999996, a: 1}
+  m_BuildTextureStacks: []
+  m_AllowLocking: 1
+--- !u!1001 &172324161
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1552238951006641643, guid: e143c37e2b0944c278fd43733d72fa3b, type: 3}
+      propertyPath: m_Name
+      value: NetSyncManager
+      objectReference: {fileID: 0}
+    - target: {fileID: 3615311826436424041, guid: e143c37e2b0944c278fd43733d72fa3b, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3615311826436424041, guid: e143c37e2b0944c278fd43733d72fa3b, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3615311826436424041, guid: e143c37e2b0944c278fd43733d72fa3b, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3615311826436424041, guid: e143c37e2b0944c278fd43733d72fa3b, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3615311826436424041, guid: e143c37e2b0944c278fd43733d72fa3b, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3615311826436424041, guid: e143c37e2b0944c278fd43733d72fa3b, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3615311826436424041, guid: e143c37e2b0944c278fd43733d72fa3b, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3615311826436424041, guid: e143c37e2b0944c278fd43733d72fa3b, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3615311826436424041, guid: e143c37e2b0944c278fd43733d72fa3b, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3615311826436424041, guid: e143c37e2b0944c278fd43733d72fa3b, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5729049226429455924, guid: e143c37e2b0944c278fd43733d72fa3b, type: 3}
+      propertyPath: _syncBatteryLevel
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5729049226429455924, guid: e143c37e2b0944c278fd43733d72fa3b, type: 3}
+      propertyPath: _localAvatarPrefab
+      value: 
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: e143c37e2b0944c278fd43733d72fa3b, type: 3}
+--- !u!1 &245765279
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 245765280}
+  - component: {fileID: 245765283}
+  - component: {fileID: 245765282}
+  - component: {fileID: 245765281}
+  m_Layer: 0
+  m_Name: Primitive_0_Cube
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &245765280
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 245765279}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -2.5, y: -1.55, z: 3}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1475274255}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!23 &245765281
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 245765279}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 1404314396}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 1
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!65 &245765282
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 245765279}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!33 &245765283
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 245765279}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!1 &264860645
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 264860646}
+  - component: {fileID: 264860649}
+  - component: {fileID: 264860648}
+  - component: {fileID: 264860647}
+  m_Layer: 0
+  m_Name: Primitive_0_Cube
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &264860646
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 264860645}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -2.5, y: 2.27, z: 3}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 994727394}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!23 &264860647
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 264860645}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 1404314396}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 1
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!65 &264860648
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 264860645}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!33 &264860649
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 264860645}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!1 &994727392
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 994727394}
+  - component: {fileID: 994727393}
+  m_Layer: 0
+  m_Name: NaivePrimitiveSync
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &994727393
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 994727392}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 78d6506e0988840b08bd298a17f120e3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _primitive0: {fileID: 264860646}
+  _primitive1: {fileID: 1876703496}
+  _primitive2: {fileID: 1861025666}
+  _size0: 1
+  _color0: {r: 1, g: 0, b: 0, a: 1}
+  _size1: 1
+  _color1: {r: 0, g: 1, b: 0, a: 1}
+  _size2: 1
+  _color2: {r: 0, g: 0, b: 1, a: 1}
+--- !u!4 &994727394
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 994727392}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 264860646}
+  - {fileID: 1876703496}
+  - {fileID: 1861025666}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1158897731
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1158897734}
+  - component: {fileID: 1158897733}
+  - component: {fileID: 1158897732}
+  m_Layer: 0
+  m_Name: Directional Light
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1158897732
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1158897731}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 474bcb49853aa07438625e644c072ee6, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Version: 3
+  m_UsePipelineSettings: 1
+  m_AdditionalLightsShadowResolutionTier: 2
+  m_LightLayerMask: 1
+  m_RenderingLayers: 1
+  m_CustomShadowLayers: 0
+  m_ShadowLayerMask: 1
+  m_ShadowRenderingLayers: 1
+  m_LightCookieSize: {x: 1, y: 1}
+  m_LightCookieOffset: {x: 0, y: 0}
+  m_SoftShadowQuality: 0
+--- !u!108 &1158897733
+Light:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1158897731}
+  m_Enabled: 1
+  serializedVersion: 11
+  m_Type: 1
+  m_Color: {r: 1, g: 0.95686275, b: 0.8392157, a: 1}
+  m_Intensity: 1
+  m_Range: 10
+  m_SpotAngle: 30
+  m_InnerSpotAngle: 21.80208
+  m_CookieSize: 10
+  m_Shadows:
+    m_Type: 2
+    m_Resolution: -1
+    m_CustomResolution: -1
+    m_Strength: 1
+    m_Bias: 0.05
+    m_NormalBias: 0.4
+    m_NearPlane: 0.2
+    m_CullingMatrixOverride:
+      e00: 1
+      e01: 0
+      e02: 0
+      e03: 0
+      e10: 0
+      e11: 1
+      e12: 0
+      e13: 0
+      e20: 0
+      e21: 0
+      e22: 1
+      e23: 0
+      e30: 0
+      e31: 0
+      e32: 0
+      e33: 1
+    m_UseCullingMatrixOverride: 0
+  m_Cookie: {fileID: 0}
+  m_DrawHalo: 0
+  m_Flare: {fileID: 0}
+  m_RenderMode: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingLayerMask: 1
+  m_Lightmapping: 4
+  m_LightShadowCasterMode: 0
+  m_AreaSize: {x: 1, y: 1}
+  m_BounceIntensity: 1
+  m_ColorTemperature: 6570
+  m_UseColorTemperature: 0
+  m_BoundingSphereOverride: {x: 0, y: 0, z: 0, w: 0}
+  m_UseBoundingSphereOverride: 0
+  m_UseViewFrustumForShadowCasterCull: 1
+  m_ForceVisible: 0
+  m_ShadowRadius: 0
+  m_ShadowAngle: 0
+  m_LightUnit: 1
+  m_LuxAtDistance: 1
+  m_EnableSpotReflector: 1
+--- !u!4 &1158897734
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1158897731}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.40821788, y: -0.23456968, z: 0.10938163, w: 0.8754261}
+  m_LocalPosition: {x: 0, y: 3, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 50, y: -30, z: 0}
+--- !u!21 &1327652960
+Material:
+  serializedVersion: 8
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Universal Render Pipeline/Lit
+  m_Shader: {fileID: 4800000, guid: 933532a4fcc9baf4fa0491de14d08ed7, type: 3}
+  m_Parent: {fileID: 0}
+  m_ModifiedSerializedProperties: 0
+  m_ValidKeywords: []
+  m_InvalidKeywords: []
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap:
+    RenderType: Opaque
+  disabledShaderPasses:
+  - MOTIONVECTORS
+  m_LockedProperties: 
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _BaseMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _BumpMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailAlbedoMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailMask:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailNormalMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _EmissionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MetallicGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _OcclusionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _ParallaxMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _SpecGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_Lightmaps:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_LightmapsInd:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_ShadowMasks:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Ints: []
+    m_Floats:
+    - _AddPrecomputedVelocity: 0
+    - _AlphaClip: 0
+    - _AlphaToMask: 0
+    - _Blend: 0
+    - _BlendModePreserveSpecular: 1
+    - _BumpScale: 1
+    - _ClearCoatMask: 0
+    - _ClearCoatSmoothness: 0
+    - _Cull: 2
+    - _Cutoff: 0.5
+    - _DetailAlbedoMapScale: 1
+    - _DetailNormalMapScale: 1
+    - _DstBlend: 0
+    - _DstBlendAlpha: 0
+    - _EnvironmentReflections: 1
+    - _GlossMapScale: 0
+    - _Glossiness: 0
+    - _GlossyReflections: 0
+    - _Metallic: 0
+    - _OcclusionStrength: 1
+    - _Parallax: 0.005
+    - _QueueOffset: 0
+    - _ReceiveShadows: 1
+    - _Smoothness: 0.5
+    - _SmoothnessTextureChannel: 0
+    - _SpecularHighlights: 1
+    - _SrcBlend: 1
+    - _SrcBlendAlpha: 1
+    - _Surface: 0
+    - _WorkflowMode: 1
+    - _ZWrite: 1
+    m_Colors:
+    - _BaseColor: {r: 0, g: 0, b: 1, a: 1}
+    - _Color: {r: 0, g: 0, b: 1, a: 1}
+    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
+    - _SpecColor: {r: 0.19999996, g: 0.19999996, b: 0.19999996, a: 1}
+  m_BuildTextureStacks: []
+  m_AllowLocking: 1
+--- !u!21 &1404314396
+Material:
+  serializedVersion: 8
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Universal Render Pipeline/Lit
+  m_Shader: {fileID: 4800000, guid: 933532a4fcc9baf4fa0491de14d08ed7, type: 3}
+  m_Parent: {fileID: 0}
+  m_ModifiedSerializedProperties: 0
+  m_ValidKeywords: []
+  m_InvalidKeywords: []
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap:
+    RenderType: Opaque
+  disabledShaderPasses:
+  - MOTIONVECTORS
+  m_LockedProperties: 
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _BaseMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _BumpMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailAlbedoMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailMask:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailNormalMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _EmissionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MetallicGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _OcclusionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _ParallaxMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _SpecGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_Lightmaps:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_LightmapsInd:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_ShadowMasks:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Ints: []
+    m_Floats:
+    - _AddPrecomputedVelocity: 0
+    - _AlphaClip: 0
+    - _AlphaToMask: 0
+    - _Blend: 0
+    - _BlendModePreserveSpecular: 1
+    - _BumpScale: 1
+    - _ClearCoatMask: 0
+    - _ClearCoatSmoothness: 0
+    - _Cull: 2
+    - _Cutoff: 0.5
+    - _DetailAlbedoMapScale: 1
+    - _DetailNormalMapScale: 1
+    - _DstBlend: 0
+    - _DstBlendAlpha: 0
+    - _EnvironmentReflections: 1
+    - _GlossMapScale: 0
+    - _Glossiness: 0
+    - _GlossyReflections: 0
+    - _Metallic: 0
+    - _OcclusionStrength: 1
+    - _Parallax: 0.005
+    - _QueueOffset: 0
+    - _ReceiveShadows: 1
+    - _Smoothness: 0.5
+    - _SmoothnessTextureChannel: 0
+    - _SpecularHighlights: 1
+    - _SrcBlend: 1
+    - _SrcBlendAlpha: 1
+    - _Surface: 0
+    - _WorkflowMode: 1
+    - _ZWrite: 1
+    m_Colors:
+    - _BaseColor: {r: 1, g: 0, b: 0, a: 1}
+    - _Color: {r: 1, g: 0, b: 0, a: 1}
+    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
+    - _SpecColor: {r: 0.19999996, g: 0.19999996, b: 0.19999996, a: 1}
+  m_BuildTextureStacks: []
+  m_AllowLocking: 1
+--- !u!1 &1475274253
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1475274255}
+  - component: {fileID: 1475274254}
+  m_Layer: 0
+  m_Name: BinaryPrimitiveSync
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1475274254
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1475274253}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5b2fbf967453e49e4b763c1becfe55c6, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _primitive0: {fileID: 245765280}
+  _primitive1: {fileID: 1822476060}
+  _primitive2: {fileID: 25876974}
+  _params: {fileID: 11400000, guid: 40f5f6f6412104ced88de91a6339fa9b, type: 2}
+--- !u!4 &1475274255
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1475274253}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 245765280}
+  - {fileID: 1822476060}
+  - {fileID: 25876974}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1822476059
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1822476060}
+  - component: {fileID: 1822476063}
+  - component: {fileID: 1822476062}
+  - component: {fileID: 1822476061}
+  m_Layer: 0
+  m_Name: Primitive_1_Sphere
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1822476060
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1822476059}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: -1.55, z: 3}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1475274255}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!23 &1822476061
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1822476059}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 114328649}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 1
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!135 &1822476062
+SphereCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1822476059}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Radius: 0.5
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!33 &1822476063
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1822476059}
+  m_Mesh: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!1 &1861025665
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1861025666}
+  - component: {fileID: 1861025669}
+  - component: {fileID: 1861025668}
+  - component: {fileID: 1861025667}
+  m_Layer: 0
+  m_Name: Primitive_2_Cylinder
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1861025666
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1861025665}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 2.5, y: 2.77, z: 3}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 994727394}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!23 &1861025667
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1861025665}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 1327652960}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 1
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!136 &1861025668
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1861025665}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Radius: 0.5
+  m_Height: 2
+  m_Direction: 1
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!33 &1861025669
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1861025665}
+  m_Mesh: {fileID: 10206, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!1 &1876703495
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1876703496}
+  - component: {fileID: 1876703499}
+  - component: {fileID: 1876703498}
+  - component: {fileID: 1876703497}
+  m_Layer: 0
+  m_Name: Primitive_1_Sphere
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1876703496
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1876703495}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 2.27, z: 3}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 994727394}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!23 &1876703497
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1876703495}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 114328649}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 1
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!135 &1876703498
+SphereCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1876703495}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Radius: 0.5
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!33 &1876703499
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1876703495}
+  m_Mesh: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!1 &1879872015
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1879872018}
+  - component: {fileID: 1879872017}
+  - component: {fileID: 1879872016}
+  m_Layer: 0
+  m_Name: Main Camera
+  m_TagString: MainCamera
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!81 &1879872016
+AudioListener:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1879872015}
+  m_Enabled: 1
+--- !u!20 &1879872017
+Camera:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1879872015}
+  m_Enabled: 1
+  serializedVersion: 2
+  m_ClearFlags: 1
+  m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
+  m_projectionMatrixMode: 1
+  m_GateFitMode: 2
+  m_FOVAxisMode: 0
+  m_Iso: 200
+  m_ShutterSpeed: 0.005
+  m_Aperture: 16
+  m_FocusDistance: 10
+  m_FocalLength: 50
+  m_BladeCount: 5
+  m_Curvature: {x: 2, y: 11}
+  m_BarrelClipping: 0.25
+  m_Anamorphism: 0
+  m_SensorSize: {x: 36, y: 24}
+  m_LensShift: {x: 0, y: 0}
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+  near clip plane: 0.3
+  far clip plane: 1000
+  field of view: 60
+  orthographic: 0
+  orthographic size: 5
+  m_Depth: -1
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 0}
+  m_TargetDisplay: 0
+  m_TargetEye: 3
+  m_HDR: 1
+  m_AllowMSAA: 1
+  m_AllowDynamicResolution: 0
+  m_ForceIntoRT: 0
+  m_OcclusionCulling: 1
+  m_StereoConvergence: 10
+  m_StereoSeparation: 0.022
+--- !u!4 &1879872018
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1879872015}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 1, z: -10}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1660057539 &9223372036854775807
+SceneRoots:
+  m_ObjectHideFlags: 0
+  m_Roots:
+  - {fileID: 1879872018}
+  - {fileID: 1158897734}
+  - {fileID: 172324161}
+  - {fileID: 994727394}
+  - {fileID: 1475274255}

--- a/STYLY-NetSync-Unity/Assets/Samples_Dev/BinaryVariable/BinaryVariable.unity
+++ b/STYLY-NetSync-Unity/Assets/Samples_Dev/BinaryVariable/BinaryVariable.unity
@@ -350,6 +350,85 @@ Material:
     - _SpecColor: {r: 0.19999996, g: 0.19999996, b: 0.19999996, a: 1}
   m_BuildTextureStacks: []
   m_AllowLocking: 1
+--- !u!1 &136466232
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 136466233}
+  - component: {fileID: 136466235}
+  - component: {fileID: 136466234}
+  m_Layer: 0
+  m_Name: Text
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &136466233
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 136466232}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1197567894}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &136466234
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 136466232}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0, g: 0, b: 0, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 24
+    m_FontStyle: 0
+    m_BestFit: 1
+    m_MinSize: 10
+    m_MaxSize: 40
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: Capture Screenshot
+--- !u!222 &136466235
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 136466232}
+  m_CullTransparentMesh: 1
 --- !u!1001 &172324161
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -631,6 +710,203 @@ MeshFilter:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 264860645}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!1 &278419772
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 278419774}
+  - component: {fileID: 278419773}
+  m_Layer: 0
+  m_Name: ScreenshotSync
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &278419773
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 278419772}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cfc064d42322e4d1fa2109c5f92fadb0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _displayImage: {fileID: 445010775}
+  _captureButton: {fileID: 1197567891}
+--- !u!4 &278419774
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 278419772}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &445010772
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 445010773}
+  - component: {fileID: 445010774}
+  - component: {fileID: 445010775}
+  m_Layer: 0
+  m_Name: RawImage
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &445010773
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 445010772}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1512154810}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 159, y: -138}
+  m_SizeDelta: {x: 183.33759, y: 199.60248}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &445010774
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 445010772}
+  m_CullTransparentMesh: 1
+--- !u!114 &445010775
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 445010772}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1344c3c82d62a2a41a3576d8abb8e3ea, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Texture: {fileID: 0}
+  m_UVRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+--- !u!1 &788284240
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 788284243}
+  - component: {fileID: 788284242}
+  - component: {fileID: 788284241}
+  m_Layer: 0
+  m_Name: EventSystem
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &788284241
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 788284240}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 01614664b831546d2ae94a42149d80ac, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_SendPointerHoverToParent: 1
+  m_MoveRepeatDelay: 0.5
+  m_MoveRepeatRate: 0.1
+  m_XRTrackingOrigin: {fileID: 0}
+  m_ActionsAsset: {fileID: -944628639613478452, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  m_PointAction: {fileID: -1654692200621890270, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  m_MoveAction: {fileID: -8784545083839296357, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  m_SubmitAction: {fileID: 392368643174621059, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  m_CancelAction: {fileID: 7727032971491509709, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  m_LeftClickAction: {fileID: 3001919216989983466, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  m_MiddleClickAction: {fileID: -2185481485913320682, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  m_RightClickAction: {fileID: -4090225696740746782, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  m_ScrollWheelAction: {fileID: 6240969308177333660, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  m_TrackedDevicePositionAction: {fileID: 6564999863303420839, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  m_TrackedDeviceOrientationAction: {fileID: 7970375526676320489, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  m_DeselectOnBackgroundClick: 1
+  m_PointerBehavior: 0
+  m_CursorLockBehavior: 0
+  m_ScrollDeltaPerTick: 6
+--- !u!114 &788284242
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 788284240}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 76c392e42b5098c458856cdf6ecaaaa1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_FirstSelected: {fileID: 0}
+  m_sendNavigationEvents: 1
+  m_DragThreshold: 10
+--- !u!4 &788284243
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 788284240}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &994727392
 GameObject:
   m_ObjectHideFlags: 0
@@ -808,6 +1084,127 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 50, y: -30, z: 0}
+--- !u!1 &1197567890
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1197567894}
+  - component: {fileID: 1197567893}
+  - component: {fileID: 1197567892}
+  - component: {fileID: 1197567891}
+  m_Layer: 0
+  m_Name: CaptureButton
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1197567891
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1197567890}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 1197567892}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!114 &1197567892
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1197567890}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.8, g: 0.8, b: 0.8, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &1197567893
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1197567890}
+  m_CullTransparentMesh: 1
+--- !u!224 &1197567894
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1197567890}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 136466233}
+  m_Father: {fileID: 1512154810}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 159, y: -279.4684}
+  m_SizeDelta: {x: 183.33759, y: 50.400604}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!21 &1327652960
 Material:
   serializedVersion: 8
@@ -1101,6 +1498,109 @@ Transform:
   - {fileID: 25876974}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1512154809
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1512154810}
+  - component: {fileID: 1512154813}
+  - component: {fileID: 1512154812}
+  - component: {fileID: 1512154811}
+  m_Layer: 0
+  m_Name: Canvas
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1512154810
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1512154809}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0, y: 0, z: 0}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 445010773}
+  - {fileID: 1197567894}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0, y: 0}
+--- !u!114 &1512154811
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1512154809}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dc42784cf147c0c48a680349fa168899, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreReversedGraphics: 1
+  m_BlockingObjects: 0
+  m_BlockingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+--- !u!114 &1512154812
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1512154809}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_UiScaleMode: 0
+  m_ReferencePixelsPerUnit: 100
+  m_ScaleFactor: 1
+  m_ReferenceResolution: {x: 800, y: 600}
+  m_ScreenMatchMode: 0
+  m_MatchWidthOrHeight: 0
+  m_PhysicalUnit: 3
+  m_FallbackScreenDPI: 96
+  m_DefaultSpriteDPI: 96
+  m_DynamicPixelsPerUnit: 1
+  m_PresetInfoIsWorld: 0
+--- !u!223 &1512154813
+Canvas:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1512154809}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_RenderMode: 0
+  m_Camera: {fileID: 0}
+  m_PlaneDistance: 100
+  m_PixelPerfect: 0
+  m_ReceivesEvents: 1
+  m_OverrideSorting: 0
+  m_OverridePixelPerfect: 0
+  m_SortingBucketNormalizedSize: 0
+  m_VertexColorAlwaysGammaSpace: 0
+  m_AdditionalShaderChannelsFlag: 0
+  m_UpdateRectTransformForStandalone: 0
+  m_SortingLayerID: 0
+  m_SortingOrder: 0
+  m_TargetDisplay: 0
 --- !u!1 &1822476059
 GameObject:
   m_ObjectHideFlags: 0
@@ -1528,3 +2028,6 @@ SceneRoots:
   - {fileID: 172324161}
   - {fileID: 994727394}
   - {fileID: 1475274255}
+  - {fileID: 788284243}
+  - {fileID: 1512154810}
+  - {fileID: 278419774}

--- a/STYLY-NetSync-Unity/Assets/Samples_Dev/BinaryVariable/BinaryVariable.unity.meta
+++ b/STYLY-NetSync-Unity/Assets/Samples_Dev/BinaryVariable/BinaryVariable.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: cea0827953527414c822e4dd24798323
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/STYLY-NetSync-Unity/Assets/Samples_Dev/BinaryVariable/DefaultPrimitiveParams.asset
+++ b/STYLY-NetSync-Unity/Assets/Samples_Dev/BinaryVariable/DefaultPrimitiveParams.asset
@@ -1,0 +1,23 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: af115913eb7f04d2381fadaf5103147a, type: 3}
+  m_Name: DefaultPrimitiveParams
+  m_EditorClassIdentifier: 
+  primitive0:
+    size: 1
+    color: {r: 1, g: 0, b: 0, a: 1}
+  primitive1:
+    size: 1
+    color: {r: 0, g: 1, b: 0, a: 1}
+  primitive2:
+    size: 1
+    color: {r: 0, g: 0, b: 1, a: 1}

--- a/STYLY-NetSync-Unity/Assets/Samples_Dev/BinaryVariable/DefaultPrimitiveParams.asset
+++ b/STYLY-NetSync-Unity/Assets/Samples_Dev/BinaryVariable/DefaultPrimitiveParams.asset
@@ -13,11 +13,11 @@ MonoBehaviour:
   m_Name: DefaultPrimitiveParams
   m_EditorClassIdentifier: 
   primitive0:
-    size: 1
-    color: {r: 1, g: 0, b: 0, a: 1}
+    size: 0.55
+    color: {r: 0.70375204, g: 1, b: 0, a: 1}
   primitive1:
-    size: 1
-    color: {r: 0, g: 1, b: 0, a: 1}
+    size: 1.75
+    color: {r: 1, g: 0, b: 0.8156204, a: 1}
   primitive2:
-    size: 1
+    size: 1.21
     color: {r: 0, g: 0, b: 1, a: 1}

--- a/STYLY-NetSync-Unity/Assets/Samples_Dev/BinaryVariable/DefaultPrimitiveParams.asset.meta
+++ b/STYLY-NetSync-Unity/Assets/Samples_Dev/BinaryVariable/DefaultPrimitiveParams.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 40f5f6f6412104ced88de91a6339fa9b
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/STYLY-NetSync-Unity/Assets/Samples_Dev/BinaryVariable/Editor.meta
+++ b/STYLY-NetSync-Unity/Assets/Samples_Dev/BinaryVariable/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 60c96e22ff52846b4a2569e07e271cf8
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/STYLY-NetSync-Unity/Assets/Samples_Dev/BinaryVariable/Editor/BinaryPrimitiveSyncEditor.cs
+++ b/STYLY-NetSync-Unity/Assets/Samples_Dev/BinaryVariable/Editor/BinaryPrimitiveSyncEditor.cs
@@ -1,0 +1,24 @@
+using UnityEditor;
+using UnityEngine;
+
+namespace Styly.NetSync.Samples.BinaryVariable.Editor
+{
+    [CustomEditor(typeof(BinaryPrimitiveSync))]
+    public class BinaryPrimitiveSyncEditor : UnityEditor.Editor
+    {
+        public override void OnInspectorGUI()
+        {
+            DrawDefaultInspector();
+
+            EditorGUILayout.Space();
+
+            using (new EditorGUI.DisabledScope(!Application.isPlaying))
+            {
+                if (GUILayout.Button("Send"))
+                {
+                    ((BinaryPrimitiveSync)target).Send();
+                }
+            }
+        }
+    }
+}

--- a/STYLY-NetSync-Unity/Assets/Samples_Dev/BinaryVariable/Editor/BinaryPrimitiveSyncEditor.cs.meta
+++ b/STYLY-NetSync-Unity/Assets/Samples_Dev/BinaryVariable/Editor/BinaryPrimitiveSyncEditor.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: c2971b248d2fe44bc97031e1c2402410

--- a/STYLY-NetSync-Unity/Assets/Samples_Dev/BinaryVariable/Editor/NaivePrimitiveSyncEditor.cs
+++ b/STYLY-NetSync-Unity/Assets/Samples_Dev/BinaryVariable/Editor/NaivePrimitiveSyncEditor.cs
@@ -1,0 +1,24 @@
+using UnityEditor;
+using UnityEngine;
+
+namespace Styly.NetSync.Samples.BinaryVariable.Editor
+{
+    [CustomEditor(typeof(NaivePrimitiveSync))]
+    public class NaivePrimitiveSyncEditor : UnityEditor.Editor
+    {
+        public override void OnInspectorGUI()
+        {
+            DrawDefaultInspector();
+
+            EditorGUILayout.Space();
+
+            using (new EditorGUI.DisabledScope(!Application.isPlaying))
+            {
+                if (GUILayout.Button("Send All"))
+                {
+                    ((NaivePrimitiveSync)target).SendAll();
+                }
+            }
+        }
+    }
+}

--- a/STYLY-NetSync-Unity/Assets/Samples_Dev/BinaryVariable/Editor/NaivePrimitiveSyncEditor.cs.meta
+++ b/STYLY-NetSync-Unity/Assets/Samples_Dev/BinaryVariable/Editor/NaivePrimitiveSyncEditor.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 717d4671f59084cc38c9b349d62b60d8

--- a/STYLY-NetSync-Unity/Assets/Samples_Dev/BinaryVariable/NaivePrimitiveSync.cs
+++ b/STYLY-NetSync-Unity/Assets/Samples_Dev/BinaryVariable/NaivePrimitiveSync.cs
@@ -1,0 +1,120 @@
+using UnityEngine;
+
+namespace Styly.NetSync.Samples.BinaryVariable
+{
+    /// <summary>
+    /// Naive approach: syncs each primitive's size and color as individual string NetworkVariables.
+    /// This requires 6 separate variables (size_0, color_0, size_1, color_1, size_2, color_2).
+    /// </summary>
+    public class NaivePrimitiveSync : MonoBehaviour
+    {
+        [Header("Primitives")]
+        [SerializeField] private Transform _primitive0;
+        [SerializeField] private Transform _primitive1;
+        [SerializeField] private Transform _primitive2;
+
+        [Header("Parameters")]
+        [SerializeField] private float _size0 = 1f;
+        [SerializeField] private Color _color0 = Color.red;
+        [SerializeField] private float _size1 = 1f;
+        [SerializeField] private Color _color1 = Color.green;
+        [SerializeField] private float _size2 = 1f;
+        [SerializeField] private Color _color2 = Color.blue;
+
+        private NetSyncManager _nsm;
+        private bool _ready;
+
+        private void Start()
+        {
+            _nsm = NetSyncManager.Instance;
+            if (_nsm == null) return;
+
+            _nsm.OnReady.AddListener(OnReady);
+            _nsm.OnGlobalVariableChanged.AddListener(OnGlobalVariableChanged);
+        }
+
+        private void OnDestroy()
+        {
+            if (_nsm == null) return;
+            _nsm.OnReady.RemoveListener(OnReady);
+            _nsm.OnGlobalVariableChanged.RemoveListener(OnGlobalVariableChanged);
+        }
+
+        private void OnReady()
+        {
+            _ready = true;
+            // Apply initial values from network if they exist
+            ApplyFromNetwork();
+        }
+
+        [ContextMenu("Send All")]
+        public void SendAll()
+        {
+            if (!_ready) return;
+
+            _nsm.SetGlobalVariable("naive_size_0", _size0.ToString("R"));
+            _nsm.SetGlobalVariable("naive_color_0", ColorUtility.ToHtmlStringRGBA(_color0));
+            _nsm.SetGlobalVariable("naive_size_1", _size1.ToString("R"));
+            _nsm.SetGlobalVariable("naive_color_1", ColorUtility.ToHtmlStringRGBA(_color1));
+            _nsm.SetGlobalVariable("naive_size_2", _size2.ToString("R"));
+            _nsm.SetGlobalVariable("naive_color_2", ColorUtility.ToHtmlStringRGBA(_color2));
+        }
+
+        private void OnGlobalVariableChanged(string name, string oldValue, string newValue)
+        {
+            switch (name)
+            {
+                case "naive_size_0":
+                    if (float.TryParse(newValue, out float s0)) SetSize(_primitive0, s0);
+                    break;
+                case "naive_color_0":
+                    if (ColorUtility.TryParseHtmlString("#" + newValue, out Color c0)) SetColor(_primitive0, c0);
+                    break;
+                case "naive_size_1":
+                    if (float.TryParse(newValue, out float s1)) SetSize(_primitive1, s1);
+                    break;
+                case "naive_color_1":
+                    if (ColorUtility.TryParseHtmlString("#" + newValue, out Color c1)) SetColor(_primitive1, c1);
+                    break;
+                case "naive_size_2":
+                    if (float.TryParse(newValue, out float s2)) SetSize(_primitive2, s2);
+                    break;
+                case "naive_color_2":
+                    if (ColorUtility.TryParseHtmlString("#" + newValue, out Color c2)) SetColor(_primitive2, c2);
+                    break;
+            }
+        }
+
+        private void ApplyFromNetwork()
+        {
+            string s;
+
+            s = _nsm.GetGlobalVariable("naive_size_0");
+            if (s != null && float.TryParse(s, out float s0)) SetSize(_primitive0, s0);
+            s = _nsm.GetGlobalVariable("naive_color_0");
+            if (s != null && ColorUtility.TryParseHtmlString("#" + s, out Color c0)) SetColor(_primitive0, c0);
+
+            s = _nsm.GetGlobalVariable("naive_size_1");
+            if (s != null && float.TryParse(s, out float s1)) SetSize(_primitive1, s1);
+            s = _nsm.GetGlobalVariable("naive_color_1");
+            if (s != null && ColorUtility.TryParseHtmlString("#" + s, out Color c1)) SetColor(_primitive1, c1);
+
+            s = _nsm.GetGlobalVariable("naive_size_2");
+            if (s != null && float.TryParse(s, out float s2)) SetSize(_primitive2, s2);
+            s = _nsm.GetGlobalVariable("naive_color_2");
+            if (s != null && ColorUtility.TryParseHtmlString("#" + s, out Color c2)) SetColor(_primitive2, c2);
+        }
+
+        private static void SetSize(Transform t, float size)
+        {
+            if (t != null) t.localScale = Vector3.one * size;
+        }
+
+        private static void SetColor(Transform t, Color color)
+        {
+            if (t == null) return;
+            var renderer = t.GetComponent<Renderer>();
+            if (renderer != null) renderer.material.color = color;
+        }
+    }
+}

--- a/STYLY-NetSync-Unity/Assets/Samples_Dev/BinaryVariable/NaivePrimitiveSync.cs.meta
+++ b/STYLY-NetSync-Unity/Assets/Samples_Dev/BinaryVariable/NaivePrimitiveSync.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 78d6506e0988840b08bd298a17f120e3

--- a/STYLY-NetSync-Unity/Assets/Samples_Dev/BinaryVariable/PrimitiveParams.cs
+++ b/STYLY-NetSync-Unity/Assets/Samples_Dev/BinaryVariable/PrimitiveParams.cs
@@ -1,0 +1,35 @@
+using UnityEngine;
+
+namespace Styly.NetSync.Samples.BinaryVariable
+{
+    /// <summary>
+    /// ScriptableObject that holds size and color for three primitives.
+    /// Serialized to byte[] via JsonUtility for NetworkVariable sync.
+    /// </summary>
+    [CreateAssetMenu(fileName = "PrimitiveParams", menuName = "STYLY NetSync/Samples/PrimitiveParams")]
+    public class PrimitiveParams : ScriptableObject
+    {
+        [System.Serializable]
+        public struct Entry
+        {
+            public float size;
+            public Color color;
+        }
+
+        public Entry primitive0 = new Entry { size = 1f, color = Color.red };
+        public Entry primitive1 = new Entry { size = 1f, color = Color.green };
+        public Entry primitive2 = new Entry { size = 1f, color = Color.blue };
+
+        public byte[] Serialize()
+        {
+            string json = JsonUtility.ToJson(this);
+            return System.Text.Encoding.UTF8.GetBytes(json);
+        }
+
+        public void Deserialize(byte[] data)
+        {
+            string json = System.Text.Encoding.UTF8.GetString(data);
+            JsonUtility.FromJsonOverwrite(json, this);
+        }
+    }
+}

--- a/STYLY-NetSync-Unity/Assets/Samples_Dev/BinaryVariable/PrimitiveParams.cs.meta
+++ b/STYLY-NetSync-Unity/Assets/Samples_Dev/BinaryVariable/PrimitiveParams.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: af115913eb7f04d2381fadaf5103147a

--- a/STYLY-NetSync-Unity/Assets/Samples_Dev/BinaryVariable/README.md
+++ b/STYLY-NetSync-Unity/Assets/Samples_Dev/BinaryVariable/README.md
@@ -1,0 +1,89 @@
+# BinaryVariable Sample
+
+Demonstrates the `byte[]` NetworkVariable feature by syncing binary data between clients.
+
+## Scene Setup
+
+Open `BinaryVariable.unity`. The scene contains:
+
+- **NetSyncManager** — network connection (configure server address before playing)
+- **Primitive_0_Cube / Primitive_1_Sphere / Primitive_2_Cylinder** — sync targets
+- **Canvas** — UI for screenshot sync (RawImage + Capture Button)
+- **EventSystem** — required for UI interaction
+
+## Samples
+
+### 1. Naive Primitive Sync (string-based)
+
+**Script:** `NaivePrimitiveSync.cs` (disabled by default)
+
+Syncs each primitive's size and color using individual `string` NetworkVariables. This requires **6 separate variables**:
+
+| Variable | Type | Example |
+|---|---|---|
+| `naive_size_0` | string (float) | `"1.5"` |
+| `naive_color_0` | string (hex RGBA) | `"FF0000FF"` |
+| `naive_size_1` | string (float) | `"2.0"` |
+| ... | ... | ... |
+
+**Usage:**
+1. Enable the `NaivePrimitiveSync` GameObject
+2. Enter Play Mode and connect to the server
+3. Edit size/color values in the Inspector
+4. Click **Send All** button in the Inspector
+
+### 2. Binary Primitive Sync (byte[]-based)
+
+**Script:** `BinaryPrimitiveSync.cs` + `PrimitiveParams.cs`
+
+Syncs all three primitives' parameters via a **single `byte[]` NetworkVariable**. A `PrimitiveParams` ScriptableObject is serialized to JSON bytes and sent as one variable.
+
+| Variable | Type | Content |
+|---|---|---|
+| `binary_primitives` | byte[] | JSON of all 3 entries (size + color) |
+
+**Usage:**
+1. Enter Play Mode and connect to the server
+2. Edit the `DefaultPrimitiveParams` asset in the Inspector (size/color per primitive)
+3. Click **Send** button in the Inspector
+
+**Advantages over the naive approach:**
+- 1 variable instead of 6
+- Adding new parameters requires only a field addition to `PrimitiveParams` — no new variables needed
+- All parameters update atomically in a single message
+
+### 3. Screenshot Sync
+
+**Script:** `ScreenshotSync.cs`
+
+Captures a screenshot, resizes it to fit within the 64KB NetworkVariable limit, and syncs it as JPEG bytes. Other clients display the received image on a RawImage.
+
+| Variable | Type | Content |
+|---|---|---|
+| `screenshot` | byte[] | JPEG image data |
+
+**Usage:**
+1. Enter Play Mode and connect to the server
+2. Click the **Capture Screenshot** button in the Game view
+3. The screenshot appears on the RawImage for all connected clients
+
+**Size constraints:**
+- Max resolution: 320px (longest side, aspect ratio preserved)
+- JPEG quality: 50
+- Max payload: 64KB (`MAX_VAR_VALUE_LENGTH`)
+
+## File Structure
+
+```
+BinaryVariable/
+├── BinaryVariable.unity           # Sample scene
+├── README.md                      # This file
+├── PrimitiveParams.cs             # ScriptableObject with Serialize/Deserialize
+├── DefaultPrimitiveParams.asset   # Default parameter values
+├── NaivePrimitiveSync.cs          # String-based sync (6 variables)
+├── BinaryPrimitiveSync.cs         # byte[]-based sync (1 variable)
+├── ScreenshotSync.cs              # Screenshot capture & sync
+└── Editor/
+    ├── NaivePrimitiveSyncEditor.cs   # Inspector with Send All button
+    └── BinaryPrimitiveSyncEditor.cs  # Inspector with Send button
+```

--- a/STYLY-NetSync-Unity/Assets/Samples_Dev/BinaryVariable/ScreenshotSync.cs
+++ b/STYLY-NetSync-Unity/Assets/Samples_Dev/BinaryVariable/ScreenshotSync.cs
@@ -1,0 +1,127 @@
+using System.Collections;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace Styly.NetSync.Samples.BinaryVariable
+{
+    /// <summary>
+    /// Captures a screenshot and syncs it as a byte[] NetworkVariable.
+    /// Displays received screenshots on a RawImage.
+    /// </summary>
+    public class ScreenshotSync : MonoBehaviour
+    {
+        private const string VariableName = "screenshot";
+        private const int MaxBytes = 65536;
+        private const int MaxResolution = 320;
+        private const int JpegQuality = 50;
+
+        [Header("UI")]
+        [SerializeField] private RawImage _displayImage;
+        [SerializeField] private Button _captureButton;
+
+        private NetSyncManager _nsm;
+        private bool _ready;
+        private Texture2D _texture;
+
+        private void Start()
+        {
+            _nsm = NetSyncManager.Instance;
+            if (_nsm == null) return;
+
+            _captureButton.onClick.AddListener(OnCaptureClicked);
+            _nsm.OnReady.AddListener(OnReady);
+            _nsm.OnGlobalBytesVariableChanged.AddListener(OnGlobalBytesVariableChanged);
+        }
+
+        private void OnDestroy()
+        {
+            if (_nsm == null) return;
+            _nsm.OnReady.RemoveListener(OnReady);
+            _nsm.OnGlobalBytesVariableChanged.RemoveListener(OnGlobalBytesVariableChanged);
+
+            if (_texture != null) Destroy(_texture);
+        }
+
+        private void OnReady()
+        {
+            _ready = true;
+            byte[] existing = _nsm.GetGlobalVariableBytes(VariableName);
+            if (existing != null && existing.Length > 0)
+            {
+                ApplyImage(existing);
+            }
+        }
+
+        private void OnCaptureClicked()
+        {
+            if (!_ready) return;
+            StartCoroutine(CaptureAndSend());
+        }
+
+        private IEnumerator CaptureAndSend()
+        {
+            yield return new WaitForEndOfFrame();
+
+            var screenTex = ScreenCapture.CaptureScreenshotAsTexture();
+            var resized = Resize(screenTex, MaxResolution);
+            Destroy(screenTex);
+
+            byte[] jpg = resized.EncodeToJPG(JpegQuality);
+            Destroy(resized);
+
+            if (jpg.Length > MaxBytes)
+            {
+                UnityEngine.Debug.LogWarning($"[ScreenshotSync] Image too large ({jpg.Length} bytes), skipping send");
+                yield break;
+            }
+
+            _nsm.SetGlobalVariable(VariableName, jpg);
+        }
+
+        private static Texture2D Resize(Texture2D source, int maxSide)
+        {
+            int w = source.width;
+            int h = source.height;
+            float scale = Mathf.Min(1f, (float)maxSide / Mathf.Max(w, h));
+            int newW = Mathf.Max(1, Mathf.RoundToInt(w * scale));
+            int newH = Mathf.Max(1, Mathf.RoundToInt(h * scale));
+
+            var srcPixels = source.GetPixels();
+            var dstPixels = new Color[newW * newH];
+            for (int y = 0; y < newH; y++)
+            {
+                float v = (float)y / (newH - 1);
+                int srcY = Mathf.Clamp(Mathf.RoundToInt(v * (h - 1)), 0, h - 1);
+                for (int x = 0; x < newW; x++)
+                {
+                    float u = (float)x / (newW - 1);
+                    int srcX = Mathf.Clamp(Mathf.RoundToInt(u * (w - 1)), 0, w - 1);
+                    dstPixels[y * newW + x] = srcPixels[srcY * w + srcX];
+                }
+            }
+            var resized = new Texture2D(newW, newH, TextureFormat.RGB24, false);
+            resized.SetPixels(dstPixels);
+            resized.Apply();
+
+            return resized;
+        }
+
+        private void OnGlobalBytesVariableChanged(string name, byte[] oldValue, byte[] newValue)
+        {
+            if (name != VariableName) return;
+            ApplyImage(newValue);
+        }
+
+        private void ApplyImage(byte[] pngData)
+        {
+            if (pngData == null || pngData.Length == 0) return;
+
+            if (_texture == null)
+            {
+                _texture = new Texture2D(2, 2);
+            }
+            _texture.LoadImage(pngData);
+            _displayImage.texture = _texture;
+        }
+    }
+}

--- a/STYLY-NetSync-Unity/Assets/Samples_Dev/BinaryVariable/ScreenshotSync.cs.meta
+++ b/STYLY-NetSync-Unity/Assets/Samples_Dev/BinaryVariable/ScreenshotSync.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: cfc064d42322e4d1fa2109c5f92fadb0

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/BinarySerializer.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/BinarySerializer.cs
@@ -23,6 +23,10 @@ namespace Styly.NetSync
         public const byte MSG_CLIENT_POSE = 11;  // Client pose (quaternion + timestamps)
         public const byte MSG_ROOM_POSE = 12;  // Room pose snapshot (quaternion + timestamps)
 
+        // Network Variable value type tags
+        public const byte VAR_TYPE_STRING = 0x00;
+        public const byte VAR_TYPE_BYTES = 0x01;
+
         // Transform data type identifiers (deprecated - kept for reference)
         // Protocol v3 pose encoding constants
         private const float ABS_POS_SCALE = 0.01f;
@@ -889,11 +893,21 @@ namespace Styly.NetSync
             writer.Write((byte)nameBytes.Length);
             writer.Write(nameBytes);
 
-            // Variable value (max 1024 bytes)
-            var varValue = data.TryGetValue("variableValue", out var valueObj) ? (valueObj != null ? valueObj.ToString() : "") : "";
-            if (varValue.Length > 1024) varValue = varValue.Substring(0, 1024);
-            var valueBytes = System.Text.Encoding.UTF8.GetBytes(varValue);
-            writer.Write((ushort)valueBytes.Length);
+            // Variable value: [1B type_tag][4B uint32 length][N bytes payload]
+            var valueType = data.TryGetValue("variableValueType", out var typeObj) ? Convert.ToByte(typeObj) : VAR_TYPE_STRING;
+            byte[] valueBytes;
+            if (valueType == VAR_TYPE_BYTES && data.TryGetValue("variableValueBytes", out var bytesObj))
+            {
+                valueBytes = (byte[])bytesObj;
+            }
+            else
+            {
+                var varValue = data.TryGetValue("variableValue", out var valueObj) ? (valueObj != null ? valueObj.ToString() : "") : "";
+                valueBytes = System.Text.Encoding.UTF8.GetBytes(varValue);
+                valueType = VAR_TYPE_STRING;
+            }
+            writer.Write(valueType);
+            writer.Write((uint)valueBytes.Length);
             writer.Write(valueBytes);
 
             // Timestamp (8 bytes double)
@@ -935,11 +949,21 @@ namespace Styly.NetSync
             writer.Write((byte)nameBytes.Length);
             writer.Write(nameBytes);
 
-            // Variable value (max 1024 bytes)
-            var varValue = data.TryGetValue("variableValue", out var valueObj) ? (valueObj != null ? valueObj.ToString() : "") : "";
-            if (varValue.Length > 1024) varValue = varValue.Substring(0, 1024);
-            var valueBytes = System.Text.Encoding.UTF8.GetBytes(varValue);
-            writer.Write((ushort)valueBytes.Length);
+            // Variable value: [1B type_tag][4B uint32 length][N bytes payload]
+            var valueType = data.TryGetValue("variableValueType", out var typeObj) ? Convert.ToByte(typeObj) : VAR_TYPE_STRING;
+            byte[] valueBytes;
+            if (valueType == VAR_TYPE_BYTES && data.TryGetValue("variableValueBytes", out var bytesObj))
+            {
+                valueBytes = (byte[])bytesObj;
+            }
+            else
+            {
+                var varValue = data.TryGetValue("variableValue", out var valueObj) ? (valueObj != null ? valueObj.ToString() : "") : "";
+                valueBytes = System.Text.Encoding.UTF8.GetBytes(varValue);
+                valueType = VAR_TYPE_STRING;
+            }
+            writer.Write(valueType);
+            writer.Write((uint)valueBytes.Length);
             writer.Write(valueBytes);
 
             // Timestamp (8 bytes double)
@@ -1031,9 +1055,16 @@ namespace Styly.NetSync
                 var nameLength = reader.ReadByte();
                 variable["name"] = System.Text.Encoding.UTF8.GetString(reader.ReadBytes(nameLength));
 
-                // Variable value
-                var valueLength = reader.ReadUInt16();
-                variable["value"] = System.Text.Encoding.UTF8.GetString(reader.ReadBytes(valueLength));
+                // Variable value: [1B type_tag][4B uint32 length][N bytes payload]
+                var valueType = reader.ReadByte();
+                var valueLength = reader.ReadUInt32();
+                var rawBytes = reader.ReadBytes((int)valueLength);
+                variable["valueType"] = valueType;
+                variable["valueBytes"] = rawBytes;
+                if (valueType == VAR_TYPE_STRING)
+                {
+                    variable["value"] = System.Text.Encoding.UTF8.GetString(rawBytes);
+                }
 
                 // Timestamp
                 variable["timestamp"] = reader.ReadDouble();
@@ -1074,9 +1105,16 @@ namespace Styly.NetSync
                     var nameLength = reader.ReadByte();
                     variable["name"] = System.Text.Encoding.UTF8.GetString(reader.ReadBytes(nameLength));
 
-                    // Variable value
-                    var valueLength = reader.ReadUInt16();
-                    variable["value"] = System.Text.Encoding.UTF8.GetString(reader.ReadBytes(valueLength));
+                    // Variable value: [1B type_tag][4B uint32 length][N bytes payload]
+                    var valueType = reader.ReadByte();
+                    var valueLength = reader.ReadUInt32();
+                    var rawBytes = reader.ReadBytes((int)valueLength);
+                    variable["valueType"] = valueType;
+                    variable["valueBytes"] = rawBytes;
+                    if (valueType == VAR_TYPE_STRING)
+                    {
+                        variable["value"] = System.Text.Encoding.UTF8.GetString(rawBytes);
+                    }
 
                     // Timestamp
                     variable["timestamp"] = reader.ReadDouble();

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/NetworkVariableManager.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/NetworkVariableManager.cs
@@ -17,12 +17,13 @@ namespace Styly.NetSync
     internal readonly struct NVValue : IEquatable<NVValue>
     {
         public readonly byte TypeTag; // VAR_TYPE_STRING=0 or VAR_TYPE_BYTES=1
-        public readonly byte[] RawBytes;
+        private readonly byte[] _rawBytes;
+        public byte[] RawBytes => _rawBytes ?? Array.Empty<byte>();
 
         public NVValue(byte typeTag, byte[] rawBytes)
         {
             TypeTag = typeTag;
-            RawBytes = rawBytes ?? Array.Empty<byte>();
+            _rawBytes = rawBytes ?? Array.Empty<byte>();
         }
 
         public static NVValue FromString(string value)

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/NetworkVariableManager.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/NetworkVariableManager.cs
@@ -4,12 +4,62 @@ using System.Buffers;
 using System.Collections.Generic;
 using System.Collections.Concurrent;
 using System.IO;
+using System.Linq;
 using System.Text;
 using UnityEngine;
 using Newtonsoft.Json.Linq;
 
 namespace Styly.NetSync
 {
+    /// <summary>
+    /// Tagged union for network variable values (string or byte[]).
+    /// </summary>
+    internal readonly struct NVValue : IEquatable<NVValue>
+    {
+        public readonly byte TypeTag; // VAR_TYPE_STRING=0 or VAR_TYPE_BYTES=1
+        public readonly byte[] RawBytes;
+
+        public NVValue(byte typeTag, byte[] rawBytes)
+        {
+            TypeTag = typeTag;
+            RawBytes = rawBytes ?? Array.Empty<byte>();
+        }
+
+        public static NVValue FromString(string value)
+        {
+            return new NVValue(BinarySerializer.VAR_TYPE_STRING,
+                value != null ? Encoding.UTF8.GetBytes(value) : Array.Empty<byte>());
+        }
+
+        public static NVValue FromBytes(byte[] value)
+        {
+            return new NVValue(BinarySerializer.VAR_TYPE_BYTES, value ?? Array.Empty<byte>());
+        }
+
+        public string AsString => TypeTag == BinarySerializer.VAR_TYPE_STRING ? Encoding.UTF8.GetString(RawBytes) : null;
+
+        public bool Equals(NVValue other)
+        {
+            return TypeTag == other.TypeTag && RawBytes.SequenceEqual(other.RawBytes);
+        }
+
+        public override bool Equals(object obj) => obj is NVValue other && Equals(other);
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                int hash = TypeTag;
+                for (int i = 0; i < Math.Min(RawBytes.Length, 16); i++)
+                    hash = hash * 31 + RawBytes[i];
+                return hash;
+            }
+        }
+
+        public static bool operator ==(NVValue left, NVValue right) => left.Equals(right);
+        public static bool operator !=(NVValue left, NVValue right) => !left.Equals(right);
+    }
+
     internal class NetworkVariableManager
     {
         private readonly IConnectionManager _connectionManager;
@@ -18,38 +68,42 @@ namespace Styly.NetSync
 
         // Reusable serialization resources to reduce allocations per send
         private readonly ReusableBufferWriter _buf;
-        private const int INITIAL_BUFFER_CAPACITY = 1024;
+        private const int INITIAL_BUFFER_CAPACITY = 4096;
 
         // Network Variables storage
-        private readonly Dictionary<string, string> _globalVariables = new();
-        private readonly Dictionary<int, Dictionary<string, string>> _clientVariables = new();
+        private readonly Dictionary<string, NVValue> _globalVariables = new();
+        private readonly Dictionary<int, Dictionary<string, NVValue>> _clientVariables = new();
 
         // Network Variables limits (must match server)
         private const int MAX_GLOBAL_VARS = 100;
         private const int MAX_CLIENT_VARS = 100;
         private const int MAX_VAR_NAME_LENGTH = 64;
-        private const int MAX_VAR_VALUE_LENGTH = 1024;
+        private const int MAX_VAR_VALUE_LENGTH = 65536;
 
         // Debounce configuration
         private const double DEBOUNCE_INTERVAL = 0.1; // 100ms debounce
 
         // Send-side dedupe caches
-        private readonly Dictionary<string, string> _lastSentGlobal = new();
-        private readonly Dictionary<(int, string), string> _lastSentClient = new();
+        private readonly Dictionary<string, NVValue> _lastSentGlobal = new();
+        private readonly Dictionary<(int, string), NVValue> _lastSentClient = new();
 
         // Leading-edge throttles (cooldowns) for NV sends
         private readonly Dictionary<string, double> _nextAllowedGlobal = new();
         private readonly Dictionary<(int clientNo, string name), double> _nextAllowedClient = new();
 
         // Debounce buffers for pending sends
-        private readonly Dictionary<string, string> _pendingGlobal = new();
+        private readonly Dictionary<string, NVValue> _pendingGlobal = new();
         private readonly Dictionary<string, double> _dueGlobal = new();
-        private readonly Dictionary<(int, string), string> _pendingClient = new();
+        private readonly Dictionary<(int, string), NVValue> _pendingClient = new();
         private readonly Dictionary<(int, string), double> _dueClient = new();
 
-        // Events (using C# events, NOT SendMessage)
+        // Events for string-typed variables (using C# events, NOT SendMessage)
         public event Action<string, string, string> OnGlobalVariableChanged;
         public event Action<int, string, string, string> OnClientVariableChanged;
+
+        // Events for byte[]-typed variables
+        public event Action<string, byte[], byte[]> OnGlobalBytesVariableChanged;
+        public event Action<int, string, byte[], byte[]> OnClientBytesVariableChanged;
 
         // Flag to track if initial network variables have been received
         private bool _hasReceivedInitialSync = false;
@@ -108,12 +162,26 @@ namespace Styly.NetSync
             _buf = new ReusableBufferWriter(INITIAL_BUFFER_CAPACITY);
         }
 
-        // Global Variables API
+        // Global Variables API (string)
         public bool SetGlobalVariable(string name, string value, string roomId)
         {
-            if (!ValidateVariableName(name) || !ValidateVariableValue(value))
+            if (!ValidateVariableName(name) || !ValidateStringValue(value))
                 return false;
 
+            return SetGlobalVariableInternal(name, NVValue.FromString(value), roomId);
+        }
+
+        // Global Variables API (byte[])
+        public bool SetGlobalVariable(string name, byte[] value, string roomId)
+        {
+            if (!ValidateVariableName(name) || !ValidateBytesValue(value))
+                return false;
+
+            return SetGlobalVariableInternal(name, NVValue.FromBytes(value), roomId);
+        }
+
+        private bool SetGlobalVariableInternal(string name, NVValue nvValue, string roomId)
+        {
             if (_globalVariables.Count >= MAX_GLOBAL_VARS && !_globalVariables.ContainsKey(name))
             {
                 Debug.LogWarning($"Global variable limit ({MAX_GLOBAL_VARS}) reached");
@@ -123,17 +191,17 @@ namespace Styly.NetSync
             // Offline mode: write locally and fire event without server round-trip
             if (_netSyncManager != null && _netSyncManager.IsOfflineMode)
             {
-                var oldValue = _globalVariables.TryGetValue(name, out var existing) ? existing : null;
-                if (!string.Equals(oldValue, value))
+                var hasOld = _globalVariables.TryGetValue(name, out var existing);
+                if (!hasOld || existing != nvValue)
                 {
-                    _globalVariables[name] = value;
-                    OnGlobalVariableChanged?.Invoke(name, oldValue, value);
+                    _globalVariables[name] = nvValue;
+                    FireGlobalEvent(name, hasOld ? existing : default, nvValue);
                 }
                 return true;
             }
 
             // Dedupe: same as the last actually sent value -> skip, but treat as success
-            if (_lastSentGlobal.TryGetValue(name, out var lastSent) && lastSent == value)
+            if (_lastSentGlobal.TryGetValue(name, out var lastSent) && lastSent == nvValue)
                 return true;
 
             double now = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() / 1000.0;
@@ -143,13 +211,13 @@ namespace Styly.NetSync
             if (allowImmediate)
             {
                 // Try immediate send; only start cooldown if it *actually* sent
-                if (TrySendGlobalNow(name, value, roomId))
+                if (TrySendGlobalNow(name, nvValue, roomId))
                 {
                     _nextAllowedGlobal[name] = now + DEBOUNCE_INTERVAL;
                 }
 
                 // Always schedule trailing edge (latest-wins) and DO NOT extend it later
-                _pendingGlobal[name] = value;
+                _pendingGlobal[name] = nvValue;
                 if (!_dueGlobal.ContainsKey(name))
                     _dueGlobal[name] = now + DEBOUNCE_INTERVAL;
 
@@ -157,7 +225,7 @@ namespace Styly.NetSync
             }
 
             // Inside cooldown: update pending value but keep the original deadline
-            _pendingGlobal[name] = value;
+            _pendingGlobal[name] = nvValue;
             if (!_dueGlobal.ContainsKey(name))
                 _dueGlobal[name] = next;
 
@@ -165,20 +233,24 @@ namespace Styly.NetSync
         }
 
         // Internal method to send now (used by flush)
-        private bool TrySendGlobalNow(string name, string value, string roomId)
+        private bool TrySendGlobalNow(string name, NVValue nvValue, string roomId)
         {
             var timestamp = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() / 1000.0;
             var data = new Dictionary<string, object>
             {
                 ["senderClientNo"] = _netSyncManager.ClientNo,
                 ["variableName"] = name,
-                ["variableValue"] = value,
+                ["variableValueType"] = nvValue.TypeTag,
                 ["timestamp"] = timestamp
             };
+            if (nvValue.TypeTag == BinarySerializer.VAR_TYPE_BYTES)
+                data["variableValueBytes"] = nvValue.RawBytes;
+            else
+                data["variableValue"] = nvValue.AsString;
 
             try
             {
-                var required = EstimateGlobalVarSetSize(name, value);
+                var required = EstimateNVSetSize(name, nvValue.RawBytes.Length, hasTarget: false);
                 _buf.EnsureCapacity(required);
 
                 _buf.Stream.Position = 0;
@@ -191,7 +263,7 @@ namespace Styly.NetSync
                 var sent = _connectionManager.TryEnqueueControl(roomId, payload);
                 if (sent)
                 {
-                    _lastSentGlobal[name] = value; // Update last sent cache
+                    _lastSentGlobal[name] = nvValue;
                 }
                 return sent;
             }
@@ -208,17 +280,44 @@ namespace Styly.NetSync
             {
                 throw new InvalidOperationException("Cannot get global variables before OnReady event. Please wait for OnReady to be fired.");
             }
-            return _globalVariables.TryGetValue(name, out var value) ? value : defaultValue;
+            if (_globalVariables.TryGetValue(name, out var nv) && nv.TypeTag == BinarySerializer.VAR_TYPE_STRING)
+                return nv.AsString;
+            return defaultValue;
         }
 
-        // Client Variables API
+        public byte[] GetGlobalVariableBytes(string name, byte[] defaultValue = null)
+        {
+            if (!_hasReceivedInitialSync)
+            {
+                throw new InvalidOperationException("Cannot get global variables before OnReady event. Please wait for OnReady to be fired.");
+            }
+            if (_globalVariables.TryGetValue(name, out var nv) && nv.TypeTag == BinarySerializer.VAR_TYPE_BYTES)
+                return nv.RawBytes;
+            return defaultValue;
+        }
+
+        // Client Variables API (string)
         public bool SetClientVariable(string name, string value, int targetClientNo, string roomId)
         {
-            if (!ValidateVariableName(name) || !ValidateVariableValue(value))
+            if (!ValidateVariableName(name) || !ValidateStringValue(value))
                 return false;
 
+            return SetClientVariableInternal(name, NVValue.FromString(value), targetClientNo, roomId);
+        }
+
+        // Client Variables API (byte[])
+        public bool SetClientVariable(string name, byte[] value, int targetClientNo, string roomId)
+        {
+            if (!ValidateVariableName(name) || !ValidateBytesValue(value))
+                return false;
+
+            return SetClientVariableInternal(name, NVValue.FromBytes(value), targetClientNo, roomId);
+        }
+
+        private bool SetClientVariableInternal(string name, NVValue nvValue, int targetClientNo, string roomId)
+        {
             if (!_clientVariables.ContainsKey(targetClientNo))
-                _clientVariables[targetClientNo] = new Dictionary<string, string>();
+                _clientVariables[targetClientNo] = new Dictionary<string, NVValue>();
 
             var clientVars = _clientVariables[targetClientNo];
             if (clientVars.Count >= MAX_CLIENT_VARS && !clientVars.ContainsKey(name))
@@ -230,11 +329,11 @@ namespace Styly.NetSync
             // Offline mode: write locally and fire event without server round-trip
             if (_netSyncManager != null && _netSyncManager.IsOfflineMode)
             {
-                var oldValue = clientVars.TryGetValue(name, out var existing) ? existing : null;
-                if (!string.Equals(oldValue, value))
+                var hasOld = clientVars.TryGetValue(name, out var existing);
+                if (!hasOld || existing != nvValue)
                 {
-                    clientVars[name] = value;
-                    OnClientVariableChanged?.Invoke(targetClientNo, name, oldValue, value);
+                    clientVars[name] = nvValue;
+                    FireClientEvent(targetClientNo, name, hasOld ? existing : default, nvValue);
                 }
                 return true;
             }
@@ -242,7 +341,7 @@ namespace Styly.NetSync
             var key = (targetClientNo, name);
 
             // Dedupe: same as the last actually sent value -> skip, but treat as success
-            if (_lastSentClient.TryGetValue(key, out var lastSent) && lastSent == value)
+            if (_lastSentClient.TryGetValue(key, out var lastSent) && lastSent == nvValue)
                 return true;
 
             double now = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() / 1000.0;
@@ -251,13 +350,13 @@ namespace Styly.NetSync
             bool allowImmediate = !_nextAllowedClient.TryGetValue(key, out var next) || now >= next;
             if (allowImmediate)
             {
-                if (TrySendClientNow(targetClientNo, name, value, roomId))
+                if (TrySendClientNow(targetClientNo, name, nvValue, roomId))
                 {
                     _nextAllowedClient[key] = now + DEBOUNCE_INTERVAL;
                 }
 
                 // Schedule trailing and keep its deadline fixed
-                _pendingClient[key] = value;
+                _pendingClient[key] = nvValue;
                 if (!_dueClient.ContainsKey(key))
                     _dueClient[key] = now + DEBOUNCE_INTERVAL;
 
@@ -265,7 +364,7 @@ namespace Styly.NetSync
             }
 
             // Inside cooldown: update pending value but keep original due time
-            _pendingClient[key] = value;
+            _pendingClient[key] = nvValue;
             if (!_dueClient.ContainsKey(key))
                 _dueClient[key] = next;
 
@@ -273,7 +372,7 @@ namespace Styly.NetSync
         }
 
         // Internal method to send now (used by flush)
-        private bool TrySendClientNow(int targetClientNo, string name, string value, string roomId)
+        private bool TrySendClientNow(int targetClientNo, string name, NVValue nvValue, string roomId)
         {
             var timestamp = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() / 1000.0;
             var data = new Dictionary<string, object>
@@ -281,13 +380,17 @@ namespace Styly.NetSync
                 ["senderClientNo"] = _netSyncManager.ClientNo,
                 ["targetClientNo"] = targetClientNo,
                 ["variableName"] = name,
-                ["variableValue"] = value,
+                ["variableValueType"] = nvValue.TypeTag,
                 ["timestamp"] = timestamp
             };
+            if (nvValue.TypeTag == BinarySerializer.VAR_TYPE_BYTES)
+                data["variableValueBytes"] = nvValue.RawBytes;
+            else
+                data["variableValue"] = nvValue.AsString;
 
             try
             {
-                var required = EstimateClientVarSetSize(name, value);
+                var required = EstimateNVSetSize(name, nvValue.RawBytes.Length, hasTarget: true);
                 _buf.EnsureCapacity(required);
 
                 _buf.Stream.Position = 0;
@@ -301,7 +404,7 @@ namespace Styly.NetSync
                 if (sent)
                 {
                     var key = (targetClientNo, name);
-                    _lastSentClient[key] = value; // Update last sent cache
+                    _lastSentClient[key] = nvValue;
                 }
                 return sent;
             }
@@ -320,7 +423,22 @@ namespace Styly.NetSync
             }
             if (_clientVariables.TryGetValue(clientNo, out var clientVars))
             {
-                return clientVars.TryGetValue(name, out var value) ? value : defaultValue;
+                if (clientVars.TryGetValue(name, out var nv) && nv.TypeTag == BinarySerializer.VAR_TYPE_STRING)
+                    return nv.AsString;
+            }
+            return defaultValue;
+        }
+
+        public byte[] GetClientVariableBytes(string name, int clientNo, byte[] defaultValue = null)
+        {
+            if (!_hasReceivedInitialSync)
+            {
+                throw new InvalidOperationException("Cannot get client variables before OnReady event. Please wait for OnReady to be fired.");
+            }
+            if (_clientVariables.TryGetValue(clientNo, out var clientVars))
+            {
+                if (clientVars.TryGetValue(name, out var nv) && nv.TypeTag == BinarySerializer.VAR_TYPE_BYTES)
+                    return nv.RawBytes;
             }
             return defaultValue;
         }
@@ -369,21 +487,20 @@ namespace Styly.NetSync
                     if (variable != null)
                     {
                         var name = variable.TryGetValue("name", out var nameObj) ? (nameObj != null ? nameObj.ToString() : null) : null;
-                        var value = variable.TryGetValue("value", out var valueObj) ? (valueObj != null ? valueObj.ToString() : null) : null;
+                        if (string.IsNullOrEmpty(name)) continue;
 
-                        if (!string.IsNullOrEmpty(name) && value != null)
+                        var nvValue = ExtractNVValue(variable);
+
+                        var hasOld = _globalVariables.TryGetValue(name, out var existing);
+                        // Skip if value is unchanged
+                        if (hasOld && existing == nvValue)
                         {
-                            var oldValue = _globalVariables.TryGetValue(name, out var existing) ? existing : null;
-                            // Skip if value is unchanged
-                            if (object.Equals(oldValue, value))
-                            {
-                                continue;
-                            }
-                            _globalVariables[name] = value;
-
-                            // Trigger event only when changed
-                            OnGlobalVariableChanged?.Invoke(name, oldValue, value);
+                            continue;
                         }
+                        _globalVariables[name] = nvValue;
+
+                        // Trigger event only when changed
+                        FireGlobalEvent(name, hasOld ? existing : default, nvValue);
                     }
                 }
             }
@@ -416,7 +533,7 @@ namespace Styly.NetSync
                         if (variables == null) continue;
 
                         if (!_clientVariables.ContainsKey(clientNo))
-                            _clientVariables[clientNo] = new Dictionary<string, string>();
+                            _clientVariables[clientNo] = new Dictionary<string, NVValue>();
 
                         var clientVars = _clientVariables[clientNo];
 
@@ -427,22 +544,21 @@ namespace Styly.NetSync
                             if (variable != null)
                             {
                                 var name = variable.TryGetValue("name", out var nameObj) ? (nameObj != null ? nameObj.ToString() : null) : null;
-                                var value = variable.TryGetValue("value", out var valueObj) ? (valueObj != null ? valueObj.ToString() : null) : null;
+                                if (string.IsNullOrEmpty(name)) continue;
 
-                                if (!string.IsNullOrEmpty(name) && value != null)
+                                var nvValue = ExtractNVValue(variable);
+
+                                var hasOld = clientVars.TryGetValue(name, out var existing);
+                                // Skip if value is unchanged
+                                if (hasOld && existing == nvValue)
                                 {
-                                    var oldValue = clientVars.TryGetValue(name, out var existing) ? existing : null;
-                                    // Skip if value is unchanged
-                                    if (string.Equals(oldValue, value, StringComparison.Ordinal))
-                                    {
-                                        continue;
-                                    }
-
-                                    clientVars[name] = value;
-
-                                    // Trigger event only when changed
-                                    OnClientVariableChanged?.Invoke(clientNo, name, oldValue, value);
+                                    continue;
                                 }
+
+                                clientVars[name] = nvValue;
+
+                                // Trigger event only when changed
+                                FireClientEvent(clientNo, name, hasOld ? existing : default, nvValue);
                             }
                         }
                     }
@@ -461,20 +577,98 @@ namespace Styly.NetSync
             return true;
         }
 
-        private bool ValidateVariableValue(string value)
+        private bool ValidateStringValue(string value)
         {
-            if (value == null || value.Length > MAX_VAR_VALUE_LENGTH)
+            if (value == null)
             {
-                Debug.LogWarning($"Invalid variable value: must be 0-{MAX_VAR_VALUE_LENGTH} characters");
+                Debug.LogWarning("Invalid variable value: must not be null");
+                return false;
+            }
+            int byteLen = Encoding.UTF8.GetByteCount(value);
+            if (byteLen > MAX_VAR_VALUE_LENGTH)
+            {
+                Debug.LogWarning($"Invalid variable value: {byteLen} bytes exceeds {MAX_VAR_VALUE_LENGTH} byte limit");
                 return false;
             }
             return true;
         }
 
+        private bool ValidateBytesValue(byte[] value)
+        {
+            if (value == null)
+            {
+                Debug.LogWarning("Invalid variable value: must not be null");
+                return false;
+            }
+            if (value.Length > MAX_VAR_VALUE_LENGTH)
+            {
+                Debug.LogWarning($"Invalid variable value: {value.Length} bytes exceeds {MAX_VAR_VALUE_LENGTH} byte limit");
+                return false;
+            }
+            return true;
+        }
+
+        // Extract NVValue from deserialized dictionary
+        private static NVValue ExtractNVValue(Dictionary<string, object> variable)
+        {
+            byte valueType = BinarySerializer.VAR_TYPE_STRING;
+            if (variable.TryGetValue("valueType", out var typeObj))
+                valueType = Convert.ToByte(typeObj);
+
+            if (valueType == BinarySerializer.VAR_TYPE_BYTES && variable.TryGetValue("valueBytes", out var bytesObj))
+            {
+                return new NVValue(BinarySerializer.VAR_TYPE_BYTES, (byte[])bytesObj);
+            }
+
+            // String type or fallback
+            byte[] rawBytes;
+            if (variable.TryGetValue("valueBytes", out var rawObj))
+            {
+                rawBytes = (byte[])rawObj;
+            }
+            else
+            {
+                var strValue = variable.TryGetValue("value", out var valueObj) ? (valueObj != null ? valueObj.ToString() : "") : "";
+                rawBytes = Encoding.UTF8.GetBytes(strValue);
+            }
+            return new NVValue(BinarySerializer.VAR_TYPE_STRING, rawBytes);
+        }
+
+        // Fire appropriate event based on type tag
+        private void FireGlobalEvent(string name, NVValue oldValue, NVValue newValue)
+        {
+            if (newValue.TypeTag == BinarySerializer.VAR_TYPE_BYTES)
+            {
+                OnGlobalBytesVariableChanged?.Invoke(name, oldValue.RawBytes, newValue.RawBytes);
+            }
+            else
+            {
+                OnGlobalVariableChanged?.Invoke(name, oldValue.AsString, newValue.AsString);
+            }
+        }
+
+        private void FireClientEvent(int clientNo, string name, NVValue oldValue, NVValue newValue)
+        {
+            if (newValue.TypeTag == BinarySerializer.VAR_TYPE_BYTES)
+            {
+                OnClientBytesVariableChanged?.Invoke(clientNo, name, oldValue.RawBytes, newValue.RawBytes);
+            }
+            else
+            {
+                OnClientVariableChanged?.Invoke(clientNo, name, oldValue.AsString, newValue.AsString);
+            }
+        }
+
         // Get all global variables (for debugging/inspection)
         public Dictionary<string, string> GetAllGlobalVariables()
         {
-            return new Dictionary<string, string>(_globalVariables);
+            var result = new Dictionary<string, string>();
+            foreach (var kvp in _globalVariables)
+            {
+                if (kvp.Value.TypeTag == BinarySerializer.VAR_TYPE_STRING)
+                    result[kvp.Key] = kvp.Value.AsString;
+            }
+            return result;
         }
 
         // Get all client variables for a specific client (for debugging/inspection)
@@ -482,7 +676,13 @@ namespace Styly.NetSync
         {
             if (_clientVariables.TryGetValue(clientNo, out var clientVars))
             {
-                return new Dictionary<string, string>(clientVars);
+                var result = new Dictionary<string, string>();
+                foreach (var kvp in clientVars)
+                {
+                    if (kvp.Value.TypeTag == BinarySerializer.VAR_TYPE_STRING)
+                        result[kvp.Key] = kvp.Value.AsString;
+                }
+                return result;
             }
             return new Dictionary<string, string>();
         }
@@ -502,26 +702,12 @@ namespace Styly.NetSync
 
         // Buffer growth handled by ReusableBufferWriter
 
-        private static int EstimateGlobalVarSetSize(string name, string value)
+        // Unified size estimation: 1 (msgType) + 2 (sender) + [2 (target)] + 1 + nameLen + 1 (typeTag) + 4 (uint32 valueLen) + valueLen + 8 (timestamp)
+        private static int EstimateNVSetSize(string name, int valueBytesLength, bool hasTarget)
         {
-            // 1 (type) + 2 (sender) + 1 + nameLen + 2 + valueLen + 8 (timestamp)
-            int nameLen = ClampedUtf8Length(name, 64);
-            int valueLen = ClampedUtf8Length(value, 1024);
-            return 1 + 2 + 1 + nameLen + 2 + valueLen + 8;
-        }
-
-        private static int EstimateClientVarSetSize(string name, string value)
-        {
-            // 1 (type) + 2 (sender) + 2 (target) + 1 + nameLen + 2 + valueLen + 8 (timestamp)
-            int nameLen = ClampedUtf8Length(name, 64);
-            int valueLen = ClampedUtf8Length(value, 1024);
-            return 1 + 2 + 2 + 1 + nameLen + 2 + valueLen + 8;
-        }
-
-        private static int ClampedUtf8Length(string s, int max)
-        {
-            var len = s != null ? Encoding.UTF8.GetByteCount(s) : 0;
-            return Math.Min(len, max);
+            int nameLen = name != null ? Math.Min(Encoding.UTF8.GetByteCount(name), 64) : 0;
+            int targetSize = hasTarget ? 2 : 0;
+            return 1 + 2 + targetSize + 1 + nameLen + 1 + 4 + valueBytesLength + 8;
         }
 
         /// <summary>
@@ -530,7 +716,7 @@ namespace Styly.NetSync
         /// <returns>True if all pending were flushed, false if any backpressure occurred.</returns>
         private bool FlushPendingGlobal(double nowSeconds, string roomId)
         {
-            var toFlush = new List<(string name, string value)>();
+            var toFlush = new List<(string name, NVValue value)>();
             bool allFlushed = true;
 
             foreach (var kvp in _dueGlobal)
@@ -576,7 +762,7 @@ namespace Styly.NetSync
         /// <returns>True if all pending were flushed, false if any backpressure occurred.</returns>
         private bool FlushPendingClient(double nowSeconds, string roomId)
         {
-            var toFlush = new List<((int targetClientNo, string name) key, string value)>();
+            var toFlush = new List<((int targetClientNo, string name) key, NVValue value)>();
             bool allFlushed = true;
 
             foreach (var kvp in _dueClient)

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/NetSyncManager.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/NetSyncManager.cs
@@ -38,6 +38,8 @@ namespace Styly.NetSync
         public UnityEvent<int, string, string[]> OnRPCReceived;
         public UnityEvent<string, string, string> OnGlobalVariableChanged;
         public UnityEvent<int, string, string, string> OnClientVariableChanged;
+        public UnityEvent<string, byte[], byte[]> OnGlobalBytesVariableChanged;
+        public UnityEvent<int, string, byte[], byte[]> OnClientBytesVariableChanged;
         public UnityEvent OnReady;
         /// <summary>
         /// Event fired when server and client versions do not match.
@@ -138,7 +140,7 @@ namespace Styly.NetSync
             }
         }
 
-        // Network Variables API
+        // Network Variables API (string)
         public bool SetGlobalVariable(string name, string value)
         {
             return _networkVariableManager != null ? _networkVariableManager.SetGlobalVariable(name, value, _roomId) : false;
@@ -172,6 +174,43 @@ namespace Styly.NetSync
         public string GetClientVariable(string name, int clientNo, string defaultValue = null)
         {
             return _networkVariableManager != null ? _networkVariableManager.GetClientVariable(name, clientNo, defaultValue) : defaultValue;
+        }
+
+        // Network Variables API (byte[])
+        public bool SetGlobalVariable(string name, byte[] value)
+        {
+            return _networkVariableManager != null ? _networkVariableManager.SetGlobalVariable(name, value, _roomId) : false;
+        }
+
+        public byte[] GetGlobalVariableBytes(string name, byte[] defaultValue = null)
+        {
+            return _networkVariableManager != null ? _networkVariableManager.GetGlobalVariableBytes(name, defaultValue) : defaultValue;
+        }
+
+        public bool SetClientVariable(string name, byte[] value)
+        {
+            if (_clientNo <= 0)
+            {
+                // Late-binding: store as NVValue for pending
+                _pendingSelfClientNVBytes.Add((name, value));
+                return true;
+            }
+            return _networkVariableManager != null ? _networkVariableManager.SetClientVariable(name, value, _clientNo, _roomId) : false;
+        }
+
+        public bool SetClientVariable(string name, byte[] value, int targetClientNo)
+        {
+            return _networkVariableManager != null ? _networkVariableManager.SetClientVariable(name, value, targetClientNo, _roomId) : false;
+        }
+
+        public byte[] GetClientVariableBytes(string name, byte[] defaultValue = null)
+        {
+            return _networkVariableManager != null ? _networkVariableManager.GetClientVariableBytes(name, _clientNo, defaultValue) : defaultValue;
+        }
+
+        public byte[] GetClientVariableBytes(string name, int clientNo, byte[] defaultValue = null)
+        {
+            return _networkVariableManager != null ? _networkVariableManager.GetClientVariableBytes(name, clientNo, defaultValue) : defaultValue;
         }
 
         /// <summary>
@@ -290,6 +329,7 @@ namespace Styly.NetSync
         private float _nextDiscoveryAttemptAt = 0f;
         private float _reconnectAt;
         private readonly List<(string name, string value)> _pendingSelfClientNV = new List<(string name, string value)>();
+        private readonly List<(string name, byte[] value)> _pendingSelfClientNVBytes = new List<(string name, byte[] value)>();
         private bool _hasInvokedReady = false;
         private bool _shouldCheckReady = false;
         private bool _shouldSendHandshake = false;
@@ -627,6 +667,8 @@ namespace Styly.NetSync
             {
                 _networkVariableManager.OnGlobalVariableChanged += OnGlobalVariableChangedHandler;
                 _networkVariableManager.OnClientVariableChanged += OnClientVariableChangedHandler;
+                _networkVariableManager.OnGlobalBytesVariableChanged += OnGlobalBytesVariableChangedHandler;
+                _networkVariableManager.OnClientBytesVariableChanged += OnClientBytesVariableChangedHandler;
             }
 
             // Setup discovery event
@@ -782,17 +824,36 @@ namespace Styly.NetSync
             OnClientVariableChanged?.Invoke(clientNo, name, oldValue, newValue);
         }
 
+        private void OnGlobalBytesVariableChangedHandler(string name, byte[] oldValue, byte[] newValue)
+        {
+            Debug.Log($"[NetSyncManager] Global Bytes Variable Changed - Name: {name}, Old: {(oldValue != null ? $"<binary:{oldValue.Length} bytes>" : "null")}, New: {(newValue != null ? $"<binary:{newValue.Length} bytes>" : "null")}");
+            OnGlobalBytesVariableChanged?.Invoke(name, oldValue, newValue);
+        }
+
+        private void OnClientBytesVariableChangedHandler(int clientNo, string name, byte[] oldValue, byte[] newValue)
+        {
+            Debug.Log($"[NetSyncManager] Client Bytes Variable Changed - Client#{clientNo}, Name: {name}, Old: {(oldValue != null ? $"<binary:{oldValue.Length} bytes>" : "null")}, New: {(newValue != null ? $"<binary:{newValue.Length} bytes>" : "null")}");
+            OnClientBytesVariableChanged?.Invoke(clientNo, name, oldValue, newValue);
+        }
+
         private void OnLocalClientNoAssigned(int clientNo)
         {
             _clientNo = clientNo;
             DebugLog($"Local client number assigned: {clientNo}");
 
-            // Flush pending self client NV
+            // Flush pending self client NV (string)
             foreach (var (name, value) in _pendingSelfClientNV)
             {
                 _networkVariableManager?.SetClientVariable(name, value, _clientNo, _roomId);
             }
             _pendingSelfClientNV.Clear();
+
+            // Flush pending self client NV (bytes)
+            foreach (var (name, value) in _pendingSelfClientNVBytes)
+            {
+                _networkVariableManager?.SetClientVariable(name, value, _clientNo, _roomId);
+            }
+            _pendingSelfClientNVBytes.Clear();
 
             // Set flag to check ready state on main thread
             _shouldCheckReady = true;


### PR DESCRIPTION
## Summary

- Add `byte[]` type support to NetworkVariable (both global and client variables) with type tag-based wire format
- Increase `MAX_VAR_VALUE_LENGTH` from 1,024 to 65,536 bytes (64KB)
- Add BinaryVariable sample scene demonstrating three sync patterns:
  - **NaivePrimitiveSync**: 6 individual string variables for size/color
  - **BinaryPrimitiveSync**: 1 byte[] variable via ScriptableObject serialization
  - **ScreenshotSync**: capture, resize, JPEG-encode, and sync screenshots as byte[]
- Fix `NVValue` null `RawBytes` crash when using `default(NVValue)` during initial sync

## Test plan

- [ ] Run Python server and connect Unity client — verify handshake and variable sync
- [ ] Test NaivePrimitiveSync: edit size/color in Inspector, click Send All, verify sync on second client
- [ ] Test BinaryPrimitiveSync: edit PrimitiveParams asset, click Send, verify sync on second client
- [ ] Test ScreenshotSync: click Capture Screenshot, verify image appears on RawImage for all clients
- [ ] Verify no errors in Unity console during initial sync (NVValue null fix)
- [ ] Run Python tests: `pytest` in STYLY-NetSync-Server

🤖 Generated with [Claude Code](https://claude.com/claude-code)