### PR TITLE
[BREAKING CHANGE] feat(RoomBridge): add endpoints for retrieving global and client variables

### DIFF
--- a/STYLY-NetSync-Server/README.md
+++ b/STYLY-NetSync-Server/README.md
@@ -145,6 +145,30 @@ curl -sS -X POST "http://127.0.0.1:8800/v1/rooms/default_room/devices/00000000-0
 
 The response includes the current mapping status (`clientNo` or `null`) and whether each key was `"applied"` or `"queued"`.
 
+- Read endpoints:
+  - `GET /v1/rooms/{roomId}/devices/{deviceId}/client-variables` — returns all client variables for the device.
+
+    ```json
+    {"clientNo": 7, "variables": {"name": "Jack", "lang": "EN"}}
+    ```
+
+    If the device has no `clientNo` mapping yet, returns `{"clientNo": null, "variables": {}}`.
+
+  - `GET /v1/rooms/{roomId}/devices/{deviceId}/client-variables/{name}` — returns a single variable.
+
+    ```json
+    {"clientNo": 7, "value": "Jack"}
+    ```
+
+    Returns `404` if the device is unmapped or the variable is not set.
+
+- Example:
+
+  ```bash
+  curl -sS "http://127.0.0.1:8800/v1/rooms/default_room/devices/00000000-0000-0000-0000-000000000000/client-variables"
+  curl -sS "http://127.0.0.1:8800/v1/rooms/default_room/devices/00000000-0000-0000-0000-000000000000/client-variables/name"
+  ```
+
 ### Global variables
 
 - Endpoint: `POST /v1/rooms/{roomId}/global-variables`
