### PR TITLE
refactor: keep server start script for 24h via startup sweep

### DIFF
--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Editor/StartPythonServer.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Editor/StartPythonServer.cs
@@ -229,7 +229,7 @@ namespace Styly.NetSync.Editor
         }
 
         // Temp scripts are kept on disk so the user can stop and restart the server from
-        // the same terminal. Sweep ones older than this on Editor startup.
+        // the same terminal. Sweep ones older than this on editor load / domain reload.
         private const double TempScriptMaxAgeHours = 24.0;
         private const string TempScriptPrefix = "start_styly_netsync_server_";
 

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Editor/StartPythonServer.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Editor/StartPythonServer.cs
@@ -228,23 +228,44 @@ namespace Styly.NetSync.Editor
             return projectRoot;
         }
 
-        private static void ScheduleTempFileCleanup(string filePath, int delayMs = 5000)
+        // Temp scripts are kept on disk so the user can stop and restart the server from
+        // the same terminal. Sweep ones older than this on Editor startup.
+        private const double TempScriptMaxAgeHours = 24.0;
+        private const string TempScriptPrefix = "start_styly_netsync_server_";
+
+        [InitializeOnLoadMethod]
+        private static void SweepStaleTempScripts()
         {
-            System.Threading.Tasks.Task.Delay(delayMs).ContinueWith(_ =>
+            try
             {
-                try
+                string tempPath = Path.GetTempPath();
+                if (!Directory.Exists(tempPath)) return;
+
+                DateTime cutoff = DateTime.UtcNow.AddHours(-TempScriptMaxAgeHours);
+                string[] patterns = { TempScriptPrefix + "*.sh", TempScriptPrefix + "*.ps1" };
+
+                foreach (string pattern in patterns)
                 {
-                    if (File.Exists(filePath))
+                    foreach (string file in Directory.GetFiles(tempPath, pattern))
                     {
-                        File.Delete(filePath);
-                        Debug.Log($"Cleaned up temporary script: {filePath}");
+                        try
+                        {
+                            if (File.GetLastWriteTimeUtc(file) < cutoff)
+                            {
+                                File.Delete(file);
+                            }
+                        }
+                        catch
+                        {
+                            // Ignore individual failures (file in use, permissions, etc.)
+                        }
                     }
                 }
-                catch (Exception e)
-                {
-                    Debug.LogWarning($"Failed to clean up temporary script: {e.Message}");
-                }
-            });
+            }
+            catch (Exception e)
+            {
+                Debug.LogWarning($"Failed to sweep stale NetSync server scripts: {e.Message}");
+            }
         }
 
         /// <summary>
@@ -383,7 +404,7 @@ read -p 'Press any key to exit...'
 ";
 
             // Create a unique temp file with .sh extension
-            string tempScriptPath = Path.Combine(Path.GetTempPath(), $"start_styly_netsync_server_{Guid.NewGuid():N}.sh");
+            string tempScriptPath = Path.Combine(Path.GetTempPath(), $"{TempScriptPrefix}{Guid.NewGuid():N}.sh");
             File.WriteAllText(tempScriptPath, shellScript);
 
             // Make script executable
@@ -417,9 +438,6 @@ read -p 'Press any key to exit...'
             {
                 RunInTerminal($"/bin/bash {QuoteForShell(tempScriptPath)}");
                 Debug.Log("STYLY NetSync: Starting Python server in Terminal...");
-
-                // Schedule cleanup of temporary script file
-                ScheduleTempFileCleanup(tempScriptPath);
             }
             catch (Exception e)
             {
@@ -521,8 +539,9 @@ Write-Host 'Server stopped.' -ForegroundColor Yellow
 Read-Host 'Press Enter to exit'
 ";
 
-            // Create a unique temp file and change its extension to .ps1
-            string tempScriptPath = Path.ChangeExtension(Path.GetTempFileName(), ".ps1");
+            // Create a unique temp file with .ps1 extension. The shared prefix lets the
+            // startup sweep recognize and clean up stale scripts from previous sessions.
+            string tempScriptPath = Path.Combine(Path.GetTempPath(), $"{TempScriptPrefix}{Guid.NewGuid():N}.ps1");
             File.WriteAllText(tempScriptPath, powershellScript);
 
             // Get the project root directory
@@ -553,9 +572,6 @@ Read-Host 'Press Enter to exit'
             {
                 process.Start();
                 Debug.Log("STYLY NetSync: Starting Python server in PowerShell...");
-
-                // Schedule cleanup of temporary script file
-                ScheduleTempFileCleanup(tempScriptPath);
             }
             catch (Exception e)
             {
@@ -685,7 +701,7 @@ read -p 'Press any key to exit...'
 ";
 
             // Create a unique temp file with .sh extension
-            string tempScriptPath = Path.Combine(Path.GetTempPath(), $"start_styly_netsync_server_{Guid.NewGuid():N}.sh");
+            string tempScriptPath = Path.Combine(Path.GetTempPath(), $"{TempScriptPrefix}{Guid.NewGuid():N}.sh");
             File.WriteAllText(tempScriptPath, shellScript);
 
             // Make script executable
@@ -742,9 +758,6 @@ read -p 'Press any key to exit...'
             {
                 process.Start();
                 Debug.Log($"STYLY NetSync: Starting Python server in {availableTerminal}...");
-
-                // Schedule cleanup of temporary script file
-                ScheduleTempFileCleanup(tempScriptPath);
             }
             catch (Exception e)
             {


### PR DESCRIPTION
## Summary
- Replace the per-launch `Task.Delay(5000)` cleanup with an `[InitializeOnLoadMethod]` sweep that runs at Editor startup, so the temp script written by **Tools → STYLY → NetSync → Start Server** stays on disk long enough for the user to stop the server (Ctrl+C) and re-run it from the same terminal.
- Files matching `start_styly_netsync_server_*.{sh,ps1}` in the OS temp dir whose `LastWriteTimeUtc` is older than 24h are removed; individual delete failures (file in use, permissions) are swallowed.
- Align the Windows path's filename to the same `start_styly_netsync_server_<guid>.ps1` pattern so the sweep can match it (also incidentally avoids the previous orphan `.tmp` from `Path.GetTempFileName()`).

## Test plan
- [x] Verified manually: server starts, the temp script persists past 5s, can Ctrl+C and re-run the same script in the terminal
- [ ] (Optional) Backdate a script's mtime (`touch -t 202001010000 …`) and reopen Unity → confirm it gets swept
- [x] `uloop compile` clean (no new errors/warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)