### PR TITLE
feat: add inspector tooltips for events on NetSyncManager and NetSyncAvatar

### DIFF
--- a/STYLY-NetSync-Unity/AGENTS.md
+++ b/STYLY-NetSync-Unity/AGENTS.md
@@ -41,3 +41,12 @@
 2. Check Unity Console for connection status
 3. Verify Python server is running
 4. Test with `Assets/Samples_Dev/Debug/Debug Scene.unity`
+
+## Adding a New UnityEvent Field
+
+`UnityEventDrawer` swallows `[Tooltip]`, so event fields need a custom-editor overlay.
+
+- Add `[Tooltip("…")]` and initialize at declaration (`= new UnityEvent<…>()`). No `[Header]` on event fields.
+- In the custom editor, register the field name in `EventProperties` (and `EventGroupHeaders` if it starts a new section). Existing `DrawEventWithTooltip` handles the rest.
+
+Non-UnityEvent fields: plain `[Tooltip]` is enough.

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Editor/NetSyncAvatarEditor.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Editor/NetSyncAvatarEditor.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using UnityEngine;
 using UnityEditor;
 
@@ -10,19 +11,40 @@ namespace Styly.NetSync.Editor
         private bool _showClientVariables = true;
         // Timestamp of the last inspector repaint. Used to throttle repaint calls in play mode.
         private double _lastRepaint;
-        
+
+        // UnityEventDrawer swallows the [Tooltip] on UnityEvent fields, so these
+        // event properties are rendered manually and get an invisible GUI.Label
+        // overlay on the header rect to restore hover tooltips.
+        private static readonly HashSet<string> EventProperties = new HashSet<string>
+        {
+            "OnClientVariableChanged",
+            "OnHandTrackingLost",
+            "OnHandTrackingRestored"
+        };
+
+        // Group headers drawn before the mapped event. [Header] lives in the
+        // runtime file normally, but a Header decorator shifts GetLastRect so
+        // the tooltip overlay lands on the header label instead of the event
+        // foldout — so we render the header here instead.
+        private static readonly Dictionary<string, string> EventGroupHeaders = new Dictionary<string, string>
+        {
+            { "OnClientVariableChanged", "Network Variable Events" },
+            { "OnHandTrackingLost", "Hand Tracking Events" }
+        };
+
         private void OnEnable()
         {
             _netSyncAvatar = (NetSyncAvatar)target;
         }
-        
+
         public override void OnInspectorGUI()
         {
             // Update serialized object to reflect runtime changes
             serializedObject.Update();
 
-            // Draw default inspector
-            DrawDefaultInspector();
+            DrawInspectorProperties();
+
+            serializedObject.ApplyModifiedProperties();
 
             // Only show network variables during play mode
             if (!Application.isPlaying)
@@ -97,6 +119,63 @@ namespace Styly.NetSync.Editor
                     _lastRepaint = now;
                 }
             }
+        }
+
+        private void DrawInspectorProperties()
+        {
+            var iterator = serializedObject.GetIterator();
+            bool enterChildren = true;
+
+            while (iterator.NextVisible(enterChildren))
+            {
+                enterChildren = false;
+
+                if (iterator.propertyPath == "m_Script")
+                {
+                    using (new EditorGUI.DisabledScope(true))
+                    {
+                        EditorGUILayout.PropertyField(iterator, true);
+                    }
+                    continue;
+                }
+
+                if (EventProperties.Contains(iterator.propertyPath))
+                {
+                    if (EventGroupHeaders.TryGetValue(iterator.propertyPath, out var header))
+                    {
+                        EditorGUILayout.Space();
+                        EditorGUILayout.LabelField(header, EditorStyles.boldLabel);
+                    }
+                    DrawEventWithTooltip(iterator);
+                    continue;
+                }
+
+                EditorGUILayout.PropertyField(iterator, true);
+            }
+        }
+
+        // Reserves the PropertyField's rect explicitly so we know its top
+        // position, then draws the UnityEvent and overlays an invisible
+        // GUI.Label on its foldout header row. GetLastRect is unreliable here
+        // because an expanded UnityEvent's last sub-control is the "+/-" row
+        // at the bottom, not the foldout header.
+        private static void DrawEventWithTooltip(SerializedProperty property)
+        {
+            var height = EditorGUI.GetPropertyHeight(property, true);
+            var rect = EditorGUILayout.GetControlRect(true, height);
+            EditorGUI.PropertyField(rect, property, true);
+
+            if (string.IsNullOrEmpty(property.tooltip))
+            {
+                return;
+            }
+
+            var headerRect = new Rect(
+                rect.x,
+                rect.y,
+                rect.width,
+                EditorGUIUtility.singleLineHeight);
+            GUI.Label(headerRect, new GUIContent(string.Empty, property.tooltip));
         }
     }
 }

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Editor/NetSyncManagerEditor.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Editor/NetSyncManagerEditor.cs
@@ -19,6 +19,29 @@ namespace Styly.NetSync.Editor
         };
         private static readonly HashSet<string> AdvancedProperties = new HashSet<string>(AdvancedPropertyOrder);
 
