### PR TITLE
fix(NetSyncAvatar): correct avatar head height in Editor when CameraYOffset is set

### DIFF
--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/NetSyncAvatar.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/NetSyncAvatar.cs
@@ -193,15 +193,28 @@ namespace Styly.NetSync
         }
 
 #if UNITY_EDITOR
+        private Camera _cachedEditorMainCamera;
+        private Transform _cachedEditorMainCameraTransform;
+
         // Editor-only fallback: when no XR device is active, TrackedPoseDriver leaves
         // _head at (0,0,0). Return Camera.main.transform so the local avatar reflects
         // CameraYOffset. Returns null when an XR device (Meta Link, XR Device Simulator,
         // etc.) is active, so real tracked poses are never overwritten.
+        private Transform GetCachedEditorMainCameraTransform()
+        {
+            if (_cachedEditorMainCamera == null)
+            {
+                _cachedEditorMainCamera = Camera.main;
+                _cachedEditorMainCameraTransform = _cachedEditorMainCamera != null ? _cachedEditorMainCamera.transform : null;
+            }
+
+            return _cachedEditorMainCameraTransform;
+        }
+
         private Transform TryGetEditorHeadOverride()
         {
             if (XRSettings.isDeviceActive) { return null; }
-            var mainCam = Camera.main;
-            return mainCam != null ? mainCam.transform : null;
+            return GetCachedEditorMainCameraTransform();
         }
 
         void LateUpdate()

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/NetSyncAvatar.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/NetSyncAvatar.cs
@@ -189,6 +189,20 @@ namespace Styly.NetSync
             }
         }
 
