### PR TITLE
feat(Editor): prefer scene NetSyncManager port in server launch dialog

### DIFF
--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Editor/StartPythonServer.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Editor/StartPythonServer.cs
@@ -18,7 +18,7 @@ namespace Styly.NetSync.Editor
         // Port settings
         public int DealerPort = 5555;
         public int PubPort = 5556;
-        public int ServerDiscoveryPort = 9999;
+        public int ServerDiscoveryPort = StartPythonServer.DefaultServerDiscoveryPort;
         public int RestApiPort = 8800;
         public bool DisableServerDiscovery = false;
         public string ConfigFile = "";
@@ -59,7 +59,7 @@ namespace Styly.NetSync.Editor
             {
                 sb.Append(" --no-server-discovery");
             }
-            else if (ServerDiscoveryPort != 9999)
+            else if (ServerDiscoveryPort != StartPythonServer.DefaultServerDiscoveryPort)
             {
                 sb.Append($" --server-discovery-port {ServerDiscoveryPort}");
             }
@@ -88,6 +88,8 @@ namespace Styly.NetSync.Editor
 
     internal static class StartPythonServer
     {
+        internal const int DefaultServerDiscoveryPort = 9999;
+
         internal static bool TryGetServerDiscoveryPortFromScene(out int port)
         {
             // Try to find NetSyncManager in the active scene first, then other loaded scenes
@@ -117,13 +119,13 @@ namespace Styly.NetSync.Editor
                 }
             }
 
-            port = 9999;
+            port = DefaultServerDiscoveryPort;
             return false;
         }
 
         internal static int GetDefaultServerDiscoveryPort()
         {
-            return TryGetServerDiscoveryPortFromScene(out int port) ? port : 9999;
+            return TryGetServerDiscoveryPortFromScene(out int port) ? port : DefaultServerDiscoveryPort;
         }
 
         internal static string GetServerVersionSafe()

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Editor/StartPythonServer.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Editor/StartPythonServer.cs
@@ -88,7 +88,7 @@ namespace Styly.NetSync.Editor
 
     internal static class StartPythonServer
     {
-        internal static int GetDefaultServerDiscoveryPort()
+        internal static bool TryGetServerDiscoveryPortFromScene(out int port)
         {
             // Try to find NetSyncManager in the active scene first, then other loaded scenes
             Scene activeScene = SceneManager.GetActiveScene();
@@ -111,13 +111,19 @@ namespace Styly.NetSync.Editor
                     NetSyncManager manager = rootObject.GetComponentInChildren<NetSyncManager>(true);
                     if (manager != null)
                     {
-                        return manager.ServerDiscoveryPort;
+                        port = manager.ServerDiscoveryPort;
+                        return true;
                     }
                 }
             }
 
-            // Return default port if NetSyncManager is not found
-            return 9999;
+            port = 9999;
+            return false;
+        }
+
+        internal static int GetDefaultServerDiscoveryPort()
+        {
+            return TryGetServerDiscoveryPortFromScene(out int port) ? port : 9999;
         }
 
         internal static string GetServerVersionSafe()

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Editor/StartPythonServerWindow.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Editor/StartPythonServerWindow.cs
@@ -200,8 +200,11 @@ namespace Styly.NetSync.Editor
         {
             _dealerPort = EditorPrefs.GetInt(PrefsPrefix + "DealerPort", 5555);
             _pubPort = EditorPrefs.GetInt(PrefsPrefix + "PubPort", 5556);
-            _serverDiscoveryPort = EditorPrefs.GetInt(PrefsPrefix + "ServerDiscoveryPort",
-                StartPythonServer.GetDefaultServerDiscoveryPort());
+            // Prefer the NetSyncManager in an open scene over the saved value,
+            // so the dialog reflects the port currently configured in the scene.
+            _serverDiscoveryPort = StartPythonServer.TryGetServerDiscoveryPortFromScene(out int scenePort)
+                ? scenePort
+                : EditorPrefs.GetInt(PrefsPrefix + "ServerDiscoveryPort", 9999);
             _restApiPort = EditorPrefs.GetInt(PrefsPrefix + "RestApiPort", 8800);
             _disableServerDiscovery = EditorPrefs.GetBool(PrefsPrefix + "DisableServerDiscovery", false);
             _configFile = EditorPrefs.GetString(PrefsPrefix + "ConfigFile", "");

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Editor/StartPythonServerWindow.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Editor/StartPythonServerWindow.cs
@@ -10,7 +10,7 @@ namespace Styly.NetSync.Editor
         // Port settings
         private int _dealerPort = 5555;
         private int _pubPort = 5556;
-        private int _serverDiscoveryPort = 9999;
+        private int _serverDiscoveryPort = StartPythonServer.DefaultServerDiscoveryPort;
         private int _restApiPort = 8800;
         private bool _disableServerDiscovery = false;
         private string _configFile = "";
@@ -204,7 +204,7 @@ namespace Styly.NetSync.Editor
             // so the dialog reflects the port currently configured in the scene.
             _serverDiscoveryPort = StartPythonServer.TryGetServerDiscoveryPortFromScene(out int scenePort)
                 ? scenePort
-                : EditorPrefs.GetInt(PrefsPrefix + "ServerDiscoveryPort", 9999);
+                : EditorPrefs.GetInt(PrefsPrefix + "ServerDiscoveryPort", StartPythonServer.DefaultServerDiscoveryPort);
             _restApiPort = EditorPrefs.GetInt(PrefsPrefix + "RestApiPort", 8800);
             _disableServerDiscovery = EditorPrefs.GetBool(PrefsPrefix + "DisableServerDiscovery", false);
             _configFile = EditorPrefs.GetString(PrefsPrefix + "ConfigFile", "");


### PR DESCRIPTION
## Summary
- The `Start NetSync Server` dialog now prefers the `ServerDiscoveryPort` of a `NetSyncManager` in an open scene over the `EditorPrefs`-saved value.
- Fallback order: open-scene `NetSyncManager` port → saved EditorPrefs value → `9999`.
- Refactors `GetDefaultServerDiscoveryPort` into `TryGetServerDiscoveryPortFromScene(out int port)`; the original name is kept as a thin wrapper (still used by `Reset to Defaults`).

## Motivation
Previously the dialog always showed the last-saved value, which could be stale when switching between projects or scenes. Reading from the scene's `NetSyncManager` ensures the launched server matches the port the scene is configured to discover.

## Test plan
- [ ] Open a scene with a `NetSyncManager` whose `ServerDiscoveryPort` differs from the last-used dialog value → dialog shows the scene's port.
- [ ] Open a scene without a `NetSyncManager` → dialog shows the previously saved value (or 9999 on first use).
- [ ] Verify `Reset to Defaults` still picks up the scene's port when present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)