+        // UnityEventDrawer swallows the [Tooltip] on UnityEvent fields, so these
+        // event properties are rendered manually and get an invisible GUI.Label
+        // overlay on the header rect to restore hover tooltips.
+        private static readonly HashSet<string> EventProperties = new HashSet<string>
+        {
+            "OnAvatarConnected",
+            "OnAvatarDisconnected",
+            "OnRPCReceived",
+            "OnGlobalVariableChanged",
+            "OnClientVariableChanged",
+            "OnReady",
+            "OnVersionMismatch"
+        };
+
+        // Group headers drawn before the mapped event. [Header] lives in the
+        // runtime file normally, but a Header decorator shifts GetLastRect so
+        // the tooltip overlay lands on the header label instead of the event
+        // foldout — so we render the header here instead.
+        private static readonly Dictionary<string, string> EventGroupHeaders = new Dictionary<string, string>
+        {
+            { "OnAvatarConnected", "Events" }
+        };
+
         public override bool RequiresConstantRepaint()
         {
             return Application.isPlaying;
@@ -56,6 +79,17 @@ namespace Styly.NetSync.Editor
                     continue;
                 }
 
+                if (EventProperties.Contains(iterator.propertyPath))
+                {
+                    if (EventGroupHeaders.TryGetValue(iterator.propertyPath, out var header))
+                    {
+                        EditorGUILayout.Space();
+                        EditorGUILayout.LabelField(header, EditorStyles.boldLabel);
+                    }
+                    DrawEventWithTooltip(iterator);
+                    continue;
+                }
+
                 bool isTargetField = iterator.propertyPath == "_serverAddress" || iterator.propertyPath == "_roomId";
                 bool disable = EditorApplication.isPlaying && isTargetField;
 
@@ -70,6 +104,30 @@ namespace Styly.NetSync.Editor
             DrawGlobalVariablesSection();
 
             serializedObject.ApplyModifiedProperties();