+#if UNITY_EDITOR
+        void LateUpdate()
+        {
+            // In the Editor there is no XR device, so TrackedPoseDriver leaves _head at (0,0,0).
+            // Override the local avatar head transform to Camera.main so the avatar renders at
+            // the correct height (CameraYOffset applied) during editor play-mode testing.
+            if (IsLocalAvatar && _head != null && Camera.main != null)
+            {
+                _head.position = Camera.main.transform.position;
+                _head.rotation = Camera.main.transform.rotation;
+            }
+        }
+#endif
+
         // Get current transform data for sending
         internal ClientTransformData GetTransformData()
         {
@@ -217,9 +231,20 @@ namespace Styly.NetSync
             _tx.physical = _txPhysical;
 
             // World space transforms.
+            // In the Editor there is no XR device, so TrackedPoseDriver returns (0,0,0).
+            // Camera.main.transform.position correctly reflects CameraYOffset (e.g. 1.3 m)
+            // that was set for a comfortable editor view, matching the visual camera height.
+            // On-device builds use _head.position (floor-relative XR tracking) directly.
+#if UNITY_EDITOR
+            var headForSync = Camera.main != null ? Camera.main.transform : _head;
+            Fill(_txHead,
+                headForSync != null ? headForSync.position : Vector3.zero,
+                headForSync != null ? headForSync.rotation : Quaternion.identity);
+#else
             Fill(_txHead,
                 _head != null ? _head.position : Vector3.zero,
                 _head != null ? _head.rotation : Quaternion.identity);
+#endif
             _tx.head = _txHead;
 
             Fill(_txRight,

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/NetSyncAvatar.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/NetSyncAvatar.cs
@@ -4,6 +4,9 @@ using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.Events;
 using Unity.XR.CoreUtils;
+#if UNITY_EDITOR
+using UnityEngine.XR;
+#endif
 
 namespace Styly.NetSync
 {
@@ -190,15 +193,25 @@ namespace Styly.NetSync
         }
 
 #if UNITY_EDITOR
+        // Editor-only fallback: when no XR device is active, TrackedPoseDriver leaves
+        // _head at (0,0,0). Return Camera.main.transform so the local avatar reflects
+        // CameraYOffset. Returns null when an XR device (Meta Link, XR Device Simulator,
+        // etc.) is active, so real tracked poses are never overwritten.
+        private Transform TryGetEditorHeadOverride()
+        {
+            if (XRSettings.isDeviceActive) { return null; }
+            var mainCam = Camera.main;
+            return mainCam != null ? mainCam.transform : null;
+        }
+
         void LateUpdate()
         {
-            // In the Editor there is no XR device, so TrackedPoseDriver leaves _head at (0,0,0).
-            // Override the local avatar head transform to Camera.main so the avatar renders at
-            // the correct height (CameraYOffset applied) during editor play-mode testing.
-            if (IsLocalAvatar && _head != null && Camera.main != null)
+            if (!IsLocalAvatar || _head == null) { return; }
+            var overrideTransform = TryGetEditorHeadOverride();
+            if (overrideTransform != null)
             {
-                _head.position = Camera.main.transform.position;
-                _head.rotation = Camera.main.transform.rotation;
+                _head.position = overrideTransform.position;
+                _head.rotation = overrideTransform.rotation;
             }
         }
 #endif
@@ -231,20 +244,18 @@ namespace Styly.NetSync
             _tx.physical = _txPhysical;
 
             // World space transforms.
-            // In the Editor there is no XR device, so TrackedPoseDriver returns (0,0,0).
-            // Camera.main.transform.position correctly reflects CameraYOffset (e.g. 1.3 m)
-            // that was set for a comfortable editor view, matching the visual camera height.
-            // On-device builds use _head.position (floor-relative XR tracking) directly.
+            // In the Editor without an active XR device, TrackedPoseDriver returns (0,0,0).
+            // TryGetEditorHeadOverride() substitutes Camera.main.transform so the transmitted
+            // head pose reflects CameraYOffset. When an XR device is active (Meta Link, XR
+            // Device Simulator, on-device builds), _head is used directly.
+            Transform headForSync = _head;
 #if UNITY_EDITOR
-            var headForSync = Camera.main != null ? Camera.main.transform : _head;
+            var overrideTransform = TryGetEditorHeadOverride();
+            if (overrideTransform != null) { headForSync = overrideTransform; }
+#endif
             Fill(_txHead,
                 headForSync != null ? headForSync.position : Vector3.zero,
                 headForSync != null ? headForSync.rotation : Quaternion.identity);
-#else
-            Fill(_txHead,
-                _head != null ? _head.position : Vector3.zero,
-                _head != null ? _head.rotation : Quaternion.identity);
-#endif
             _tx.head = _txHead;
 
             Fill(_txRight,


### PR DESCRIPTION
## Root cause

The bug is caused by `<XRHMD>/centerEyePosition` returning different values depending on the execution environment:

| Environment | `centerEyePosition` | `_head.position` | `Camera.main.position` |
|---|---|---|---|
| **Editor** (no XR device) | `(0, 0, 0)` | `(0, 0, 0)` ← wrong | `(0, 1.3, 0)` ← correct |
| **HMD** (floor tracking) | `(x, ~1.6, z)` actual tracking | `(x, ~1.6, z)` ← correct | `(x, 2.9, z)` ← includes CameraYOffset too |

`XROrigin.CameraYOffset = 1.3` raises `Camera.main` for a comfortable editor view, but `TrackedPoseDriver` on `_head` reads `centerEyePosition` directly — it never sees `CameraYOffset`. On HMD, real tracking fills that gap. In the Editor, nothing does, so `_head` stays at y=0 while the camera is at y=1.3.

This caused two visible issues in Editor play-mode:
1. The **network-synced remote avatar** transmitted `_head.position = 0` → appeared at y=0
2. The **local avatar** rendered with its head at y=0 instead of at camera height

## Fix

Guard both fixes with `#if UNITY_EDITOR` so device builds are completely unaffected.

- **`GetTransformData()`**: use `Camera.main.transform` for the transmitted head position in Editor, so the value reflects `CameraYOffset`.
- **`LateUpdate()` (Editor only)**: override `_head.position/rotation` to `Camera.main` each frame so the local avatar also renders at the correct height.

Note: `XRInteractionSimulator` with "Override XR Simulation Input" enabled would bake `CameraYOffset` into `centerEyePosition` automatically, but relying on that setting is fragile. The `#if UNITY_EDITOR` fallback makes this work regardless of simulator configuration.

## Test plan

- [ ] Editor play-mode: remote avatar head appears at the same height as the local camera (not at y=0)
- [ ] Editor play-mode: local avatar head renders at camera height
- [ ] HMD device build: no behaviour change — avatar head follows XR floor tracking as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)