### PR TITLE
feat(rest_bridge): add GET endpoints for global and client variables

### DIFF
--- a/STYLY-NetSync-Server/src/styly_netsync/rest_bridge.py
+++ b/STYLY-NetSync-Server/src/styly_netsync/rest_bridge.py
@@ -284,6 +284,24 @@ class BridgeManager:
                 self._bridges[room_id] = bridge
             return bridge
 
+    def peek(self, room_id: str) -> RoomBridge | None:
+        """Return an existing bridge for the room, or None if not yet created."""
+        with self._lock:
+            return self._bridges.get(room_id)
+
+
+def _live_client_variables(
+    manager: BridgeManager, room_id: str, device_id: str
+) -> dict[str, str]:
+    """Return live client variables from the bridge cache, or {} if unavailable."""
+    bridge = manager.peek(room_id)
+    if bridge is None:
+        return {}
+    client_no = bridge.get_client_no(device_id)
+    if not client_no:
+        return {}
+    return bridge.manager.get_all_client_variables(client_no)
+
 
 def create_app(server_addr: str, dealer_port: int, sub_port: int) -> FastAPI:
     """Create the FastAPI application hosting the REST bridge."""
@@ -308,15 +326,20 @@ def create_app(server_addr: str, dealer_port: int, sub_port: int) -> FastAPI:
 
     @app.get("/v1/rooms/{room_id}/global-variables")
     def get_global_vars(room_id: str) -> dict[str, object]:
-        bridge = manager.get(room_id)
-        live = bridge.manager.get_all_global_variables()
+        # Use peek to avoid spawning a bridge for read traffic.
+        bridge = manager.peek(room_id)
+        live: dict[str, str] = (
+            bridge.manager.get_all_global_variables() if bridge is not None else {}
+        )
         pending = global_store.get(room_id)
         return {"roomId": room_id, "vars": {**live, **pending}}
 
     @app.get("/v1/rooms/{room_id}/global-variables/{name}")
     def get_global_var(room_id: str, name: str) -> dict[str, object]:
-        bridge = manager.get(room_id)
-        live = bridge.manager.get_all_global_variables()
+        bridge = manager.peek(room_id)
+        live: dict[str, str] = (
+            bridge.manager.get_all_global_variables() if bridge is not None else {}
+        )
         pending = global_store.get(room_id)
         merged = {**live, **pending}
         if name not in merged:
@@ -325,19 +348,22 @@ def create_app(server_addr: str, dealer_port: int, sub_port: int) -> FastAPI:
 
     @app.get("/v1/rooms/{room_id}/devices/{device_id}/client-variables")
     def get_client_vars(room_id: str, device_id: str) -> dict[str, object]:
-        data = store.get(room_id, device_id)
-        return {"roomId": room_id, "deviceId": device_id, "vars": data}
+        pending = store.get(room_id, device_id)
+        live = _live_client_variables(manager, room_id, device_id)
+        return {"roomId": room_id, "deviceId": device_id, "vars": {**live, **pending}}
 
     @app.get("/v1/rooms/{room_id}/devices/{device_id}/client-variables/{name}")
     def get_client_var(room_id: str, device_id: str, name: str) -> dict[str, object]:
-        data = store.get(room_id, device_id)
-        if name not in data:
+        pending = store.get(room_id, device_id)
+        live = _live_client_variables(manager, room_id, device_id)
+        merged = {**live, **pending}
+        if name not in merged:
             raise HTTPException(status_code=404, detail=f"Variable '{name}' not found")
         return {
             "roomId": room_id,
             "deviceId": device_id,
             "name": name,
-            "value": data[name],
+            "value": merged[name],
         }
 
     @app.post("/v1/rooms/{room_id}/devices/{device_id}/client-variables")

