### PR TITLE
[BREAKING CHANGE Wired Protocol] Refactor/physical position

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,14 +36,15 @@ black src/ tests/ && ruff check src/ tests/ && mypy src/ && pytest --cov=src
 
 - **Server**: Multi-threaded Python (receive, periodic, discovery threads) with ZeroMQ DEALER-ROUTER + PUB-SUB and group-based room management
 - **Unity Client**: Manager pattern with internal components (connection, transform sync, RPC, network variables, avatars)
-- **Protocol**: Binary v3 with quantized positions and smallest-three quaternion compression
+- **Protocol**: Binary v4 with quantized positions and smallest-three quaternion compression
 - **Technology**: Python 3.11+ / pyzmq / FastAPI / msgpack (server), Unity 6 / NetMQ / Newtonsoft.Json (client)
 
 ## Protocol Rules
 
-- Transform protocol is `protocolVersion=3` only (`v2` removed)
+- Transform protocol is `protocolVersion=4` only (earlier versions removed)
 - Message IDs: `MSG_CLIENT_POSE=11`, `MSG_ROOM_POSE=12`
 - `Head` is absolute; `Right/Left/Virtual` are head-relative
+- `xrOriginDelta` is `(dx, dy, dz, dyaw)` quantized as 4×`int16` (`LOCO_POS_SCALE = 0.01m` for translation, `PHYSICAL_YAW_SCALE = 0.1°` for yaw); receivers reconstruct physical pose as `physical = invDeltaRot * (headPos − deltaPos)`
 - Position quantization: absolute `int24 @ 0.01m`, head-relative `int16 @ 0.005m`; out-of-range values clamped
 - Quaternion: 32-bit smallest-three compression
 - Server relays raw client pose body bytes (opaque relay, no decode)

--- a/README.md
+++ b/README.md
@@ -85,8 +85,9 @@ The uvx command automatically downloads the package, creates an isolated virtual
 ### Version compatibility note
 
 - Keep Unity package and server versions aligned.
-- Transform synchronization uses protocol version `3` and does not provide backward compatibility with older transform protocols.
-- Protocol v3 position quantization uses:
+- Transform synchronization uses protocol version `4` and does not provide backward compatibility with older transform protocols.
+- v4 vs. v3: `xrOriginDelta` adds a Y component (4×`int16`: `dx, dy, dz, dyaw`) so receivers can reconstruct vertical rig motion (e.g. elevators).
+- Protocol v4 position quantization uses:
   - Absolute scale (`Head`/`Physical`): signed `int24` at `0.01 m` per unit, per-axis range `[-83,886.08 m, 83,886.07 m]`.
   - Head-relative scale (`Right`/`Left`/`Virtual`): `0.005 m` per unit, per-axis range `[-163.84 m, 163.835 m]`.
 - This is an encoding range, not a hard world-size limit. Large virtual worlds are supported as long as each encoded value stays in range (out-of-range values are clamped).

--- a/STYLY-NetSync-Server/AGENTS.md
+++ b/STYLY-NetSync-Server/AGENTS.md
@@ -27,7 +27,7 @@ styly-netsync-simulator --clients 100 --server localhost --room default_room
 ## Architecture
 
 - **NetSyncServer** (`server.py`): Multi-threaded (receive, periodic, discovery threads)
-- **BinarySerializer** (`binary_serializer.py`): Protocol v3 transform serializer
+- **BinarySerializer** (`binary_serializer.py`): Protocol v4 transform serializer
 - **Python Client API** (`client.py`): `net_sync_manager` class for Python clients
 - **REST Bridge** (`rest_bridge.py`): FastAPI REST API for external integrations
 

--- a/STYLY-NetSync-Server/README.md
+++ b/STYLY-NetSync-Server/README.md
@@ -42,11 +42,12 @@ styly-netsync-simulator --server tcp://localhost --room my_room --clients 50
 
 ## Wire protocol compatibility
 
