### PR TITLE
feat(NetSyncManager): expose public ServerAddress getter (#392)

### DIFF
--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/NetSyncManager.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/NetSyncManager.cs
@@ -378,6 +378,13 @@ namespace Styly.NetSync
         public string RoomId => _roomId;
 
         /// <summary>
+        /// Server address the client is configured to connect to, or the
+        /// address resolved via auto-discovery when the inspector field is left empty.
+        /// Empty string until auto-discovery completes.
+        /// </summary>
+        public string ServerAddress => _serverAddress;
+
+        /// <summary>
         /// UDP port used for server discovery.
         /// </summary>
         public int ServerDiscoveryPort


### PR DESCRIPTION
## Summary
- Add a public read-only `ServerAddress` property on `NetSyncManager` so consumers (debug UI, OSC integration, etc.) can read the configured or auto-discovered server host.
- Non-breaking: getter only — configuration still flows through the Inspector field or auto-discovery.
- Covers both cases: the property reflects the Inspector-supplied address immediately, and the auto-discovered address after `OnServerDiscovered()` runs.

Closes #392

## Test plan
- [ ] Open `STYLY-NetSync-Unity/` in Unity 6 and confirm the package compiles with no new warnings/errors.
- [ ] In `Assets/Samples_Dev/Debug/Debug Scene.unity`, leave `Server Address` empty, enter Play mode with the Python server running, and log `NetSyncManager.Instance.ServerAddress` — should return the auto-discovered host (no `tcp://` prefix).
- [ ] Set `Server Address` explicitly (e.g. `127.0.0.1`) and confirm the property returns that exact value in Play mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)