### PR TITLE
feat(NetSyncManager): add methods to retrieve client number by device ID and device ID by client number

### DIFF
--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/NetSyncManager.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/NetSyncManager.cs
@@ -214,6 +214,8 @@ namespace Styly.NetSync
         /// Returns 0 when the mapping is not yet known (e.g. before the device has
         /// been observed in this room, or before the local handshake has completed),
         /// or when <paramref name="deviceId"/> is null or empty.
+        /// When network traffic logging is enabled, unresolved lookups may also
+        /// emit a warning from the underlying message processor.
         /// </summary>
         /// <param name="deviceId">The stable device identifier.</param>
         /// <returns>The client number, or 0 if no mapping is known.</returns>

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/NetSyncManager.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/NetSyncManager.cs
@@ -210,6 +210,34 @@ namespace Styly.NetSync
         }
 
         /// <summary>
+        /// Gets the server-assigned client number for the specified device ID.
+        /// Returns 0 when the mapping is not yet known (e.g. before the device has
+        /// been observed in this room, or before the local handshake has completed),
+        /// or when <paramref name="deviceId"/> is null or empty.
+        /// </summary>
+        /// <param name="deviceId">The stable device identifier.</param>
+        /// <returns>The client number, or 0 if no mapping is known.</returns>
+        public int GetClientNoByDeviceId(string deviceId)
+        {
+            if (string.IsNullOrEmpty(deviceId)) return 0;
+            return _messageProcessor != null ? _messageProcessor.GetClientNo(deviceId) : 0;
+        }
+
+        /// <summary>
+        /// Gets the stable device ID for the specified client number.
+        /// Returns null when the mapping is not yet known (e.g. before the device
+        /// has been observed in this room), or when <paramref name="clientNo"/> is
+        /// not a positive value.
+        /// </summary>
+        /// <param name="clientNo">The server-assigned client number (&gt; 0).</param>
+        /// <returns>The device ID, or null if no mapping is known.</returns>
+        public string GetDeviceIdByClientNo(int clientNo)
+        {
+            if (clientNo <= 0) return null;
+            return _messageProcessor != null ? _messageProcessor.GetDeviceIdFromClientNo(clientNo) : null;
+        }
+
+        /// <summary>
         /// Gets a list (int[]) of all currently connected client numbers.
         /// </summary>
         /// <param name="includeStealthClients">If true, includes clients in stealth mode (no visible avatar). Default is false.</param>


### PR DESCRIPTION
This pull request adds two new utility methods to `NetSyncManager` to facilitate mapping between device IDs and server-assigned client numbers. These methods improve the ability to look up client information based on device identifiers and vice versa, with appropriate handling for unknown or invalid input.

**New mapping utilities:**

* Added `GetClientNoByDeviceId(string deviceId)` to retrieve the client number for a given device ID, returning 0 if the mapping is unknown or the input is null/empty.
* Added `GetDeviceIdByClientNo(int clientNo)` to retrieve the device ID for a given client number, returning null if the mapping is unknown or the client number is not positive.

Close https://github.com/styly-dev/STYLY-NetSync/issues/411