-- Current transform wire protocol is `protocolVersion = 3`.
-- Transform messages use `MSG_CLIENT_POSE` (11) and `MSG_ROOM_POSE` (12) with the compact V3 pose body.
-- Legacy transform protocol v2 and JSON transform fallback are not supported.
+- Current transform wire protocol is `protocolVersion = 4`.
+- Transform messages use `MSG_CLIENT_POSE` (11) and `MSG_ROOM_POSE` (12) with the compact V4 pose body.
+- v4 vs. v3: `xrOriginDelta` carries a Y component as a 4th `int16` (`dx, dy, dz, dyaw` = 8 bytes vs. v3's 6), so receivers can reconstruct the sender's rig-Y motion (e.g. elevators).
+- Legacy transform protocols (v2/v3) and JSON transform fallback are not supported.
 - Deploy Unity and Python updates together when changing transform protocol behavior.
-- Protocol v3 position quantization ranges:
+- Protocol v4 position quantization ranges:
   - Absolute (`physicalPos`, `headPosAbs`): signed `int24` at `0.01 m` per unit, per-axis range `[-83,886.08 m, 83,886.07 m]`.
   - Head-relative (`right/left/virtual`): signed `int16` at `0.005 m` per unit, per-axis range `[-163.84 m, 163.835 m]`.
 - These are encoding limits, not a hard world-size cap. Worlds can be larger, but encoded axis values are clamped if they exceed the representable range.
@@ -55,15 +56,15 @@ styly-netsync-simulator --server tcp://localhost --room my_room --clients 50
 
 The following options summarize trade-offs when expanding absolute-position range.
 
-Assumed baseline (`protocolVersion=3`):
-- Client pose body with `Physical+Head+Right+Left` valid and `virtualCount=0`: `49 bytes`
-- Room per-client entry (`clientNo + poseTime + clientBody`): `59 bytes`
+Assumed baseline (`protocolVersion=4`):
+- Client pose body with `Physical+Head+Right+Left` valid and `virtualCount=0`: `51 bytes`
+- Room per-client entry (`clientNo + poseTime + clientBody`): `61 bytes`
 
 | Option | Absolute Position Encoding | Per-axis Range | Client Body Delta | Room Per-client Delta |
 |---|---|---:|---:|---:|
-| A. Coarser scale (current integer width) | `int24 @ 0.02m` | `[-167,772.16m, 167,772.14m]` | `+0B` (`49 -> 49`) | `+0B` (`59 -> 59`) |
-| B. Cell + local | `cell(i16, 256m) + local(int24 @ 0.01m)` | `[-8,472,494.08m, 8,472,238.07m]` | `+6B` (`49 -> 55`, `+12.2%`) | `+6B` (`59 -> 65`, `+10.2%`) |
-| C. Cell + local (large cell) | `cell(i16, 1024m) + local(int24 @ 0.01m)` | `[-33,638,318.08m, 33,637,294.07m]` | `+6B` (`49 -> 55`, `+12.2%`) | `+6B` (`59 -> 65`, `+10.2%`) |
+| A. Coarser scale (current integer width) | `int24 @ 0.02m` | `[-167,772.16m, 167,772.14m]` | `+0B` (`51 -> 51`) | `+0B` (`61 -> 61`) |
+| B. Cell + local | `cell(i16, 256m) + local(int24 @ 0.01m)` | `[-8,472,494.08m, 8,472,238.07m]` | `+6B` (`51 -> 57`, `+11.8%`) | `+6B` (`61 -> 67`, `+9.8%`) |
+| C. Cell + local (large cell) | `cell(i16, 1024m) + local(int24 @ 0.01m)` | `[-33,638,318.08m, 33,637,294.07m]` | `+6B` (`51 -> 57`, `+11.8%`) | `+6B` (`61 -> 67`, `+9.8%`) |
 
 Notes:
 - Option B/C deltas assume both absolute transforms are present (`physicalPos` and `headPosAbs`).

--- a/STYLY-NetSync-Server/README.md
+++ b/STYLY-NetSync-Server/README.md
@@ -48,7 +48,8 @@ styly-netsync-simulator --server tcp://localhost --room my_room --clients 50
 - Legacy transform protocols (v2/v3) and JSON transform fallback are not supported.
 - Deploy Unity and Python updates together when changing transform protocol behavior.
 - Protocol v4 position quantization ranges:
-  - Absolute (`physicalPos`, `headPosAbs`): signed `int24` at `0.01 m` per unit, per-axis range `[-83,886.08 m, 83,886.07 m]`.
+  - Absolute (`headPosAbs` only): signed `int24` at `0.01 m` per unit, per-axis range `[-83,886.08 m, 83,886.07 m]`.
+  - XROrigin locomotion delta (`xrOriginDelta`, 4×`int16`: `dx, dy, dz, dyaw`): `0.01 m` per unit for translation, `0.1°` for yaw. Receivers reconstruct `physicalPos = invDeltaRot * (headPos − deltaPos)`; it is not on the wire as a separate absolute field.
   - Head-relative (`right/left/virtual`): signed `int16` at `0.005 m` per unit, per-axis range `[-163.84 m, 163.835 m]`.
 - These are encoding limits, not a hard world-size cap. Worlds can be larger, but encoded axis values are clamped if they exceed the representable range.
 
@@ -57,17 +58,17 @@ styly-netsync-simulator --server tcp://localhost --room my_room --clients 50
 The following options summarize trade-offs when expanding absolute-position range.
 
 Assumed baseline (`protocolVersion=4`):
-- Client pose body with `Physical+Head+Right+Left` valid and `virtualCount=0`: `51 bytes`
-- Room per-client entry (`clientNo + poseTime + clientBody`): `61 bytes`
+- Client pose body with `Physical+Head+Right+Left` valid and `virtualCount=0`: `46 bytes` (matches `test_client_body_size_with_full_pose_no_virtuals`).
+- Room per-client entry (`clientNo + poseTime + clientBody`): `56 bytes`.
 
 | Option | Absolute Position Encoding | Per-axis Range | Client Body Delta | Room Per-client Delta |
 |---|---|---:|---:|---:|
-| A. Coarser scale (current integer width) | `int24 @ 0.02m` | `[-167,772.16m, 167,772.14m]` | `+0B` (`51 -> 51`) | `+0B` (`61 -> 61`) |
-| B. Cell + local | `cell(i16, 256m) + local(int24 @ 0.01m)` | `[-8,472,494.08m, 8,472,238.07m]` | `+6B` (`51 -> 57`, `+11.8%`) | `+6B` (`61 -> 67`, `+9.8%`) |
-| C. Cell + local (large cell) | `cell(i16, 1024m) + local(int24 @ 0.01m)` | `[-33,638,318.08m, 33,637,294.07m]` | `+6B` (`51 -> 57`, `+11.8%`) | `+6B` (`61 -> 67`, `+9.8%`) |
+| A. Coarser scale (current integer width) | `int24 @ 0.02m` | `[-167,772.16m, 167,772.14m]` | `+0B` (`46 -> 46`) | `+0B` (`56 -> 56`) |
+| B. Cell + local | `cell(i16, 256m) + local(int24 @ 0.01m)` | `[-8,472,494.08m, 8,472,238.07m]` | `+6B` (`46 -> 52`, `+13.0%`) | `+6B` (`56 -> 62`, `+10.7%`) |
+| C. Cell + local (large cell) | `cell(i16, 1024m) + local(int24 @ 0.01m)` | `[-33,638,318.08m, 33,637,294.07m]` | `+6B` (`46 -> 52`, `+13.0%`) | `+6B` (`56 -> 62`, `+10.7%`) |
 
 Notes:
-- Option B/C deltas assume both absolute transforms are present (`physicalPos` and `headPosAbs`).
+- Only `headPosAbs` is on the wire as an absolute field; `physicalPos` is reconstructed from `headPosAbs + xrOriginDelta`. Option B/C deltas therefore apply to `headPosAbs` only.
 - Option B/C can reduce average overhead if `cell` is transmitted only when changed, but that requires extra state and flags in the wire format.
 
 ## Configuration

--- a/STYLY-NetSync-Server/src/styly_netsync/binary_serializer.py
+++ b/STYLY-NetSync-Server/src/styly_netsync/binary_serializer.py
@@ -32,7 +32,7 @@ MSG_OBJECT_OWNERSHIP_REJECTED = 17  # Server → Client (ROUTER): request reject
 _max_virtual_transforms = 50
 MAX_VIRTUAL_TRANSFORMS = _max_virtual_transforms  # Legacy alias for backward compat
 
-# Protocol v3 transform encoding constants
+# Protocol v4 transform encoding constants
 ABS_POS_SCALE = 0.01
 LOCO_POS_SCALE = 0.01
 REL_POS_SCALE = 0.005
@@ -372,7 +372,7 @@ def _create_transform_dict(
 
 
 def _serialize_client_body(buffer: bytearray, client: dict[str, Any]) -> None:
-    """Serialize a client body in protocol v3 compact format."""
+    """Serialize a client body in protocol v4 compact format."""
     pose_seq = int(client.get("poseSeq", 0)) & 0xFFFF
     head = client.get("head", {}) or {}
     right = client.get("rightHand", {}) or {}
@@ -852,7 +852,7 @@ def deserialize(data: bytes) -> tuple[int, dict[str, Any] | None, bytes]:
 
 
 def _deserialize_client_body(data: bytes, offset: int) -> tuple[dict[str, Any], int]:
-    """Deserialize protocol v3 compact pose body."""
+    """Deserialize protocol v4 compact pose body."""
     result: dict[str, Any] = {}
     result["poseSeq"] = struct.unpack("<H", data[offset : offset + 2])[0]
     offset += 2
@@ -1058,7 +1058,7 @@ def _deserialize_client_body(data: bytes, offset: int) -> tuple[dict[str, Any], 
 
 
 def _deserialize_client_transform(data: bytes, offset: int) -> dict[str, Any]:
-    """Deserialize client pose (v3) from binary data."""
+    """Deserialize client pose (v4) from binary data."""
     result: dict[str, Any] = {}
 
     protocol_version = data[offset]
@@ -1096,7 +1096,7 @@ def _deserialize_rpc_message(data: bytes, offset: int) -> dict[str, Any]:
 
 
 def _deserialize_room_transform(data: bytes, offset: int) -> dict[str, Any]:
-    """Deserialize room pose (v3) with client numbers only."""
+    """Deserialize room pose (v4) with client numbers only."""
     result: dict[str, Any] = {}
 
     protocol_version = data[offset]

--- a/STYLY-NetSync-Server/src/styly_netsync/binary_serializer.py
+++ b/STYLY-NetSync-Server/src/styly_netsync/binary_serializer.py
@@ -6,7 +6,7 @@ from typing import Any
 logger = logging.getLogger(__name__)
 
 # Message type identifiers
-PROTOCOL_VERSION = 3
+PROTOCOL_VERSION = 4
 MSG_CLIENT_TRANSFORM = 1
 MSG_ROOM_TRANSFORM = 2  # Legacy room transform with short IDs only
 MSG_RPC = 3  # Remote procedure call
@@ -380,6 +380,7 @@ def _serialize_client_body(buffer: bytearray, client: dict[str, Any]) -> None:
     virtuals = client.get("virtuals", []) or []
     has_xr_origin_delta = (
         "xrOriginDeltaX" in client
+        or "xrOriginDeltaY" in client
         or "xrOriginDeltaZ" in client
         or "xrOriginDeltaYaw" in client
     )
@@ -421,6 +422,7 @@ def _serialize_client_body(buffer: bytearray, client: dict[str, Any]) -> None:
     virtual_valid = head_valid and bool(flags & POSE_FLAG_VIRTUALS_VALID)
 
     xr_origin_delta_x = float(client.get("xrOriginDeltaX", 0.0))
+    xr_origin_delta_y = float(client.get("xrOriginDeltaY", 0.0))
     xr_origin_delta_z = float(client.get("xrOriginDeltaZ", 0.0))
     xr_origin_delta_yaw = float(client.get("xrOriginDeltaYaw", 0.0))
     head_pos = _transform_get_position(head)
@@ -430,8 +432,9 @@ def _serialize_client_body(buffer: bytearray, client: dict[str, Any]) -> None:
     if physical_valid:
         buffer.extend(
             struct.pack(
-                "<hhh",
+                "<hhhh",
                 _quantize_signed(xr_origin_delta_x, LOCO_POS_SCALE),
+                _quantize_signed(xr_origin_delta_y, LOCO_POS_SCALE),
                 _quantize_signed(xr_origin_delta_z, LOCO_POS_SCALE),
                 _quantize_signed(xr_origin_delta_yaw, PHYSICAL_YAW_SCALE),
             )
@@ -874,6 +877,7 @@ def _deserialize_client_body(data: bytes, offset: int) -> tuple[dict[str, Any], 
     head_pos = (0.0, 0.0, 0.0)
     head_rot = (0.0, 0.0, 0.0, 1.0)
     xr_origin_delta_x = 0.0
+    xr_origin_delta_y = 0.0
     xr_origin_delta_z = 0.0
     xr_origin_delta_yaw = 0.0
 
@@ -882,11 +886,12 @@ def _deserialize_client_body(data: bytes, offset: int) -> tuple[dict[str, Any], 
             raise ValueError(
                 "PhysicalValid set but XROrigin delta encoding flag is missing"
             )
-        dx_q, dz_q, dyaw_q = struct.unpack("<hhh", data[offset : offset + 6])
+        dx_q, dy_q, dz_q, dyaw_q = struct.unpack("<hhhh", data[offset : offset + 8])
         xr_origin_delta_x = _dequantize_signed(dx_q, LOCO_POS_SCALE)
+        xr_origin_delta_y = _dequantize_signed(dy_q, LOCO_POS_SCALE)
         xr_origin_delta_z = _dequantize_signed(dz_q, LOCO_POS_SCALE)
         xr_origin_delta_yaw = _dequantize_signed(dyaw_q, PHYSICAL_YAW_SCALE)
-        offset += 6
+        offset += 8
 
     if head_valid:
         hx_q, offset = _unpack_int24_le(data, offset)
@@ -913,7 +918,7 @@ def _deserialize_client_body(data: bytes, offset: int) -> tuple[dict[str, Any], 
 
     if physical_valid and head_valid:
         translated_x = head_pos[0] - xr_origin_delta_x
-        translated_y = head_pos[1]
+        translated_y = head_pos[1] - xr_origin_delta_y
         translated_z = head_pos[2] - xr_origin_delta_z
         physical_pos = _rotate_yaw_vector(
             translated_x,
@@ -1041,6 +1046,7 @@ def _deserialize_client_body(data: bytes, offset: int) -> tuple[dict[str, Any], 
             )
 
     result["xrOriginDeltaX"] = xr_origin_delta_x
+    result["xrOriginDeltaY"] = xr_origin_delta_y
     result["xrOriginDeltaZ"] = xr_origin_delta_z
     result["xrOriginDeltaYaw"] = xr_origin_delta_yaw
     result["physical"] = physical

--- a/STYLY-NetSync-Server/src/styly_netsync/server.py
+++ b/STYLY-NetSync-Server/src/styly_netsync/server.py
@@ -1056,7 +1056,7 @@ class NetSyncServer:
                         except UnicodeDecodeError as e:
                             logger.error(f"Failed to decode room ID: {e}")
                             continue
-                        # Protocol v3 binary-only handling (no JSON fallback)
+                        # Protocol v4 binary-only handling (no JSON fallback)
                         try:
                             msg_type, data, raw_payload = binary_serializer.deserialize(
                                 message_bytes
@@ -1127,7 +1127,7 @@ class NetSyncServer:
                                 logger.warning(f"Unknown binary msg_type: {msg_type}")
                         except Exception as e:
                             logger.warning(
-                                "Failed to decode protocol v3 message from room %s: %s",
+                                "Failed to decode protocol v4 message from room %s: %s",
                                 room_id,
                                 e,
                             )

--- a/STYLY-NetSync-Server/tests/test_binary_serializer.py
+++ b/STYLY-NetSync-Server/tests/test_binary_serializer.py
@@ -708,10 +708,12 @@ class TestTransformSerializationV4:
     def test_foot_invariant_head_minus_physical_equals_delta_y(self) -> None:
         """head.y - reconstructed physical.y must equal xrOriginDeltaY.
 
-        This is the invariant that BodyTransformSolver's remote-foot path relies on:
-        foot.y = head.y - PhysicalPosition.y collapses to xrOriginDeltaY, which is
-        the sender's rig-Y delta from startup. Pinning this avoids regressing the
-        elevator/foot-position fix.
+        Follows by construction from `_deserialize_client_body`
+        (`translated_y = head_pos[1] - xr_origin_delta_y`) and the yaw-only
+        rotation that preserves Y. Pinning this protocol-shape invariant means
+        any future change that decouples the two (e.g. dropping delta_y from
+        the reconstruction, or adding extra Y transforms) breaks loudly here
+        rather than silently on the wire.
         """
         rng = random.Random(20260425)
         for _ in range(200):

--- a/STYLY-NetSync-Server/tests/test_binary_serializer.py
+++ b/STYLY-NetSync-Server/tests/test_binary_serializer.py
@@ -220,6 +220,7 @@ def _build_random_client_pose(
     )
     head_rot = _random_unit_quaternion(rng)
     xr_origin_delta_x = rng.uniform(-20.0, 20.0)
+    xr_origin_delta_y = rng.uniform(-5.0, 5.0)
     xr_origin_delta_z = rng.uniform(-20.0, 20.0)
     xr_origin_delta_yaw = rng.uniform(-180.0, 180.0)
 
@@ -249,6 +250,7 @@ def _build_random_client_pose(
         "poseSeq": rng.randint(0, 65535),
         "flags": 0x3E,  # Physical + Head + Right + Left + Virtuals
         "xrOriginDeltaX": xr_origin_delta_x,
+        "xrOriginDeltaY": xr_origin_delta_y,
         "xrOriginDeltaZ": xr_origin_delta_z,
         "xrOriginDeltaYaw": xr_origin_delta_yaw,
         "head": _build_transform(head_pos, head_rot),
@@ -259,11 +261,15 @@ def _build_random_client_pose(
 
 
 def _reconstruct_physical_from_head_and_delta(
-    head: dict[str, float], delta_x: float, delta_z: float, delta_yaw: float
+    head: dict[str, float],
+    delta_x: float,
+    delta_y: float,
+    delta_z: float,
+    delta_yaw: float,
 ) -> tuple[tuple[float, float, float], tuple[float, float, float, float]]:
     """Reconstruct yaw-only physical pose from head pose and XROrigin delta."""
     tx = head["posX"] - delta_x
-    ty = head["posY"]
+    ty = head["posY"] - delta_y
     tz = head["posZ"] - delta_z
 
     inv_yaw_rad = math.radians(-delta_yaw)
@@ -282,12 +288,12 @@ def _reconstruct_physical_from_head_and_delta(
     return (px, ty, pz), physical_rot
 
 
-class TestTransformSerializationV3:
-    """Tests for protocol v3 transform compact serialization."""
+class TestTransformSerializationV4:
+    """Tests for protocol v4 transform compact serialization."""
 
-    def test_protocol_version_is_v3(self) -> None:
-        """Protocol version constant should be updated to v3."""
-        assert binary_serializer.PROTOCOL_VERSION == 3
+    def test_protocol_version_is_v4(self) -> None:
+        """Protocol version constant should be at v4."""
+        assert binary_serializer.PROTOCOL_VERSION == 4
 
     def test_client_roundtrip_without_flags_infers_valid_bits(self) -> None:
         """Serializer should infer valid bits when flags are omitted."""
@@ -295,6 +301,7 @@ class TestTransformSerializationV3:
             "deviceId": "infer-flags",
             "poseSeq": 77,
             "xrOriginDeltaX": 1.25,
+            "xrOriginDeltaY": 0.4,
             "xrOriginDeltaZ": -2.5,
             "xrOriginDeltaYaw": 33.3,
             "head": _build_transform(
@@ -331,6 +338,7 @@ class TestTransformSerializationV3:
         assert abs(decoded["head"]["posY"] - 1.6) <= 0.01
         assert abs(decoded["head"]["posZ"] + 2.3) <= 0.01
         assert abs(decoded["xrOriginDeltaX"] - 1.25) <= 0.01
+        assert abs(decoded["xrOriginDeltaY"] - 0.4) <= 0.01
         assert abs(decoded["xrOriginDeltaZ"] + 2.5) <= 0.01
         assert abs(decoded["xrOriginDeltaYaw"] - 33.3) <= 0.1
         assert len(decoded["virtuals"]) == 1
@@ -349,6 +357,7 @@ class TestTransformSerializationV3:
                 | binary_serializer.POSE_FLAG_VIRTUALS_VALID
             ),
             "xrOriginDeltaX": 9.0,
+            "xrOriginDeltaY": 9.0,
             "xrOriginDeltaZ": 9.0,
             "xrOriginDeltaYaw": 9.0,
             "head": _build_transform(
@@ -409,7 +418,7 @@ class TestTransformSerializationV3:
 
             assert msg_type == binary_serializer.MSG_CLIENT_POSE
             assert decoded is not None
-            assert decoded["protocolVersion"] == 3
+            assert decoded["protocolVersion"] == 4
             assert len(raw) > 0
 
             o_head = original["head"]
@@ -466,15 +475,18 @@ class TestTransformSerializationV3:
             assert left_err <= 1.0
 
             o_dx = original["xrOriginDeltaX"]
+            o_dy = original["xrOriginDeltaY"]
             o_dz = original["xrOriginDeltaZ"]
             o_dyaw = original["xrOriginDeltaYaw"]
             assert abs(o_dx - decoded["xrOriginDeltaX"]) <= 0.01
+            assert abs(o_dy - decoded["xrOriginDeltaY"]) <= 0.01
             assert abs(o_dz - decoded["xrOriginDeltaZ"]) <= 0.01
             assert abs(o_dyaw - decoded["xrOriginDeltaYaw"]) <= 0.1
 
             expected_pos, expected_rot = _reconstruct_physical_from_head_and_delta(
                 decoded["head"],
                 decoded["xrOriginDeltaX"],
+                decoded["xrOriginDeltaY"],
                 decoded["xrOriginDeltaZ"],
                 decoded["xrOriginDeltaYaw"],
             )
@@ -518,6 +530,7 @@ class TestTransformSerializationV3:
             "poseSeq": 10,
             "flags": 0x3E,
             "xrOriginDeltaX": 9999.0,
+            "xrOriginDeltaY": 9999.0,
             "xrOriginDeltaZ": -9999.0,
             "xrOriginDeltaYaw": 9999.0,
             "head": _build_transform(
@@ -551,6 +564,7 @@ class TestTransformSerializationV3:
         assert min_abs <= decoded["head"]["posY"] <= max_abs
         assert min_abs <= decoded["head"]["posZ"] <= max_abs
         assert min_loco <= decoded["xrOriginDeltaX"] <= max_loco
+        assert min_loco <= decoded["xrOriginDeltaY"] <= max_loco
         assert min_loco <= decoded["xrOriginDeltaZ"] <= max_loco
         assert (
             binary_serializer.INT16_MIN * binary_serializer.PHYSICAL_YAW_SCALE
@@ -574,6 +588,7 @@ class TestTransformSerializationV3:
             "poseSeq": 33,
             "flags": 0x3E,
             "xrOriginDeltaX": 250.12,
+            "xrOriginDeltaY": -42.5,
             "xrOriginDeltaZ": -125.34,
             "xrOriginDeltaYaw": 179.9,
             "head": _build_transform(
@@ -595,16 +610,18 @@ class TestTransformSerializationV3:
         assert abs(decoded["head"]["posY"] + 5000.9) <= 0.01
         assert abs(decoded["head"]["posZ"] - 4321.01) <= 0.01
         assert abs(decoded["xrOriginDeltaX"] - 250.12) <= 0.01
+        assert abs(decoded["xrOriginDeltaY"] + 42.5) <= 0.01
         assert abs(decoded["xrOriginDeltaZ"] + 125.34) <= 0.01
         assert abs(decoded["xrOriginDeltaYaw"] - 179.9) <= 0.1
 
     def test_client_body_size_with_full_pose_no_virtuals(self) -> None:
-        """Full pose body (no virtuals) should match current protocol v3 byte size."""
+        """Full pose body (no virtuals) should match current protocol v4 byte size."""
         payload = {
             "deviceId": "size-check",
             "poseSeq": 1,
             "flags": 0x1E,  # Physical + Head + Right + Left
             "xrOriginDeltaX": 1.0,
+            "xrOriginDeltaY": 0.5,
             "xrOriginDeltaZ": 2.0,
             "xrOriginDeltaYaw": 10.0,
             "head": _build_transform(
@@ -621,7 +638,8 @@ class TestTransformSerializationV3:
         _, _, raw = binary_serializer.deserialize(
             binary_serializer.serialize_client_transform(payload)
         )
-        assert len(raw) == 44
+        # v4 added a Y component to xrOriginDelta (+2 bytes vs. v3's 44).
+        assert len(raw) == 46
 
     def test_physical_requires_delta_encoding_flag(self) -> None:
         """PhysicalValid frames must carry the XROrigin-delta encoding bit."""
@@ -633,6 +651,7 @@ class TestTransformSerializationV3:
                 | binary_serializer.POSE_FLAG_HEAD_VALID
             ),
             "xrOriginDeltaX": 1.0,
+            "xrOriginDeltaY": 0.3,
             "xrOriginDeltaZ": -2.0,
             "xrOriginDeltaYaw": 30.0,
             "head": _build_transform(
@@ -672,7 +691,7 @@ class TestTransformSerializationV3:
 
         assert msg_type == binary_serializer.MSG_ROOM_POSE
         assert decoded is not None
-        assert decoded["protocolVersion"] == 3
+        assert decoded["protocolVersion"] == 4
         assert decoded["roomId"] == "room-v3"
         assert len(decoded["clients"]) == 2
 
@@ -685,6 +704,26 @@ class TestTransformSerializationV3:
             assert abs(src_head["posX"] - dst_head["posX"]) <= 0.01
             assert abs(src_head["posY"] - dst_head["posY"]) <= 0.01
             assert abs(src_head["posZ"] - dst_head["posZ"]) <= 0.01
+
+    def test_foot_invariant_head_minus_physical_equals_delta_y(self) -> None:
+        """head.y - reconstructed physical.y must equal xrOriginDeltaY.
+
+        This is the invariant that BodyTransformSolver's remote-foot path relies on:
+        foot.y = head.y - PhysicalPosition.y collapses to xrOriginDeltaY, which is
+        the sender's rig-Y delta from startup. Pinning this avoids regressing the
+        elevator/foot-position fix.
+        """
+        rng = random.Random(20260425)
+        for _ in range(200):
+            payload = _build_random_client_pose(rng, virtual_count=0)
+            _, decoded, _ = binary_serializer.deserialize(
+                binary_serializer.serialize_client_transform(payload)
+            )
+            assert decoded is not None
+            d_head = decoded["head"]
+            d_phys = decoded["physical"]
+            d_dy = decoded["xrOriginDeltaY"]
+            assert abs((d_head["posY"] - d_phys["posY"]) - d_dy) <= 1e-6
 
     def test_denormalized_quaternion_roundtrip(self) -> None:
         """Non-unit quaternions should be normalized and survive roundtrip."""

--- a/STYLY-NetSync-Server/tests/test_binary_serializer.py
+++ b/STYLY-NetSync-Server/tests/test_binary_serializer.py
@@ -682,7 +682,7 @@ class TestTransformSerializationV4:
         c2["poseTime"] = 223.456
 
         room_payload = {
-            "roomId": "room-v3",
+            "roomId": "room-v4",
             "broadcastTime": 999.123,
             "clients": [c1, c2],
         }
@@ -692,7 +692,7 @@ class TestTransformSerializationV4:
         assert msg_type == binary_serializer.MSG_ROOM_POSE
         assert decoded is not None
         assert decoded["protocolVersion"] == 4
-        assert decoded["roomId"] == "room-v3"
+        assert decoded["roomId"] == "room-v4"
         assert len(decoded["clients"]) == 2
 
         for src, dst in zip(room_payload["clients"], decoded["clients"], strict=True):

--- a/STYLY-NetSync-Unity/AGENTS.md
+++ b/STYLY-NetSync-Unity/AGENTS.md
@@ -31,7 +31,7 @@
 - **TransformSyncManager**: Transform sync with SendRate cap, only-on-change filtering, 1Hz idle heartbeat
 - **RPCManager**: Remote procedure calls with priority-based sending and targeted delivery
 - **NetworkVariableManager**: Synchronized key-value storage
-- **BinarySerializer**: Protocol v3 pose serialization/deserialization
+- **BinarySerializer**: Protocol v4 pose serialization/deserialization
 - **MessageProcessor**: Binary protocol message handling
 - **AvatarManager**: Player spawn/despawn management
 

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/BinarySerializer.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/BinarySerializer.cs
@@ -28,8 +28,7 @@ namespace Styly.NetSync
         public const byte MSG_OBJECT_OWNERSHIP_CHANGED = 16; // Server → Clients: ownership changed
         public const byte MSG_OBJECT_OWNERSHIP_REJECTED = 17; // Server → Client: request rejected
 
-        // Transform data type identifiers (deprecated - kept for reference)
-        // Protocol v3 pose encoding constants
+        // Protocol v4 pose encoding constants
         private const float ABS_POS_SCALE = 0.01f;
         private const float LOCO_POS_SCALE = 0.01f;
         private const float REL_POS_SCALE = 0.005f;

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/BinarySerializer.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/BinarySerializer.cs
@@ -7,7 +7,7 @@ namespace Styly.NetSync
 {
     internal static class BinarySerializer
     {
-        public const byte PROTOCOL_VERSION = 3;
+        public const byte PROTOCOL_VERSION = 4;
 
         // Message type identifiers
         public const byte MSG_CLIENT_TRANSFORM = 1;
@@ -360,6 +360,7 @@ namespace Styly.NetSync
             if (physicalValid)
             {
                 HashShort(ref hash, QuantizeSigned(xrOriginDelta.x, LOCO_POS_SCALE));
+                HashShort(ref hash, QuantizeSigned(xrOriginDelta.y, LOCO_POS_SCALE));
                 HashShort(ref hash, QuantizeSigned(xrOriginDelta.z, LOCO_POS_SCALE));
                 HashShort(ref hash, QuantizeSigned(xrOriginDeltaYaw, PHYSICAL_YAW_SCALE));
             }
@@ -471,6 +472,7 @@ namespace Styly.NetSync
             if (physicalValid)
             {
                 writer.Write(QuantizeSigned(xrOriginDelta.x, LOCO_POS_SCALE));
+                writer.Write(QuantizeSigned(xrOriginDelta.y, LOCO_POS_SCALE));
                 writer.Write(QuantizeSigned(xrOriginDelta.z, LOCO_POS_SCALE));
                 writer.Write(QuantizeSigned(xrOriginDeltaYaw, PHYSICAL_YAW_SCALE));
             }
@@ -696,6 +698,7 @@ namespace Styly.NetSync
                 bool virtualValid = headValid && ((client.flags & PoseFlags.VirtualsValid) != 0);
 
                 short dxQ = 0;
+                short dyQ = 0;
                 short dzQ = 0;
                 short dyawQ = 0;
                 client.xrOriginDeltaPosition = Vector3.zero;
@@ -708,9 +711,10 @@ namespace Styly.NetSync
                     }
 
                     dxQ = reader.ReadInt16();
+                    dyQ = reader.ReadInt16();
                     dzQ = reader.ReadInt16();
                     dyawQ = reader.ReadInt16();
-                    client.xrOriginDeltaPosition = new Vector3(dxQ * LOCO_POS_SCALE, 0f, dzQ * LOCO_POS_SCALE);
+                    client.xrOriginDeltaPosition = new Vector3(dxQ * LOCO_POS_SCALE, dyQ * LOCO_POS_SCALE, dzQ * LOCO_POS_SCALE);
                     client.xrOriginDeltaYaw = dyawQ * PHYSICAL_YAW_SCALE;
                 }
 

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/NetSyncTransformApplier.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/NetSyncTransformApplier.cs
@@ -50,6 +50,15 @@ namespace Styly.NetSync
         private bool _hasAnySnapshot;
         public bool HasAnySnapshot => _hasAnySnapshot;
 
+        // Most recent smoothed physical pose produced by Tick. The physical channel
+        // has no Transform binding (NetSyncAvatar manages PhysicalPosition itself),
+        // so consumers read the smoothed result through these properties to keep
+        // PhysicalPosition time-aligned with the head/hand channels.
+        private PoseSampleData _lastPhysicalSample;
+        private bool _hasPhysicalSample;
+        public PoseSampleData LastPhysicalSample => _lastPhysicalSample;
+        public bool HasPhysicalSample => _hasPhysicalSample;
+
         public void InitializeForAvatar(
             Transform physical,
             Transform head,
@@ -138,6 +147,7 @@ namespace Styly.NetSync
             else
             {
                 _physical.Clear();
+                _hasPhysicalSample = false;
             }
 
             if ((data.flags & PoseFlags.HeadValid) != 0 && data.head != null)
@@ -210,6 +220,7 @@ namespace Styly.NetSync
                 _virtuals[i].Clear();
             }
             _hasAnySnapshot = false;
+            _hasPhysicalSample = false;
         }
 
         public void Tick(float deltaTime, double localNow)
@@ -239,7 +250,9 @@ namespace Styly.NetSync
 
             if (_physical != null)
             {
-                ApplyBinding(_physicalBinding, _physical.Tick(renderServerTime, deltaTime));
+                _lastPhysicalSample = _physical.Tick(renderServerTime, deltaTime);
+                _hasPhysicalSample = true;
+                ApplyBinding(_physicalBinding, _lastPhysicalSample);
             }
             if (_head != null)
             {

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/TransformSyncManager.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/TransformSyncManager.cs
@@ -166,7 +166,7 @@ namespace Styly.NetSync
 
             if (physicalValid)
             {
-                bodySize += (2 * sizeof(short)) + sizeof(short); // dx i16 + dz i16 + dyaw i16
+                bodySize += 4 * sizeof(short); // dx i16 + dy i16 + dz i16 + dyaw i16
             }
 
             if (headValid)

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/NetSyncAvatar.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/NetSyncAvatar.cs
@@ -194,12 +194,22 @@ namespace Styly.NetSync
                 _transformApplier.Tick(Time.deltaTime, NetSyncClock.NowSeconds());
             }
 
-            // Reflect physical transform (local pose) only for the local avatar.
-            // Remote avatars keep the last received physical values from SetTransformData.
             if (IsLocalAvatar && _head != null)
             {
+                // Local avatar: physical pose follows the head's parent-local pose plus
+                // the cached startup XR-rig offset. No smoothing needed (driven by tracker).
                 PhysicalPosition = _head.localPosition + _netSyncManager._physicalOffsetPosition;
                 PhysicalRotation = _head.localRotation * Quaternion.Euler(_netSyncManager._physicalOffsetRotation);
+            }
+            else if (!IsLocalAvatar && _transformApplier.HasPhysicalSample)
+            {
+                // Remote avatar: read the smoothed physical sample produced by Tick so
+                // PhysicalPosition is time-aligned with the head channel. Reading the raw
+                // value set in SetTransformData would lag head's smoothing and cause the
+                // `head.y - PhysicalPosition.y` ground-center derivation to wobble.
+                var sample = _transformApplier.LastPhysicalSample;
+                PhysicalPosition = sample.Position;
+                PhysicalRotation = sample.Rotation;
             }
         }
 

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/NetSyncManager.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/NetSyncManager.cs
@@ -1300,27 +1300,26 @@ namespace Styly.NetSync
         #endregion ------------------------------------------------------------------------
 
         /// <summary>
-        /// Compute XROrigin locomotion delta in SE(2) form relative to startup origin.
-        /// t = p1 - R(dyaw) * p0, where p0/p1 use XZ plane only.
+        /// Compute XROrigin locomotion delta relative to startup origin.
+        /// t = p1 - R(dyaw) * p0, where p0/p1 are full 3D positions and R(dyaw) is yaw-only
+        /// (so the Y component reduces to t.y = p1.y - p0.y).
         /// </summary>
-        internal void ComputeXrOriginDelta(out Vector3 tXZ, out float dyawDeg)
+        internal void ComputeXrOriginDelta(out Vector3 t, out float dyawDeg)
         {
-            var p0 = new Vector3(_physicalOffsetPosition.x, 0f, _physicalOffsetPosition.z);
+            var p0 = _physicalOffsetPosition;
             var yaw0 = _physicalOffsetRotation.y;
 
             var p1 = p0;
             var yaw1 = yaw0;
             if (_XrOriginTransform != null)
             {
-                var current = _XrOriginTransform.position;
-                p1 = new Vector3(current.x, 0f, current.z);
+                p1 = _XrOriginTransform.position;
                 yaw1 = _XrOriginTransform.eulerAngles.y;
             }
 
             dyawDeg = Mathf.DeltaAngle(yaw0, yaw1);
             var deltaRotation = Quaternion.Euler(0f, dyawDeg, 0f);
-            tXZ = p1 - (deltaRotation * p0);
-            tXZ.y = 0f;
+            t = p1 - (deltaRotation * p0);
         }
 
         /// <summary>
@@ -1362,10 +1361,13 @@ namespace Styly.NetSync
                 var localYaw = Quaternion.Euler(0f, rotation.eulerAngles.y, 0f);
                 worldYaw = parent.rotation * localYaw;
 
-                // Apply local locomotion delta with the same SE(2) definition used on wire.
+                // Apply local locomotion delta. Human Presence intentionally consumes only
+                // XZ + yaw of the locomotion delta (the original SE(2) definition); vertical
+                // rig motion is left to the parent transform hierarchy.
                 ComputeXrOriginDelta(out var localDeltaPos, out var localDeltaYaw);
                 var localDeltaRot = Quaternion.Euler(0f, localDeltaYaw, 0f);
-                worldPos = localDeltaRot * worldPos + localDeltaPos;
+                var localDeltaPosXZ = new Vector3(localDeltaPos.x, 0f, localDeltaPos.z);
+                worldPos = localDeltaRot * worldPos + localDeltaPosXZ;
                 worldYaw = localDeltaRot * worldYaw;
             }
             else


### PR DESCRIPTION
This pull request upgrades the transform protocol from version 3 to version 4 throughout the codebase and documentation. The main change is the addition of a Y component to the `xrOriginDelta` field, allowing for vertical rig motion (e.g., elevators) to be encoded and reconstructed. This update impacts serialization/deserialization logic, test cases, and all relevant documentation, and removes support for older protocol versions.

**Protocol and Serialization Updates:**

* Upgraded the protocol version constant to `4` in `binary_serializer.py`, and updated all serialization and deserialization logic to handle the new 4-component `xrOriginDelta` (`dx, dy, dz, dyaw`), including quantization, packing, and unpacking. [[1]](diffhunk://#diff-b30d4e820ed3d5ddbeaacf82ed2f5154c6bc7e8067e81e103dccfe098d8d36f7L9-R9) [[2]](diffhunk://#diff-b30d4e820ed3d5ddbeaacf82ed2f5154c6bc7e8067e81e103dccfe098d8d36f7L35-R35) [[3]](diffhunk://#diff-b30d4e820ed3d5ddbeaacf82ed2f5154c6bc7e8067e81e103dccfe098d8d36f7L375-R383) [[4]](diffhunk://#diff-b30d4e820ed3d5ddbeaacf82ed2f5154c6bc7e8067e81e103dccfe098d8d36f7R425) [[5]](diffhunk://#diff-b30d4e820ed3d5ddbeaacf82ed2f5154c6bc7e8067e81e103dccfe098d8d36f7L433-R437) [[6]](diffhunk://#diff-b30d4e820ed3d5ddbeaacf82ed2f5154c6bc7e8067e81e103dccfe098d8d36f7L852-R855) [[7]](diffhunk://#diff-b30d4e820ed3d5ddbeaacf82ed2f5154c6bc7e8067e81e103dccfe098d8d36f7R880) [[8]](diffhunk://#diff-b30d4e820ed3d5ddbeaacf82ed2f5154c6bc7e8067e81e103dccfe098d8d36f7L885-R894) [[9]](diffhunk://#diff-b30d4e820ed3d5ddbeaacf82ed2f5154c6bc7e8067e81e103dccfe098d8d36f7L916-R921) [[10]](diffhunk://#diff-b30d4e820ed3d5ddbeaacf82ed2f5154c6bc7e8067e81e103dccfe098d8d36f7R1049) [[11]](diffhunk://#diff-b30d4e820ed3d5ddbeaacf82ed2f5154c6bc7e8067e81e103dccfe098d8d36f7L1055-R1061) [[12]](diffhunk://#diff-b30d4e820ed3d5ddbeaacf82ed2f5154c6bc7e8067e81e103dccfe098d8d36f7L1093-R1099)

**Documentation and Architecture:**

* Updated all documentation (`README.md`, `AGENTS.md`, and server docs) to describe protocol v4, its new `xrOriginDelta` Y component, and the new binary format. Clarified that legacy protocols (v2/v3) and JSON fallback are no longer supported. [[1]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9L39-R47) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L88-R90) [[3]](diffhunk://#diff-1f215b7326bc7d4ca3df68ed60d5ee0ad93c6bc534133d910acaf15cc80086eeL30-R30) [[4]](diffhunk://#diff-9aa400e6ada8eb55522e09b127ee700657d36cb26d46dee3c3b5799a0367ac43L45-R50) [[5]](diffhunk://#diff-9aa400e6ada8eb55522e09b127ee700657d36cb26d46dee3c3b5799a0367ac43L58-R67)

**Server Logic:**

* Updated server-side comments and error messages to refer to protocol v4 instead of v3, ensuring clarity in logs and error handling. [[1]](diffhunk://#diff-e88eea98ef9a164151fc1fdd4bf5ed9a273abbfd449f658a8d82ff1b636df45dL1059-R1059) [[2]](diffhunk://#diff-e88eea98ef9a164151fc1fdd4bf5ed9a273abbfd449f658a8d82ff1b636df45dL1130-R1130)

**Testing:**

* Updated and renamed tests to target protocol v4, including adding the Y component to test payloads and roundtrip checks, and updating expected protocol version values. [[1]](diffhunk://#diff-6e67093152a24317401fc92b2b76e20fdb4e3a01a9ea2a574d42d97b80679a99R223) [[2]](diffhunk://#diff-6e67093152a24317401fc92b2b76e20fdb4e3a01a9ea2a574d42d97b80679a99R253) [[3]](diffhunk://#diff-6e67093152a24317401fc92b2b76e20fdb4e3a01a9ea2a574d42d97b80679a99L262-R272) [[4]](diffhunk://#diff-6e67093152a24317401fc92b2b76e20fdb4e3a01a9ea2a574d42d97b80679a99L285-R304) [[5]](diffhunk://#diff-6e67093152a24317401fc92b2b76e20fdb4e3a01a9ea2a574d42d97b80679a99R341) [[6]](diffhunk://#diff-6e67093152a24317401fc92b2b76e20fdb4e3a01a9ea2a574d42d97b80679a99R360) [[7]](diffhunk://#diff-6e67093152a24317401fc92b2b76e20fdb4e3a01a9ea2a574d42d97b80679a99L412-R421)

These changes ensure that both the server and clients are aligned on the new protocol, support vertical rig motion, and maintain strict version compatibility.