--- a/STYLY-NetSync-Server/src/styly_netsync/rest_bridge.py
+++ b/STYLY-NetSync-Server/src/styly_netsync/rest_bridge.py
@@ -306,6 +306,40 @@ def create_app(server_addr: str, dealer_port: int, sub_port: int) -> FastAPI:
         """Health check endpoint."""
         return {"status": "ok"}
 
+    @app.get("/v1/rooms/{room_id}/global-variables")
+    def get_global_vars(room_id: str) -> dict[str, object]:
+        bridge = manager.get(room_id)
+        live = bridge.manager.get_all_global_variables()
+        pending = global_store.get(room_id)
+        return {"roomId": room_id, "vars": {**live, **pending}}
+
+    @app.get("/v1/rooms/{room_id}/global-variables/{name}")
+    def get_global_var(room_id: str, name: str) -> dict[str, object]:
+        bridge = manager.get(room_id)
+        live = bridge.manager.get_all_global_variables()
+        pending = global_store.get(room_id)
+        merged = {**live, **pending}
+        if name not in merged:
+            raise HTTPException(status_code=404, detail=f"Variable '{name}' not found")
+        return {"roomId": room_id, "name": name, "value": merged[name]}
+
+    @app.get("/v1/rooms/{room_id}/devices/{device_id}/client-variables")
+    def get_client_vars(room_id: str, device_id: str) -> dict[str, object]:
+        data = store.get(room_id, device_id)
+        return {"roomId": room_id, "deviceId": device_id, "vars": data}
+
+    @app.get("/v1/rooms/{room_id}/devices/{device_id}/client-variables/{name}")
+    def get_client_var(room_id: str, device_id: str, name: str) -> dict[str, object]:
+        data = store.get(room_id, device_id)
+        if name not in data:
+            raise HTTPException(status_code=404, detail=f"Variable '{name}' not found")
+        return {
+            "roomId": room_id,
+            "deviceId": device_id,
+            "name": name,
+            "value": data[name],
+        }
+
     @app.post("/v1/rooms/{room_id}/devices/{device_id}/client-variables")
     def upsert(room_id: str, device_id: str, body: UpsertBody) -> dict[str, object]:
         if not body.vars:

--- a/STYLY-NetSync-Server/tests/test_rest_bridge.py
+++ b/STYLY-NetSync-Server/tests/test_rest_bridge.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Generator
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -10,6 +11,7 @@ from fastapi.testclient import TestClient
 from styly_netsync.rest_bridge import (
     MAX_GLOBAL_VARS,
     GlobalVarStore,
+    PreseedStore,
     RoomBridge,
     create_app,
 )
@@ -270,3 +272,179 @@ class TestGlobalVariablesEndpoint:
                 assert rest_bridge.global_store.get("room1") == {}
         finally:
             rest_bridge.global_store = original_store