@@ -175,3 +199,29 @@ curl -sS -X POST "http://127.0.0.1:8800/v1/rooms/default_room/global-variables" 
 ```
 
 The response includes the room ID and whether each key was `"applied"`, `"queued"`, or `"failed"`.
+
+- Read endpoints:
+  - `GET /v1/rooms/{roomId}/global-variables` — returns all global variables for the room.
+
+    ```json
+    {"variables": {"score": "42", "stage": "lobby"}}
+    ```
+
+  - `GET /v1/rooms/{roomId}/global-variables/{name}` — returns a single variable.
+
+    ```json
+    {"value": "42"}
+    ```
+
+    Returns `404` if the variable is not set.
+
+- Example:
+
+  ```bash
+  curl -sS "http://127.0.0.1:8800/v1/rooms/default_room/global-variables"
+  curl -sS "http://127.0.0.1:8800/v1/rooms/default_room/global-variables/score"
+  ```
+
+### Read consistency
+
+GET endpoints return a snapshot of the REST bridge's in-process cache, which is populated by PUB-SUB broadcasts from the server. The first request to a room lazily creates a bridge and may return an empty snapshot until the initial broadcasts arrive — retry after a short delay if needed.

--- a/STYLY-NetSync-Server/README.md
+++ b/STYLY-NetSync-Server/README.md
@@ -121,7 +121,7 @@ The server launches an embedded FastAPI application that exposes REST endpoints 
 
 ```json
 {
-  "vars": {
+  "variables": {
     "name": "Jack",
     "lang": "EN"
   }
@@ -140,7 +140,7 @@ The server launches an embedded FastAPI application that exposes REST endpoints 
 ```bash
 curl -sS -X POST "http://127.0.0.1:8800/v1/rooms/default_room/devices/00000000-0000-0000-0000-000000000000/client-variables" \
   -H "Content-Type: application/json" \
-  -d '{"vars":{"name":"Jack","lang":"EN"}}'
+  -d '{"variables":{"name":"Jack","lang":"EN"}}'
 ```
 
 The response includes the current mapping status (`clientNo` or `null`) and whether each key was `"applied"` or `"queued"`.
@@ -176,7 +176,7 @@ The response includes the current mapping status (`clientNo` or `null`) and whet
 
 ```json
 {
-  "vars": {
+  "variables": {
     "score": "42",
     "stage": "lobby"
   }
@@ -195,7 +195,7 @@ The response includes the current mapping status (`clientNo` or `null`) and whet
 ```bash
 curl -sS -X POST "http://127.0.0.1:8800/v1/rooms/default_room/global-variables" \
   -H "Content-Type: application/json" \
-  -d '{"vars":{"score":"42","stage":"lobby"}}'
+  -d '{"variables":{"score":"42","stage":"lobby"}}'
 ```
 
 The response includes the room ID and whether each key was `"applied"`, `"queued"`, or `"failed"`.

--- a/STYLY-NetSync-Server/src/styly_netsync/rest_bridge.py
+++ b/STYLY-NetSync-Server/src/styly_netsync/rest_bridge.py
@@ -187,6 +187,25 @@ class RoomBridge:
             logger.debug("Failed to lookup client number for %s: %s", device_id, exc)
             return None
 
+    def get_global_variables(self) -> dict[str, str]:
+        """Return a snapshot of cached global variables for this room."""
+        try:
+            return self._manager.get_all_global_variables()
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.debug("get_all_global_variables failed: %s", exc)
+            return {}
+
+    def get_client_variables(self, device_id: str) -> tuple[int | None, dict[str, str]]:
+        """Return (client_no, snapshot) for device; client_no is None if unmapped."""
+        client_no = self.get_client_no(device_id)
+        if client_no is None:
+            return None, {}
+        try:
+            return client_no, self._manager.get_all_client_variables(client_no)
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.debug("get_all_client_variables failed: %s", exc)
+            return client_no, {}
+
     def _apply_to_client(self, client_no: int, kvs: dict[str, str]) -> set[str]:
         """Apply stored variables to the target client via set_client_variable."""
         applied: set[str] = set()
@@ -349,6 +368,63 @@ def create_app(server_addr: str, dealer_port: int, sub_port: int) -> FastAPI:
         return {
             "roomId": room_id,
             "result": {name: {"state": state} for name, state in statuses.items()},
+        }
+
+    @app.get("/v1/rooms/{room_id}/global-variables")
+    def get_global_variables(room_id: str) -> dict[str, object]:
+        bridge = manager.get(room_id)
+        return {
+            "roomId": room_id,
+            "variables": bridge.get_global_variables(),
+        }
+
+    @app.get("/v1/rooms/{room_id}/global-variables/{name}")
+    def get_global_variable(room_id: str, name: VarName) -> dict[str, object]:
+        bridge = manager.get(room_id)
+        variables = bridge.get_global_variables()
+        if name not in variables:
+            raise HTTPException(
+                status_code=404, detail=f"Global variable '{name}' not found"
+            )
+        return {
+            "roomId": room_id,
+            "variableName": name,
+            "variableValue": variables[name],
+        }
+
+    @app.get("/v1/rooms/{room_id}/devices/{device_id}/client-variables")
+    def get_client_variables(room_id: str, device_id: str) -> dict[str, object]:
+        bridge = manager.get(room_id)
+        client_no, variables = bridge.get_client_variables(device_id)
+        return {
+            "roomId": room_id,
+            "deviceId": device_id,
+            "mapping": {"clientNo": client_no},
+            "variables": variables,
+        }
+
+    @app.get("/v1/rooms/{room_id}/devices/{device_id}/client-variables/{name}")
+    def get_client_variable(
+        room_id: str, device_id: str, name: VarName
+    ) -> dict[str, object]:
+        bridge = manager.get(room_id)
+        client_no, variables = bridge.get_client_variables(device_id)
+        if client_no is None:
+            raise HTTPException(
+                status_code=404,
+                detail=f"Device '{device_id}' has no client mapping",
+            )
+        if name not in variables:
+            raise HTTPException(
+                status_code=404,
+                detail=f"Client variable '{name}' not found for device '{device_id}'",
+            )
+        return {
+            "roomId": room_id,
+            "deviceId": device_id,
+            "mapping": {"clientNo": client_no},
+            "variableName": name,
+            "variableValue": variables[name],
         }
 
     return app

--- a/STYLY-NetSync-Server/src/styly_netsync/rest_bridge.py
+++ b/STYLY-NetSync-Server/src/styly_netsync/rest_bridge.py
@@ -29,7 +29,7 @@ VarValue = Annotated[str, StringConstraints(max_length=MAX_VALUE)]
 class UpsertBody(BaseModel):
     """Request body for client or global variable upsert."""
 
-    vars: dict[VarName, VarValue] = Field(default_factory=dict)
+    variables: dict[VarName, VarValue] = Field(default_factory=dict)
 
 
 class PreseedStore:
@@ -327,15 +327,15 @@ def create_app(server_addr: str, dealer_port: int, sub_port: int) -> FastAPI:
 
     @app.post("/v1/rooms/{room_id}/devices/{device_id}/client-variables")
     def upsert(room_id: str, device_id: str, body: UpsertBody) -> dict[str, object]:
-        if not body.vars:
-            raise HTTPException(status_code=400, detail="vars must not be empty")
+        if not body.variables:
+            raise HTTPException(status_code=400, detail="variables must not be empty")
         try:
-            store.upsert(room_id, device_id, body.vars)
+            store.upsert(room_id, device_id, body.variables)
         except ValueError as exc:
             raise HTTPException(status_code=409, detail=str(exc)) from exc
 
         bridge = manager.get(room_id)
-        statuses = bridge.apply_now_or_queue(device_id, body.vars)
+        statuses = bridge.apply_now_or_queue(device_id, body.variables)
         client_no = bridge.get_client_no(device_id)
 
         return {
@@ -347,15 +347,15 @@ def create_app(server_addr: str, dealer_port: int, sub_port: int) -> FastAPI:
 
     @app.post("/v1/rooms/{room_id}/global-variables")
     def upsert_global(room_id: str, body: UpsertBody) -> dict[str, object]:
-        if not body.vars:
-            raise HTTPException(status_code=400, detail="vars must not be empty")
+        if not body.variables:
+            raise HTTPException(status_code=400, detail="variables must not be empty")
 
         bridge = manager.get(room_id)
-        statuses = bridge.apply_global_now_or_queue(body.vars)
+        statuses = bridge.apply_global_now_or_queue(body.variables)
 
         # Only store variables that were queued (not applied immediately)
         queued = {
-            name: body.vars[name]
+            name: body.variables[name]
             for name, state in statuses.items()
             if state != "applied"
         }

--- a/STYLY-NetSync-Server/src/styly_netsync/rest_bridge.py
+++ b/STYLY-NetSync-Server/src/styly_netsync/rest_bridge.py
@@ -373,10 +373,7 @@ def create_app(server_addr: str, dealer_port: int, sub_port: int) -> FastAPI:
     @app.get("/v1/rooms/{room_id}/global-variables")
     def get_global_variables(room_id: str) -> dict[str, object]:
         bridge = manager.get(room_id)
-        return {
-            "roomId": room_id,
-            "variables": bridge.get_global_variables(),
-        }
+        return {"variables": bridge.get_global_variables()}
 
     @app.get("/v1/rooms/{room_id}/global-variables/{name}")
     def get_global_variable(room_id: str, name: VarName) -> dict[str, object]:
@@ -386,22 +383,13 @@ def create_app(server_addr: str, dealer_port: int, sub_port: int) -> FastAPI:
             raise HTTPException(
                 status_code=404, detail=f"Global variable '{name}' not found"
             )
-        return {
-            "roomId": room_id,
-            "variableName": name,
-            "variableValue": variables[name],
-        }
+        return {"value": variables[name]}
 
     @app.get("/v1/rooms/{room_id}/devices/{device_id}/client-variables")
     def get_client_variables(room_id: str, device_id: str) -> dict[str, object]:
         bridge = manager.get(room_id)
         client_no, variables = bridge.get_client_variables(device_id)
-        return {
-            "roomId": room_id,
-            "deviceId": device_id,
-            "mapping": {"clientNo": client_no},
-            "variables": variables,
-        }
+        return {"clientNo": client_no, "variables": variables}
 
     @app.get("/v1/rooms/{room_id}/devices/{device_id}/client-variables/{name}")
     def get_client_variable(
@@ -419,13 +407,7 @@ def create_app(server_addr: str, dealer_port: int, sub_port: int) -> FastAPI:
                 status_code=404,
                 detail=f"Client variable '{name}' not found for device '{device_id}'",
             )
-        return {
-            "roomId": room_id,
-            "deviceId": device_id,
-            "mapping": {"clientNo": client_no},
-            "variableName": name,
-            "variableValue": variables[name],
-        }
+        return {"clientNo": client_no, "value": variables[name]}
 
     return app
 

--- a/STYLY-NetSync-Server/tests/test_rest_bridge.py
+++ b/STYLY-NetSync-Server/tests/test_rest_bridge.py
@@ -177,14 +177,14 @@ class TestGlobalVariablesEndpoint:
     def test_post_returns_200(self, client: TestClient) -> None:
         resp = client.post(
             "/v1/rooms/room1/global-variables",
-            json={"vars": {"score": "42"}},
+            json={"variables": {"score": "42"}},
         )
         assert resp.status_code == 200
 
     def test_post_response_structure(self, client: TestClient) -> None:
         resp = client.post(
             "/v1/rooms/room1/global-variables",
-            json={"vars": {"score": "42"}},
+            json={"variables": {"score": "42"}},
         )
         body = resp.json()
         assert body["roomId"] == "room1"
@@ -194,7 +194,7 @@ class TestGlobalVariablesEndpoint:
     def test_post_empty_vars_returns_400(self, client: TestClient) -> None:
         resp = client.post(
             "/v1/rooms/room1/global-variables",
-            json={"vars": {}},
+            json={"variables": {}},
         )
         assert resp.status_code == 400
 
@@ -206,14 +206,14 @@ class TestGlobalVariablesEndpoint:
         long_name = "x" * 65
         resp = client.post(
             "/v1/rooms/room1/global-variables",
-            json={"vars": {long_name: "v"}},
+            json={"variables": {long_name: "v"}},
         )
         assert resp.status_code == 422
 
     def test_post_var_value_too_long_returns_422(self, client: TestClient) -> None:
         resp = client.post(
             "/v1/rooms/room1/global-variables",
-            json={"vars": {"k": "x" * 1025}},
+            json={"variables": {"k": "x" * 1025}},
         )
         assert resp.status_code == 422
 
@@ -240,7 +240,7 @@ class TestGlobalVariablesEndpoint:
                 tc = TestClient(app)
                 resp = tc.post(
                     "/v1/rooms/room_full/global-variables",
-                    json={"vars": {"overflow": "x"}},
+                    json={"variables": {"overflow": "x"}},
                 )
                 assert resp.status_code == 409
         finally:
@@ -263,7 +263,7 @@ class TestGlobalVariablesEndpoint:
                 tc = TestClient(app)
                 resp = tc.post(
                     "/v1/rooms/room1/global-variables",
-                    json={"vars": {"k": "v"}},
+                    json={"variables": {"k": "v"}},
                 )
                 assert resp.status_code == 200
                 # Store should remain empty since the var was applied

--- a/STYLY-NetSync-Server/tests/test_rest_bridge.py
+++ b/STYLY-NetSync-Server/tests/test_rest_bridge.py
@@ -336,10 +336,7 @@ class TestGlobalVariablesGetEndpoint:
         tc = _make_get_client(mock_bridge)
         resp = tc.get("/v1/rooms/room1/global-variables")
         assert resp.status_code == 200
-        assert resp.json() == {
-            "roomId": "room1",
-            "variables": {"score": "10", "level": "3"},
-        }
+        assert resp.json() == {"variables": {"score": "10", "level": "3"}}
 
     def test_get_all_returns_empty_when_cache_empty(self) -> None:
         mock_bridge = MagicMock()
@@ -347,7 +344,7 @@ class TestGlobalVariablesGetEndpoint:
         tc = _make_get_client(mock_bridge)
         resp = tc.get("/v1/rooms/room1/global-variables")
         assert resp.status_code == 200
-        assert resp.json() == {"roomId": "room1", "variables": {}}
+        assert resp.json() == {"variables": {}}
 
     def test_get_single_returns_value(self) -> None:
         mock_bridge = MagicMock()
@@ -355,11 +352,7 @@ class TestGlobalVariablesGetEndpoint:
         tc = _make_get_client(mock_bridge)
         resp = tc.get("/v1/rooms/room1/global-variables/score")
         assert resp.status_code == 200
-        assert resp.json() == {
-            "roomId": "room1",
-            "variableName": "score",
-            "variableValue": "10",
-        }
+        assert resp.json() == {"value": "10"}
 
     def test_get_single_missing_returns_404(self) -> None:
         mock_bridge = MagicMock()
@@ -384,12 +377,7 @@ class TestClientVariablesGetEndpoint:
         tc = _make_get_client(mock_bridge)
         resp = tc.get("/v1/rooms/room1/devices/device-x/client-variables")
         assert resp.status_code == 200
-        assert resp.json() == {
-            "roomId": "room1",
-            "deviceId": "device-x",
-            "mapping": {"clientNo": None},
-            "variables": {},
-        }
+        assert resp.json() == {"clientNo": None, "variables": {}}
 
     def test_get_all_mapped_device_returns_snapshot(self) -> None:
         mock_bridge = MagicMock()
@@ -397,12 +385,7 @@ class TestClientVariablesGetEndpoint:
         tc = _make_get_client(mock_bridge)
         resp = tc.get("/v1/rooms/room1/devices/device-x/client-variables")
         assert resp.status_code == 200
-        assert resp.json() == {
-            "roomId": "room1",
-            "deviceId": "device-x",
-            "mapping": {"clientNo": 7},
-            "variables": {"name": "alice"},
-        }
+        assert resp.json() == {"clientNo": 7, "variables": {"name": "alice"}}
 
     def test_get_single_returns_value(self) -> None:
         mock_bridge = MagicMock()
@@ -410,13 +393,7 @@ class TestClientVariablesGetEndpoint:
         tc = _make_get_client(mock_bridge)
         resp = tc.get("/v1/rooms/room1/devices/device-x/client-variables/name")
         assert resp.status_code == 200
-        assert resp.json() == {
-            "roomId": "room1",
-            "deviceId": "device-x",
-            "mapping": {"clientNo": 7},
-            "variableName": "name",
-            "variableValue": "alice",
-        }
+        assert resp.json() == {"clientNo": 7, "value": "alice"}
 
     def test_get_single_unknown_device_returns_404(self) -> None:
         mock_bridge = MagicMock()

--- a/STYLY-NetSync-Server/tests/test_rest_bridge.py
+++ b/STYLY-NetSync-Server/tests/test_rest_bridge.py
@@ -270,3 +270,172 @@ class TestGlobalVariablesEndpoint:
                 assert rest_bridge.global_store.get("room1") == {}
         finally:
             rest_bridge.global_store = original_store
+
+
+# ---------------------------------------------------------------------------
+# RoomBridge read method tests
+# ---------------------------------------------------------------------------
+
+
+class TestRoomBridgeReadMethods:
+    def test_get_global_variables_delegates_to_manager(self) -> None:
+        bridge = _make_bridge(client_no=1)
+        bridge._manager.get_all_global_variables.return_value = {"a": "1", "b": "2"}
+        result = bridge.get_global_variables()
+        assert result == {"a": "1", "b": "2"}
+        bridge._manager.get_all_global_variables.assert_called_once_with()
+
+    def test_get_global_variables_swallows_exceptions(self) -> None:
+        bridge = _make_bridge(client_no=1)
+        bridge._manager.get_all_global_variables.side_effect = RuntimeError("boom")
+        assert bridge.get_global_variables() == {}
+
+    def test_get_client_variables_unmapped_returns_none_and_empty(self) -> None:
+        bridge = _make_bridge(client_no=1)
+        bridge._manager.get_client_no.return_value = None
+        client_no, variables = bridge.get_client_variables("device-x")
+        assert client_no is None
+        assert variables == {}
+        bridge._manager.get_all_client_variables.assert_not_called()
+
+    def test_get_client_variables_mapped_returns_snapshot(self) -> None:
+        bridge = _make_bridge(client_no=1)
+        bridge._manager.get_client_no.return_value = 7
+        bridge._manager.get_all_client_variables.return_value = {"name": "alice"}
+        client_no, variables = bridge.get_client_variables("device-x")
+        assert client_no == 7
+        assert variables == {"name": "alice"}
+        bridge._manager.get_all_client_variables.assert_called_once_with(7)
+
+    def test_get_client_variables_swallows_exceptions(self) -> None:
+        bridge = _make_bridge(client_no=1)
+        bridge._manager.get_client_no.return_value = 7
+        bridge._manager.get_all_client_variables.side_effect = RuntimeError("boom")
+        client_no, variables = bridge.get_client_variables("device-x")
+        assert client_no == 7
+        assert variables == {}
+
+
+# ---------------------------------------------------------------------------
+# GET endpoint tests via TestClient
+# ---------------------------------------------------------------------------
+
+
+def _make_get_client(mock_bridge: MagicMock) -> TestClient:
+    """Build a TestClient whose BridgeManager always returns the given bridge."""
+    with patch("styly_netsync.rest_bridge.BridgeManager") as MockBM:
+        MockBM.return_value.get.return_value = mock_bridge
+        app = create_app("localhost", 5555, 5556)
+        return TestClient(app)
+
+
+class TestGlobalVariablesGetEndpoint:
+    def test_get_all_returns_snapshot(self) -> None:
+        mock_bridge = MagicMock()
+        mock_bridge.get_global_variables.return_value = {"score": "10", "level": "3"}
+        tc = _make_get_client(mock_bridge)
+        resp = tc.get("/v1/rooms/room1/global-variables")
+        assert resp.status_code == 200
+        assert resp.json() == {
+            "roomId": "room1",
+            "variables": {"score": "10", "level": "3"},
+        }
+
+    def test_get_all_returns_empty_when_cache_empty(self) -> None:
+        mock_bridge = MagicMock()
+        mock_bridge.get_global_variables.return_value = {}
+        tc = _make_get_client(mock_bridge)
+        resp = tc.get("/v1/rooms/room1/global-variables")
+        assert resp.status_code == 200
+        assert resp.json() == {"roomId": "room1", "variables": {}}
+
+    def test_get_single_returns_value(self) -> None:
+        mock_bridge = MagicMock()
+        mock_bridge.get_global_variables.return_value = {"score": "10"}
+        tc = _make_get_client(mock_bridge)
+        resp = tc.get("/v1/rooms/room1/global-variables/score")
+        assert resp.status_code == 200
+        assert resp.json() == {
+            "roomId": "room1",
+            "variableName": "score",
+            "variableValue": "10",
+        }
+
+    def test_get_single_missing_returns_404(self) -> None:
+        mock_bridge = MagicMock()
+        mock_bridge.get_global_variables.return_value = {}
+        tc = _make_get_client(mock_bridge)
+        resp = tc.get("/v1/rooms/room1/global-variables/missing")
+        assert resp.status_code == 404
+
+    def test_get_single_name_too_long_returns_422(self) -> None:
+        mock_bridge = MagicMock()
+        mock_bridge.get_global_variables.return_value = {}
+        tc = _make_get_client(mock_bridge)
+        long_name = "x" * 65
+        resp = tc.get(f"/v1/rooms/room1/global-variables/{long_name}")
+        assert resp.status_code == 422
+
+
+class TestClientVariablesGetEndpoint:
+    def test_get_all_unknown_device_returns_null_mapping_and_empty(self) -> None:
+        mock_bridge = MagicMock()
+        mock_bridge.get_client_variables.return_value = (None, {})
+        tc = _make_get_client(mock_bridge)
+        resp = tc.get("/v1/rooms/room1/devices/device-x/client-variables")
+        assert resp.status_code == 200
+        assert resp.json() == {
+            "roomId": "room1",
+            "deviceId": "device-x",
+            "mapping": {"clientNo": None},
+            "variables": {},
+        }
+
+    def test_get_all_mapped_device_returns_snapshot(self) -> None:
+        mock_bridge = MagicMock()
+        mock_bridge.get_client_variables.return_value = (7, {"name": "alice"})
+        tc = _make_get_client(mock_bridge)
+        resp = tc.get("/v1/rooms/room1/devices/device-x/client-variables")
+        assert resp.status_code == 200
+        assert resp.json() == {
+            "roomId": "room1",
+            "deviceId": "device-x",
+            "mapping": {"clientNo": 7},
+            "variables": {"name": "alice"},
+        }
+
+    def test_get_single_returns_value(self) -> None:
+        mock_bridge = MagicMock()
+        mock_bridge.get_client_variables.return_value = (7, {"name": "alice"})
+        tc = _make_get_client(mock_bridge)
+        resp = tc.get("/v1/rooms/room1/devices/device-x/client-variables/name")
+        assert resp.status_code == 200
+        assert resp.json() == {
+            "roomId": "room1",
+            "deviceId": "device-x",
+            "mapping": {"clientNo": 7},
+            "variableName": "name",
+            "variableValue": "alice",
+        }
+
+    def test_get_single_unknown_device_returns_404(self) -> None:
+        mock_bridge = MagicMock()
+        mock_bridge.get_client_variables.return_value = (None, {})
+        tc = _make_get_client(mock_bridge)
+        resp = tc.get("/v1/rooms/room1/devices/device-x/client-variables/name")
+        assert resp.status_code == 404
+
+    def test_get_single_missing_variable_returns_404(self) -> None:
+        mock_bridge = MagicMock()
+        mock_bridge.get_client_variables.return_value = (7, {})
+        tc = _make_get_client(mock_bridge)
+        resp = tc.get("/v1/rooms/room1/devices/device-x/client-variables/name")
+        assert resp.status_code == 404
+
+    def test_get_single_name_too_long_returns_422(self) -> None:
+        mock_bridge = MagicMock()
+        mock_bridge.get_client_variables.return_value = (7, {})
+        tc = _make_get_client(mock_bridge)
+        long_name = "x" * 65
+        resp = tc.get(f"/v1/rooms/room1/devices/device-x/client-variables/{long_name}")
+        assert resp.status_code == 422


### PR DESCRIPTION
This pull request adds new read endpoints for fetching global and client variables via the REST API, updates the documentation to describe these endpoints, and introduces comprehensive tests to ensure correct behavior and error handling. The changes improve the observability and reliability of variable state retrieval in the system.

**New API endpoints and documentation:**

* Added `GET /v1/rooms/{roomId}/global-variables` and `GET /v1/rooms/{roomId}/global-variables/{name}` endpoints to fetch all or a single global variable for a room. [[1]](diffhunk://#diff-9aa400e6ada8eb55522e09b127ee700657d36cb26d46dee3c3b5799a0367ac43R202-R227) [[2]](diffhunk://#diff-f9fcb7afc747fdd287e53429c6493c863087a53af37514301e72d0024b039f80R373-R411)
* Added `GET /v1/rooms/{roomId}/devices/{deviceId}/client-variables` and `GET /v1/rooms/{roomId}/devices/{deviceId}/client-variables/{name}` endpoints to fetch all or a single client variable for a device. [[1]](diffhunk://#diff-9aa400e6ada8eb55522e09b127ee700657d36cb26d46dee3c3b5799a0367ac43R148-R171) [[2]](diffhunk://#diff-f9fcb7afc747fdd287e53429c6493c863087a53af37514301e72d0024b039f80R373-R411)
* Updated `README.md` with documentation and usage examples for the new endpoints, as well as a note on read consistency and caching behavior. [[1]](diffhunk://#diff-9aa400e6ada8eb55522e09b127ee700657d36cb26d46dee3c3b5799a0367ac43R148-R171) [[2]](diffhunk://#diff-9aa400e6ada8eb55522e09b127ee700657d36cb26d46dee3c3b5799a0367ac43R202-R227)

**Backend logic:**

* Implemented `get_global_variables` and `get_client_variables` methods in `RoomBridge`, including defensive error handling to ensure robust API responses.

**Testing:**

* Added extensive unit and integration tests for the new read methods and endpoints, covering normal operation, error cases, and input validation.

Close https://github.com/styly-dev/STYLY-NetSync/issues/418