+        }
+
+        // Reserves the PropertyField's rect explicitly so we know its top
+        // position, then draws the UnityEvent and overlays an invisible
+        // GUI.Label on its foldout header row. GetLastRect is unreliable here
+        // because an expanded UnityEvent's last sub-control is the "+/-" row
+        // at the bottom, not the foldout header.
+        private static void DrawEventWithTooltip(SerializedProperty property)
+        {
+            var height = EditorGUI.GetPropertyHeight(property, true);
+            var rect = EditorGUILayout.GetControlRect(true, height);
+            EditorGUI.PropertyField(rect, property, true);
+
+            if (string.IsNullOrEmpty(property.tooltip))
+            {
+                return;
+            }
+
+            var headerRect = new Rect(
+                rect.x,
+                rect.y,
+                rect.width,
+                EditorGUIUtility.singleLineHeight);
+            GUI.Label(headerRect, new GUIContent(string.Empty, property.tooltip));
         }
 
         private void DrawAdvancedSection(List<string> advancedPropertyPaths)

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/NetSyncAvatar.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/NetSyncAvatar.cs
@@ -10,18 +10,26 @@ namespace Styly.NetSync
     public class NetSyncAvatar : MonoBehaviour
     {
         [Header("Network Settings")]
-        [SerializeField, ReadOnly] private string _deviceId;
-        [SerializeField, ReadOnly] private int _clientNo;
+        [SerializeField, ReadOnly, Tooltip("Runtime-only device identifier assigned by the server. Empty in Edit mode.")]
+        private string _deviceId;
+        [SerializeField, ReadOnly, Tooltip("Runtime-only client number assigned by the server. 0 until the client is assigned.")]
+        private int _clientNo;
 
         [Header("Physical Transform Data")]
-        [ReadOnly] public Vector3 PhysicalPosition;
-        [ReadOnly] public Quaternion PhysicalRotation;
+        [ReadOnly, Tooltip("Physical (real-world) position of this avatar relative to the XR rig. Updated every sync tick at runtime.")]
+        public Vector3 PhysicalPosition;
+        [ReadOnly, Tooltip("Physical (real-world) rotation of this avatar relative to the XR rig. Updated every sync tick at runtime.")]
+        public Quaternion PhysicalRotation;
 
         [Header("Body Parts")]
+        [Tooltip("Head transform (typically the XR camera). Synced as an absolute pose.")]
         public Transform _head;
+        [Tooltip("Right hand transform (controller or tracked hand root). Synced relative to the head.")]
         public Transform _rightHand;
+        [Tooltip("Left hand transform (controller or tracked hand root). Synced relative to the head.")]
         public Transform _leftHand;
-        public Transform[] _virtualTransforms; // Object array to sync Virtual position (world coordinate system)
+        [Tooltip("Additional transforms synchronized in world space (e.g. held objects). Order must match across peers.")]
+        public Transform[] _virtualTransforms;
 
         // Properties
         public string DeviceId => _deviceId;
@@ -35,12 +43,11 @@ namespace Styly.NetSync
         private readonly NetSyncTransformApplier _transformApplier = new NetSyncTransformApplier();
         private readonly NetSyncSmoothingSettings _smoothingSettings = new NetSyncSmoothingSettings();
 
-        // Events
-        [Header("Network Variable Events")]
+        // Event-group headers and per-event tooltips are rendered by
+        // NetSyncAvatarEditor so UnityEventDrawer doesn't swallow them.
         [Tooltip("Fired when a client variable changes for this avatar's owner. Parameters: name (string), oldValue (string), newValue (string).")]
         public UnityEvent<string, string, string> OnClientVariableChanged;
 
-        [Header("Hand Tracking Events")]
         /// <summary>
         /// Invoked when hand tracking is lost (true hand tracking loss, not controller switch).
         /// Parameter: Hand (Left or Right)

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/NetSyncAvatar.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/NetSyncAvatar.cs
@@ -45,22 +45,23 @@ namespace Styly.NetSync
 
         // Event-group headers and per-event tooltips are rendered by
         // NetSyncAvatarEditor so UnityEventDrawer doesn't swallow them.
+        // Initialize UnityEvents at declaration to ensure they are always non-null.
         [Tooltip("Fired when a client variable changes for this avatar's owner. Parameters: name (string), oldValue (string), newValue (string).")]
-        public UnityEvent<string, string, string> OnClientVariableChanged;
+        public UnityEvent<string, string, string> OnClientVariableChanged = new UnityEvent<string, string, string>();
 
         /// <summary>
         /// Invoked when hand tracking is lost (true hand tracking loss, not controller switch).
         /// Parameter: Hand (Left or Right)
         /// </summary>
         [Tooltip("Fired when hand tracking is lost (true hand tracking loss, not controller switch). Parameter: hand (Hand) — Left or Right.")]
-        public UnityEvent<Hand> OnHandTrackingLost;
+        public UnityEvent<Hand> OnHandTrackingLost = new UnityEvent<Hand>();
 
         /// <summary>
         /// Invoked when hand tracking is restored.
         /// Parameter: Hand (Left or Right)
         /// </summary>
         [Tooltip("Fired when hand tracking is restored. Parameter: hand (Hand) — Left or Right.")]
-        public UnityEvent<Hand> OnHandTrackingRestored;
+        public UnityEvent<Hand> OnHandTrackingRestored = new UnityEvent<Hand>();
 
         // --- Cached objects for zero-allocation transform packaging on send ---
         // These are reused every frame to avoid GC pressure from frequent network sends.

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/NetSyncAvatar.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/NetSyncAvatar.cs
@@ -37,6 +37,7 @@ namespace Styly.NetSync
 
         // Events
         [Header("Network Variable Events")]
+        [Tooltip("Fired when a client variable changes for this avatar's owner. Parameters: name (string), oldValue (string), newValue (string).")]
         public UnityEvent<string, string, string> OnClientVariableChanged;
 
         [Header("Hand Tracking Events")]
@@ -44,12 +45,14 @@ namespace Styly.NetSync
         /// Invoked when hand tracking is lost (true hand tracking loss, not controller switch).
         /// Parameter: Hand (Left or Right)
         /// </summary>
+        [Tooltip("Fired when hand tracking is lost (true hand tracking loss, not controller switch). Parameter: hand (Hand) — Left or Right.")]
         public UnityEvent<Hand> OnHandTrackingLost;
 
         /// <summary>
         /// Invoked when hand tracking is restored.
         /// Parameter: Hand (Left or Right)
         /// </summary>
+        [Tooltip("Fired when hand tracking is restored. Parameter: hand (Hand) — Left or Right.")]
         public UnityEvent<Hand> OnHandTrackingRestored;
 
         // --- Cached objects for zero-allocation transform packaging on send ---

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/NetSyncManager.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/NetSyncManager.cs
@@ -32,7 +32,8 @@ namespace Styly.NetSync
         private bool _logTransformDetail = false;
         private bool _logNetworkTraffic = false;
 
-        [Header("Events")]
+        // The "Events" header and per-event tooltips are rendered by
+        // NetSyncManagerEditor so UnityEventDrawer doesn't swallow them.
         // Initialize UnityEvents at declaration to ensure they are always non-null
         [Tooltip("Fired when a remote avatar connects. Parameter: clientNo (int) — the unique client number assigned to the connected avatar.")]
         public UnityEvent<int> OnAvatarConnected = new UnityEvent<int>();

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/NetSyncManager.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/NetSyncManager.cs
@@ -34,16 +34,23 @@ namespace Styly.NetSync
 
         [Header("Events")]
         // Initialize UnityEvents at declaration to ensure they are always non-null
+        [Tooltip("Fired when a remote avatar connects. Parameter: clientNo (int) — the unique client number assigned to the connected avatar.")]
         public UnityEvent<int> OnAvatarConnected = new UnityEvent<int>();
+        [Tooltip("Fired when a remote avatar disconnects. Parameter: clientNo (int) — the unique client number of the disconnected avatar.")]
         public UnityEvent<int> OnAvatarDisconnected = new UnityEvent<int>();
+        [Tooltip("Fired when an RPC is received. Parameters: senderClientNo (int), functionName (string), args (string[]).")]
         public UnityEvent<int, string, string[]> OnRPCReceived;
+        [Tooltip("Fired when a global network variable changes. Parameters: name (string), oldValue (string), newValue (string).")]
         public UnityEvent<string, string, string> OnGlobalVariableChanged;
+        [Tooltip("Fired when a client-specific network variable changes. Parameters: clientNo (int), name (string), oldValue (string), newValue (string).")]
         public UnityEvent<int, string, string, string> OnClientVariableChanged;
+        [Tooltip("Fired when the client is fully connected and synchronized (connected, handshaked, and network variables synced).")]
         public UnityEvent OnReady;
         /// <summary>
         /// Event fired when server and client versions do not match.
         /// Parameters: (serverVersion, clientVersion) as strings like "0.7.5"
         /// </summary>
+        [Tooltip("Fired when server and client versions do not match. Parameters: serverVersion (string), clientVersion (string) — e.g. \"0.7.5\".")]
         public UnityEvent<string, string> OnVersionMismatch = new UnityEvent<string, string>();
 
         // Advanced Options (drawn by NetSyncManagerEditor in a foldout)

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/NetSyncManager.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/NetSyncManager.cs
@@ -40,13 +40,13 @@ namespace Styly.NetSync
         [Tooltip("Fired when a remote avatar disconnects. Parameter: clientNo (int) — the unique client number of the disconnected avatar.")]
         public UnityEvent<int> OnAvatarDisconnected = new UnityEvent<int>();
         [Tooltip("Fired when an RPC is received. Parameters: senderClientNo (int), functionName (string), args (string[]).")]
-        public UnityEvent<int, string, string[]> OnRPCReceived;
+        public UnityEvent<int, string, string[]> OnRPCReceived = new UnityEvent<int, string, string[]>();
         [Tooltip("Fired when a global network variable changes. Parameters: name (string), oldValue (string), newValue (string).")]
-        public UnityEvent<string, string, string> OnGlobalVariableChanged;
+        public UnityEvent<string, string, string> OnGlobalVariableChanged = new UnityEvent<string, string, string>();
         [Tooltip("Fired when a client-specific network variable changes. Parameters: clientNo (int), name (string), oldValue (string), newValue (string).")]
-        public UnityEvent<int, string, string, string> OnClientVariableChanged;
+        public UnityEvent<int, string, string, string> OnClientVariableChanged = new UnityEvent<int, string, string, string>();
         [Tooltip("Fired when the client is fully connected and synchronized (connected, handshaked, and network variables synced).")]
-        public UnityEvent OnReady;
+        public UnityEvent OnReady = new UnityEvent();
         /// <summary>
         /// Event fired when server and client versions do not match.
         /// Parameters: (serverVersion, clientVersion) as strings like "0.7.5"


### PR DESCRIPTION
Add `[Tooltip]` attributes to all UnityEvent fields in NetSyncManager and NetSyncAvatar, explaining each event's purpose and parameter meanings in the Unity Inspector.

Closes #406

Generated with [Claude Code](https://claude.ai/code)