+
+
+# ---------------------------------------------------------------------------
+# GET global-variables endpoint tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def client_with_global_vars() -> TestClient:
+    """TestClient with BridgeManager mocked to expose live global variables."""
+    with patch("styly_netsync.rest_bridge.BridgeManager") as MockBridgeManager:
+        mock_mgr = MagicMock()
+        mock_mgr.get_all_global_variables.return_value = {"score": "42", "level": "3"}
+        mock_bridge = MagicMock()
+        mock_bridge.manager = mock_mgr
+        MockBridgeManager.return_value.get.return_value = mock_bridge
+
+        app = create_app("localhost", 5555, 5556)
+        return TestClient(app)
+
+
+class TestGetGlobalVariablesEndpoint:
+    def test_get_all_returns_200(self, client_with_global_vars: TestClient) -> None:
+        resp = client_with_global_vars.get("/v1/rooms/room1/global-variables")
+        assert resp.status_code == 200
+
+    def test_get_all_response_structure(
+        self, client_with_global_vars: TestClient
+    ) -> None:
+        resp = client_with_global_vars.get("/v1/rooms/room1/global-variables")
+        body = resp.json()
+        assert body["roomId"] == "room1"
+        assert "vars" in body
+        assert body["vars"]["score"] == "42"
+        assert body["vars"]["level"] == "3"
+
+    def test_get_all_empty_room_returns_empty_vars(self) -> None:
+        with patch("styly_netsync.rest_bridge.BridgeManager") as MockBM:
+            mock_mgr = MagicMock()
+            mock_mgr.get_all_global_variables.return_value = {}
+            mock_bridge = MagicMock()
+            mock_bridge.manager = mock_mgr
+            MockBM.return_value.get.return_value = mock_bridge
+
+            app = create_app("localhost", 5555, 5556)
+            tc = TestClient(app)
+            resp = tc.get("/v1/rooms/empty_room/global-variables")
+        assert resp.status_code == 200
+        assert resp.json()["vars"] == {}
+
+    def test_get_all_merges_pending_with_live(self) -> None:
+        """Pending (queued) vars should overlay live vars in the response."""
+        from styly_netsync import rest_bridge
+
+        original_store = rest_bridge.global_store
+        rest_bridge.global_store = GlobalVarStore()
+        rest_bridge.global_store.upsert("room1", {"score": "99", "pending": "yes"})
+        try:
+            with patch("styly_netsync.rest_bridge.BridgeManager") as MockBM:
+                mock_mgr = MagicMock()
+                mock_mgr.get_all_global_variables.return_value = {
+                    "score": "42",
+                    "live": "yes",
+                }
+                mock_bridge = MagicMock()
+                mock_bridge.manager = mock_mgr
+                MockBM.return_value.get.return_value = mock_bridge
+
+                app = create_app("localhost", 5555, 5556)
+                tc = TestClient(app)
+                resp = tc.get("/v1/rooms/room1/global-variables")
+        finally:
+            rest_bridge.global_store = original_store
+
+        body = resp.json()
+        assert body["vars"]["score"] == "99"  # pending overrides live
+        assert body["vars"]["live"] == "yes"  # live-only key preserved
+        assert body["vars"]["pending"] == "yes"  # pending-only key present
+
+    def test_get_single_returns_200(self, client_with_global_vars: TestClient) -> None:
+        resp = client_with_global_vars.get("/v1/rooms/room1/global-variables/score")
+        assert resp.status_code == 200
+
+    def test_get_single_response_structure(
+        self, client_with_global_vars: TestClient
+    ) -> None:
+        resp = client_with_global_vars.get("/v1/rooms/room1/global-variables/score")
+        body = resp.json()
+        assert body["roomId"] == "room1"
+        assert body["name"] == "score"
+        assert body["value"] == "42"
+
+    def test_get_single_not_found_returns_404(
+        self, client_with_global_vars: TestClient
+    ) -> None:
+        resp = client_with_global_vars.get("/v1/rooms/room1/global-variables/missing")
+        assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# GET client-variables endpoint tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def client_with_device_vars() -> Generator[TestClient, None, None]:
+    """TestClient with BridgeManager mocked (client vars come from PreseedStore)."""
+    from styly_netsync import rest_bridge
+
+    original_store = rest_bridge.store
+    new_store = PreseedStore()
+    new_store.upsert("room1", "device-abc", {"hp": "100", "name": "hero"})
+    rest_bridge.store = new_store
+
+    with patch("styly_netsync.rest_bridge.BridgeManager") as MockBM:
+        mock_bridge = MagicMock()
+        MockBM.return_value.get.return_value = mock_bridge
+        app = create_app("localhost", 5555, 5556)
+        yield TestClient(app)
+
+    rest_bridge.store = original_store
+
+
+class TestGetClientVariablesEndpoint:
+    def test_get_all_returns_200(self, client_with_device_vars: TestClient) -> None:
+        resp = client_with_device_vars.get(
+            "/v1/rooms/room1/devices/device-abc/client-variables"
+        )
+        assert resp.status_code == 200
+
+    def test_get_all_response_structure(
+        self, client_with_device_vars: TestClient
+    ) -> None:
+        resp = client_with_device_vars.get(
+            "/v1/rooms/room1/devices/device-abc/client-variables"
+        )
+        body = resp.json()
+        assert body["roomId"] == "room1"
+        assert body["deviceId"] == "device-abc"
+        assert body["vars"]["hp"] == "100"
+        assert body["vars"]["name"] == "hero"
+
+    def test_get_all_unknown_device_returns_empty_vars(
+        self, client_with_device_vars: TestClient
+    ) -> None:
+        resp = client_with_device_vars.get(
+            "/v1/rooms/room1/devices/unknown-device/client-variables"
+        )
+        assert resp.status_code == 200
+        assert resp.json()["vars"] == {}
+
+    def test_get_single_returns_200(self, client_with_device_vars: TestClient) -> None:
+        resp = client_with_device_vars.get(
+            "/v1/rooms/room1/devices/device-abc/client-variables/hp"
+        )
+        assert resp.status_code == 200
+
+    def test_get_single_response_structure(
+        self, client_with_device_vars: TestClient
+    ) -> None:
+        resp = client_with_device_vars.get(
+            "/v1/rooms/room1/devices/device-abc/client-variables/hp"
+        )
+        body = resp.json()
+        assert body["roomId"] == "room1"
+        assert body["deviceId"] == "device-abc"
+        assert body["name"] == "hp"
+        assert body["value"] == "100"
+
+    def test_get_single_not_found_returns_404(
+        self, client_with_device_vars: TestClient
+    ) -> None:
+        resp = client_with_device_vars.get(
+            "/v1/rooms/room1/devices/device-abc/client-variables/missing"
+        )
+        assert resp.status_code == 404

--- a/STYLY-NetSync-Server/tests/test_rest_bridge.py
+++ b/STYLY-NetSync-Server/tests/test_rest_bridge.py
@@ -287,7 +287,9 @@ def client_with_global_vars() -> TestClient:
         mock_mgr.get_all_global_variables.return_value = {"score": "42", "level": "3"}
         mock_bridge = MagicMock()
         mock_bridge.manager = mock_mgr
+        # GETs use peek; POSTs use get. Configure both so either path works.
         MockBridgeManager.return_value.get.return_value = mock_bridge
+        MockBridgeManager.return_value.peek.return_value = mock_bridge
 
         app = create_app("localhost", 5555, 5556)
         return TestClient(app)
@@ -315,12 +317,36 @@ class TestGetGlobalVariablesEndpoint:
             mock_bridge = MagicMock()
             mock_bridge.manager = mock_mgr
             MockBM.return_value.get.return_value = mock_bridge
+            MockBM.return_value.peek.return_value = mock_bridge
 
             app = create_app("localhost", 5555, 5556)
             tc = TestClient(app)
             resp = tc.get("/v1/rooms/empty_room/global-variables")
         assert resp.status_code == 200
         assert resp.json()["vars"] == {}
+
+    def test_get_all_no_bridge_returns_pending_only(self) -> None:
+        """GET must not spawn a bridge; pending-only response when none exists."""
+        from styly_netsync import rest_bridge
+
+        original_store = rest_bridge.global_store
+        rest_bridge.global_store = GlobalVarStore()
+        rest_bridge.global_store.upsert("cold_room", {"queued": "v"})
+        try:
+            with patch("styly_netsync.rest_bridge.BridgeManager") as MockBM:
+                MockBM.return_value.peek.return_value = None
+
+                app = create_app("localhost", 5555, 5556)
+                tc = TestClient(app)
+                resp = tc.get("/v1/rooms/cold_room/global-variables")
+
+                # peek() used, get() must not have been called for read traffic.
+                MockBM.return_value.get.assert_not_called()
+        finally:
+            rest_bridge.global_store = original_store
+
+        assert resp.status_code == 200
+        assert resp.json()["vars"] == {"queued": "v"}
 
     def test_get_all_merges_pending_with_live(self) -> None:
         """Pending (queued) vars should overlay live vars in the response."""
@@ -339,6 +365,7 @@ class TestGetGlobalVariablesEndpoint:
                 mock_bridge = MagicMock()
                 mock_bridge.manager = mock_mgr
                 MockBM.return_value.get.return_value = mock_bridge
+                MockBM.return_value.peek.return_value = mock_bridge
 
                 app = create_app("localhost", 5555, 5556)
                 tc = TestClient(app)
@@ -388,6 +415,8 @@ def client_with_device_vars() -> Generator[TestClient, None, None]:
 
     with patch("styly_netsync.rest_bridge.BridgeManager") as MockBM:
         mock_bridge = MagicMock()
+        # No live bridge — pending store is the only source in these cases.
+        MockBM.return_value.peek.return_value = None
         MockBM.return_value.get.return_value = mock_bridge
         app = create_app("localhost", 5555, 5556)
         yield TestClient(app)
@@ -448,3 +477,55 @@ class TestGetClientVariablesEndpoint:
             "/v1/rooms/room1/devices/device-abc/client-variables/missing"
         )
         assert resp.status_code == 404
+
+    def test_get_all_merges_live_with_pending(self) -> None:
+        """Live client vars from bridge should merge with pending; pending overlays."""
+        from styly_netsync import rest_bridge
+
+        original_store = rest_bridge.store
+        rest_bridge.store = PreseedStore()
+        rest_bridge.store.upsert("room1", "device-abc", {"hp": "50", "pending": "yes"})
+        try:
+            with patch("styly_netsync.rest_bridge.BridgeManager") as MockBM:
+                mock_mgr = MagicMock()
+                mock_mgr.get_all_client_variables.return_value = {
+                    "hp": "100",
+                    "live": "yes",
+                }
+                mock_bridge = MagicMock()
+                mock_bridge.manager = mock_mgr
+                mock_bridge.get_client_no.return_value = 7
+                MockBM.return_value.peek.return_value = mock_bridge
+
+                app = create_app("localhost", 5555, 5556)
+                tc = TestClient(app)
+                resp = tc.get("/v1/rooms/room1/devices/device-abc/client-variables")
+        finally:
+            rest_bridge.store = original_store
+
+        body = resp.json()
+        assert body["vars"]["hp"] == "50"  # pending overrides live
+        assert body["vars"]["live"] == "yes"  # live-only key preserved
+        assert body["vars"]["pending"] == "yes"  # pending-only key present
+        mock_mgr.get_all_client_variables.assert_called_once_with(7)
+
+    def test_get_all_no_bridge_does_not_spawn_bridge(self) -> None:
+        """GET must not spawn a bridge for unknown rooms."""
+        from styly_netsync import rest_bridge
+
+        original_store = rest_bridge.store
+        rest_bridge.store = PreseedStore()
+        try:
+            with patch("styly_netsync.rest_bridge.BridgeManager") as MockBM:
+                MockBM.return_value.peek.return_value = None
+
+                app = create_app("localhost", 5555, 5556)
+                tc = TestClient(app)
+                resp = tc.get("/v1/rooms/cold_room/devices/unknown/client-variables")
+
+                MockBM.return_value.get.assert_not_called()
+        finally:
+            rest_bridge.store = original_store
+
+        assert resp.status_code == 200
+        assert resp.json()["vars"] == {}


### PR DESCRIPTION
Adds four read-only endpoints to the REST bridge so external systems can inspect variable state without spinning up a ZeroMQ client:

- GET `/v1/rooms/{room_id}/global-variables`
- GET `/v1/rooms/{room_id}/global-variables/{name}`
- GET `/v1/rooms/{room_id}/devices/{device_id}/client-variables`
- GET `/v1/rooms/{room_id}/devices/{device_id}/client-variables/{name}`

Closes #418

Generated with [Claude Code](https://claude.ai/code)