### PR TITLE
[codex] Add pose-space transform sync

### DIFF
--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/AvatarManager.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/AvatarManager.cs
@@ -140,6 +140,25 @@ namespace Styly.NetSync
             }
         }
 
+        public void ClearRemoteAvatarSnapshots(int clientNo)
+        {
+            if (_peerAvatars.TryGetValue(clientNo, out var net) && net != null)
+            {
+                net.ClearTransformSnapshots();
+            }
+        }
+
+        public void ClearAllRemoteAvatarSnapshots()
+        {
+            foreach (var net in _peerAvatars.Values)
+            {
+                if (net != null)
+                {
+                    net.ClearTransformSnapshots();
+                }
+            }
+        }
+
         /// <summary>
         /// Try to get a cached NetSyncAvatar component for a remote client.
         /// </summary>

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/BinarySerializer.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/BinarySerializer.cs
@@ -738,15 +738,13 @@ namespace Styly.NetSync
 
                 if (physicalValid && headValid)
                 {
-                    var deltaPos = client.xrOriginDeltaPosition;
-                    var deltaYaw = client.xrOriginDeltaYaw;
-                    var deltaRot = Quaternion.Euler(0f, deltaYaw, 0f);
-                    var invDeltaRot = Quaternion.Inverse(deltaRot);
-
-                    client.physical.position = invDeltaRot * (headPos - deltaPos);
-                    var headYaw = QuaternionToYawDegrees(headRot);
-                    var physicalYaw = NormalizeYawDegrees(headYaw - deltaYaw);
-                    client.physical.rotation = Quaternion.Euler(0f, physicalYaw, 0f);
+                    NetSyncPoseMath.ReconstructPhysicalFromHead(
+                        headPos,
+                        headRot,
+                        client.xrOriginDeltaPosition,
+                        client.xrOriginDeltaYaw,
+                        out client.physical.position,
+                        out client.physical.rotation);
                 }
                 else
                 {

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/HumanPresenceManager.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/HumanPresenceManager.cs
@@ -107,6 +107,14 @@ namespace Styly.NetSync
             }
         }
 
+        public void ClearSnapshots(int clientNo)
+        {
+            if (_applierByClient.TryGetValue(clientNo, out var applier) && applier != null)
+            {
+                applier.Clear();
+            }
+        }
+
         /// <summary>
         /// Destroy all presence instances (used on room switch/disconnect).
         /// </summary>

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/HumanPresenceManager.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/HumanPresenceManager.cs
@@ -116,6 +116,24 @@ namespace Styly.NetSync
         }
 
         /// <summary>
+        /// Clear interpolation snapshot buffers for every tracked client without
+        /// destroying the presence GameObjects. Used when the active pose space
+        /// changes so that buffered samples in the previous frame are not applied.
+        /// </summary>
+        public void ClearAllSnapshots()
+        {
+            if (_applierByClient.Count == 0) { return; }
+            foreach (var kv in _applierByClient)
+            {
+                var applier = kv.Value;
+                if (applier != null)
+                {
+                    applier.Clear();
+                }
+            }
+        }
+
+        /// <summary>
         /// Destroy all presence instances (used on room switch/disconnect).
         /// </summary>
         public void CleanupAll()

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/MessageProcessor.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/MessageProcessor.cs
@@ -390,7 +390,14 @@ namespace Styly.NetSync
                     {
                         var localPos = physical.GetPosition();
                         var localRot = physical.GetRotation();
-                        netSyncManager.UpdateHumanPresenceTransform(c.clientNo, localPos, localRot, c.poseTime, c.poseSeq);
+                        netSyncManager.UpdateHumanPresenceTransform(
+                            c.clientNo,
+                            localPos,
+                            localRot,
+                            c.xrOriginDeltaPosition,
+                            c.xrOriginDeltaYaw,
+                            c.poseTime,
+                            c.poseSeq);
                     }
                 }
 

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/NetSyncTransformApplier.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/NetSyncTransformApplier.cs
@@ -11,6 +11,7 @@ namespace Styly.NetSync
     internal class NetSyncTransformApplier
     {
         public enum SpaceMode { World, Local }
+        public delegate INetSyncPoseSpace PoseSpaceResolver();
 
         private struct TransformBinding
         {
@@ -26,6 +27,7 @@ namespace Styly.NetSync
 
         private NetSyncTimeEstimator _timeEstimator;
         private NetSyncSmoothingSettings _settings;
+        private PoseSpaceResolver _poseSpaceResolver;
         private readonly SendIntervalEstimator _intervalEstimator = new SendIntervalEstimator();
         private double _configuredSendIntervalSeconds = 0.1;
 
@@ -67,10 +69,12 @@ namespace Styly.NetSync
             Transform[] virtuals,
             NetSyncTimeEstimator timeEstimator,
             NetSyncSmoothingSettings settings,
-            float sendRateHz)
+            float sendRateHz,
+            PoseSpaceResolver poseSpaceResolver = null)
         {
             _timeEstimator = timeEstimator;
             _settings = settings ?? new NetSyncSmoothingSettings();
+            _poseSpaceResolver = poseSpaceResolver;
             _configuredSendIntervalSeconds = 1.0 / Math.Max(1e-6, sendRateHz);
 
             _physical = new PoseChannel(_settings.Physical);
@@ -104,10 +108,12 @@ namespace Styly.NetSync
             SpaceMode space,
             NetSyncTimeEstimator timeEstimator,
             NetSyncSmoothingSettings settings,
-            float sendRateHz)
+            float sendRateHz,
+            PoseSpaceResolver poseSpaceResolver = null)
         {
             _timeEstimator = timeEstimator;
             _settings = settings ?? new NetSyncSmoothingSettings();
+            _poseSpaceResolver = poseSpaceResolver;
             _configuredSendIntervalSeconds = 1.0 / Math.Max(1e-6, sendRateHz);
 
             _singleChannel = new PoseChannel(_settings.Physical);
@@ -273,14 +279,25 @@ namespace Styly.NetSync
             }
         }
 
-        private static void ApplyBinding(in TransformBinding binding, in PoseSampleData pose)
+        private void ApplyBinding(in TransformBinding binding, in PoseSampleData pose)
         {
             if (binding.Transform == null) return;
 
             if (binding.Space == SpaceMode.World)
             {
-                binding.Transform.position = pose.Position;
-                binding.Transform.rotation = pose.Rotation;
+                var position = pose.Position;
+                var rotation = pose.Rotation;
+                var poseSpace = _poseSpaceResolver != null ? _poseSpaceResolver() : null;
+                if (!NetSyncManager.IsWorldPoseSpace(poseSpace))
+                {
+                    if (!poseSpace.TrySpaceToWorld(pose.Position, pose.Rotation, out position, out rotation))
+                    {
+                        return;
+                    }
+                }
+
+                binding.Transform.position = position;
+                binding.Transform.rotation = rotation;
             }
             else
             {

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/NetSyncTransformApplier.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/NetSyncTransformApplier.cs
@@ -292,7 +292,8 @@ namespace Styly.NetSync
                 {
                     if (!poseSpace.TrySpaceToWorld(pose.Position, pose.Rotation, out position, out rotation))
                     {
-                        return;
+                        position = pose.Position;
+                        rotation = pose.Rotation;
                     }
                 }
 

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/NetSyncTransformApplier.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/NetSyncTransformApplier.cs
@@ -292,8 +292,7 @@ namespace Styly.NetSync
                 {
                     if (!poseSpace.TrySpaceToWorld(pose.Position, pose.Rotation, out position, out rotation))
                     {
-                        position = pose.Position;
-                        rotation = pose.Rotation;
+                        return;
                     }
                 }
 

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/ObjectSyncManager.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/ObjectSyncManager.cs
@@ -66,6 +66,40 @@ namespace Styly.NetSync
             _sendStates.Remove(obj.ObjectId);
         }
 
+        public void ClearObjectSnapshots(uint objectId)
+        {
+            if (objectId == 0u)
+            {
+                return;
+            }
+
+            if (_registeredObjects.TryGetValue(objectId, out var obj) && obj != null)
+            {
+                var applier = obj.TransformApplier;
+                if (applier != null)
+                {
+                    applier.Clear();
+                }
+            }
+        }
+
+        public void ClearAllObjectSnapshots()
+        {
+            foreach (var obj in _registeredObjects.Values)
+            {
+                if (obj == null)
+                {
+                    continue;
+                }
+
+                var applier = obj.TransformApplier;
+                if (applier != null)
+                {
+                    applier.Clear();
+                }
+            }
+        }
+
         public void SendOwnershipRequest(string roomId, byte operationType, uint objectId)
         {
             if (objectId == 0u) return;
@@ -103,6 +137,17 @@ namespace Styly.NetSync
                 var t = obj.transform;
                 var pos = t.position;
                 var rot = t.rotation;
+                var poseSpace = NetSyncManager.Instance != null ? NetSyncManager.Instance.ResolveObjectPoseSpace(obj) : NetSyncWorldPoseSpace.Instance;
+                if (!NetSyncManager.IsWorldPoseSpace(poseSpace))
+                {
+                    if (!poseSpace.TryWorldToSpace(pos, rot, out var spacePos, out var spaceRot))
+                    {
+                        continue;
+                    }
+
+                    pos = spacePos;
+                    rot = spaceRot;
+                }
 
                 // Only-on-change check (with heartbeat)
                 if (state.HasLastPose &&

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/ObjectSyncManager.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/ObjectSyncManager.cs
@@ -142,7 +142,8 @@ namespace Styly.NetSync
                 {
                     if (!poseSpace.TryWorldToSpace(pos, rot, out var spacePos, out var spaceRot))
                     {
-                        continue;
+                        spacePos = pos;
+                        spaceRot = rot;
                     }
 
                     pos = spacePos;

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/ObjectSyncManager.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/ObjectSyncManager.cs
@@ -142,8 +142,7 @@ namespace Styly.NetSync
                 {
                     if (!poseSpace.TryWorldToSpace(pos, rot, out var spacePos, out var spaceRot))
                     {
-                        spacePos = pos;
-                        spaceRot = rot;
+                        continue;
                     }
 
                     pos = spacePos;

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/PoseSpaceManager.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/PoseSpaceManager.cs
@@ -1,0 +1,234 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace Styly.NetSync
+{
+    internal sealed class PoseSpaceManager
+    {
+        private readonly Action _clearPoseSpaceDrivenSnapshots;
+        private readonly Action<int> _clearClientDrivenSnapshots;
+        private readonly Action<uint> _clearObjectSnapshots;
+
+        private readonly Dictionary<string, INetSyncPoseSpace> _poseSpaces = new Dictionary<string, INetSyncPoseSpace>();
+        private readonly Dictionary<int, string> _clientPoseSpaceIds = new Dictionary<int, string>();
+        private readonly Dictionary<uint, string> _objectPoseSpaceIds = new Dictionary<uint, string>();
+        private string _defaultPoseSpaceId;
+        private string _localAvatarPoseSpaceId;
+
+        public PoseSpaceManager(
+            Action clearPoseSpaceDrivenSnapshots,
+            Action<int> clearClientDrivenSnapshots,
+            Action<uint> clearObjectSnapshots)
+        {
+            _clearPoseSpaceDrivenSnapshots = clearPoseSpaceDrivenSnapshots;
+            _clearClientDrivenSnapshots = clearClientDrivenSnapshots;
+            _clearObjectSnapshots = clearObjectSnapshots;
+        }
+
+        public static bool IsWorldPoseSpaceId(string spaceId)
+        {
+            return string.Equals(spaceId, NetSyncWorldPoseSpace.Instance.SpaceId, StringComparison.Ordinal);
+        }
+
+        public static bool IsWorldPoseSpace(INetSyncPoseSpace poseSpace)
+        {
+            return poseSpace == null || poseSpace.IsIdentity || ReferenceEquals(poseSpace, NetSyncWorldPoseSpace.Instance) || IsWorldPoseSpaceId(poseSpace.SpaceId);
+        }
+
+        public static string NormalizePoseSpaceId(string spaceId)
+        {
+            if (string.IsNullOrEmpty(spaceId) || IsWorldPoseSpaceId(spaceId))
+            {
+                return null;
+            }
+
+            return spaceId;
+        }
+
+        public void RegisterPoseSpace(string spaceId, Transform origin)
+        {
+            if (string.IsNullOrEmpty(spaceId))
+            {
+                return;
+            }
+
+            RegisterPoseSpace(new TransformNetSyncPoseSpace(spaceId, origin));
+        }
+
+        public void RegisterPoseSpace(INetSyncPoseSpace poseSpace)
+        {
+            if (poseSpace == null || string.IsNullOrEmpty(poseSpace.SpaceId))
+            {
+                return;
+            }
+
+            _poseSpaces[poseSpace.SpaceId] = poseSpace;
+            _clearPoseSpaceDrivenSnapshots?.Invoke();
+        }
+
+        public void UnregisterPoseSpace(string spaceId)
+        {
+            if (string.IsNullOrEmpty(spaceId) || IsWorldPoseSpaceId(spaceId))
+            {
+                return;
+            }
+
+            _poseSpaces.Remove(spaceId);
+            _clearPoseSpaceDrivenSnapshots?.Invoke();
+        }
+
+        public void SetDefaultPoseSpace(string spaceId)
+        {
+            _defaultPoseSpaceId = NormalizePoseSpaceId(spaceId);
+            _clearPoseSpaceDrivenSnapshots?.Invoke();
+        }
+
+        public void ClearDefaultPoseSpace()
+        {
+            _defaultPoseSpaceId = null;
+            _clearPoseSpaceDrivenSnapshots?.Invoke();
+        }
+
+        public void SetLocalAvatarPoseSpace(string spaceId)
+        {
+            _localAvatarPoseSpaceId = NormalizePoseSpaceId(spaceId);
+        }
+
+        public void ClearLocalAvatarPoseSpace()
+        {
+            _localAvatarPoseSpaceId = null;
+        }
+
+        public void SetClientPoseSpace(int clientNo, string spaceId)
+        {
+            if (clientNo <= 0)
+            {
+                return;
+            }
+
+            var normalized = NormalizePoseSpaceId(spaceId);
+            if (string.IsNullOrEmpty(normalized))
+            {
+                _clientPoseSpaceIds.Remove(clientNo);
+                _clearClientDrivenSnapshots?.Invoke(clientNo);
+                return;
+            }
+
+            _clientPoseSpaceIds[clientNo] = normalized;
+            _clearClientDrivenSnapshots?.Invoke(clientNo);
+        }
+
+        public void ClearClientPoseSpace(int clientNo)
+        {
+            _clientPoseSpaceIds.Remove(clientNo);
+            _clearClientDrivenSnapshots?.Invoke(clientNo);
+        }
+
+        public void SetObjectPoseSpace(uint objectId, string spaceId)
+        {
+            if (objectId == 0u)
+            {
+                return;
+            }
+
+            var normalized = NormalizePoseSpaceId(spaceId);
+            if (string.IsNullOrEmpty(normalized))
+            {
+                _objectPoseSpaceIds.Remove(objectId);
+                _clearObjectSnapshots?.Invoke(objectId);
+                return;
+            }
+
+            _objectPoseSpaceIds[objectId] = normalized;
+            _clearObjectSnapshots?.Invoke(objectId);
+        }
+
+        public void ClearObjectPoseSpace(uint objectId)
+        {
+            _objectPoseSpaceIds.Remove(objectId);
+            _clearObjectSnapshots?.Invoke(objectId);
+        }
+
+        public void NotifyObjectPoseSpaceChanged(NetSyncObject obj)
+        {
+            if (obj == null || obj.ObjectId == 0u)
+            {
+                return;
+            }
+
+            _clearObjectSnapshots?.Invoke(obj.ObjectId);
+        }
+
+        public INetSyncPoseSpace ResolveLocalAvatarPoseSpace()
+        {
+            if (!string.IsNullOrEmpty(_localAvatarPoseSpaceId))
+            {
+                return ResolvePoseSpaceById(_localAvatarPoseSpaceId);
+            }
+
+            return ResolveDefaultPoseSpace();
+        }
+
+        public INetSyncPoseSpace ResolveClientPoseSpace(int clientNo)
+        {
+            if (clientNo > 0 && _clientPoseSpaceIds.TryGetValue(clientNo, out var spaceId))
+            {
+                return ResolvePoseSpaceById(spaceId);
+            }
+
+            return ResolveDefaultPoseSpace();
+        }
+
+        public INetSyncPoseSpace ResolveObjectPoseSpace(NetSyncObject obj)
+        {
+            if (obj != null)
+            {
+                var objectId = obj.ObjectId;
+                if (objectId != 0u && _objectPoseSpaceIds.TryGetValue(objectId, out var spaceId))
+                {
+                    return ResolvePoseSpaceById(spaceId);
+                }
+
+                if (!string.IsNullOrEmpty(obj.PoseSpaceId))
+                {
+                    return ResolvePoseSpaceById(obj.PoseSpaceId);
+                }
+            }
+
+            return ResolveDefaultPoseSpace();
+        }
+
+        public bool HasPoseSpace(string spaceId)
+        {
+            return !string.IsNullOrEmpty(spaceId) && _poseSpaces.ContainsKey(spaceId);
+        }
+
+        public void ClearRoomScopedSelections()
+        {
+            _localAvatarPoseSpaceId = null;
+            _clientPoseSpaceIds.Clear();
+            _objectPoseSpaceIds.Clear();
+        }
+
+        private INetSyncPoseSpace ResolveDefaultPoseSpace()
+        {
+            return ResolvePoseSpaceById(_defaultPoseSpaceId);
+        }
+
+        private INetSyncPoseSpace ResolvePoseSpaceById(string spaceId)
+        {
+            if (string.IsNullOrEmpty(spaceId) || IsWorldPoseSpaceId(spaceId))
+            {
+                return NetSyncWorldPoseSpace.Instance;
+            }
+
+            if (_poseSpaces.TryGetValue(spaceId, out var poseSpace) && poseSpace != null)
+            {
+                return poseSpace;
+            }
+
+            return NetSyncWorldPoseSpace.Instance;
+        }
+    }
+}

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/PoseSpaceManager.cs.meta
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/PoseSpaceManager.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: f1cc0bbd779964ccc991c6e6624508cd

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/NetSyncAvatar.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/NetSyncAvatar.cs
@@ -151,7 +151,8 @@ namespace Styly.NetSync
                 _virtualTransforms,
                 _netSyncManager != null ? _netSyncManager.TimeEstimator : null,
                 _smoothingSettings,
-                _netSyncManager != null ? _netSyncManager.TransformSendRate : 10f);
+                _netSyncManager != null ? _netSyncManager.TransformSendRate : 10f,
+                null);
 
             // Prepare reusable send buffers (after transforms are known).
             EnsureTxBuffersAllocated();
@@ -174,7 +175,8 @@ namespace Styly.NetSync
                 _virtualTransforms,
                 _netSyncManager != null ? _netSyncManager.TimeEstimator : null,
                 _smoothingSettings,
-                _netSyncManager != null ? _netSyncManager.TransformSendRate : 10f);
+                _netSyncManager != null ? _netSyncManager.TransformSendRate : 10f,
+                () => _netSyncManager != null ? _netSyncManager.ResolveClientPoseSpace(_clientNo) : NetSyncWorldPoseSpace.Instance);
 
             // Prepare reusable send buffers (after transforms are known).
             EnsureTxBuffersAllocated();
@@ -259,9 +261,10 @@ namespace Styly.NetSync
             _tx.deviceId = _deviceId;
             _tx.clientNo = _clientNo;
             _tx.flags = BuildPoseFlags();
+            var poseSpace = _netSyncManager != null ? _netSyncManager.ResolveLocalAvatarPoseSpace() : NetSyncWorldPoseSpace.Instance;
             if (_netSyncManager != null)
             {
-                _netSyncManager.ComputeXrOriginDelta(out var deltaPos, out var deltaYaw);
+                _netSyncManager.ComputeXrOriginDelta(poseSpace, out var deltaPos, out var deltaYaw);
                 _tx.xrOriginDeltaPosition = deltaPos;
                 _tx.xrOriginDeltaYaw = deltaYaw;
             }
@@ -319,7 +322,45 @@ namespace Styly.NetSync
             // EnsureTxBuffersAllocated already handled resizing, so just assign.
             _tx.virtuals = _txVirtuals;
 
+            ConvertWorldPosesToPoseSpace(_tx, poseSpace);
+
             return _tx;
+        }
+
+        private static void ConvertWorldPosesToPoseSpace(ClientTransformData data, INetSyncPoseSpace poseSpace)
+        {
+            if (data == null || NetSyncManager.IsWorldPoseSpace(poseSpace))
+            {
+                return;
+            }
+
+            ConvertWorldPoseToPoseSpace(data.head, poseSpace);
+            ConvertWorldPoseToPoseSpace(data.rightHand, poseSpace);
+            ConvertWorldPoseToPoseSpace(data.leftHand, poseSpace);
+
+            if (data.virtuals == null)
+            {
+                return;
+            }
+
+            for (int i = 0; i < data.virtuals.Count; i++)
+            {
+                ConvertWorldPoseToPoseSpace(data.virtuals[i], poseSpace);
+            }
+        }
+
+        private static void ConvertWorldPoseToPoseSpace(TransformData data, INetSyncPoseSpace poseSpace)
+        {
+            if (data == null)
+            {
+                return;
+            }
+
+            if (poseSpace.TryWorldToSpace(data.position, data.rotation, out var spacePosition, out var spaceRotation))
+            {
+                data.position = spacePosition;
+                data.rotation = spaceRotation;
+            }
         }
 
         // Update device ID when mapping is received
@@ -343,6 +384,11 @@ namespace Styly.NetSync
 
             // Update client number for remote avatars
             _clientNo = data.clientNo;
+        }
+
+        internal void ClearTransformSnapshots()
+        {
+            _transformApplier.Clear();
         }
 
         // Get world transform data (world space, full 6DOF)

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/NetSyncManager.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/NetSyncManager.cs
@@ -187,122 +187,74 @@ namespace Styly.NetSync
         #region === Pose Space API ===
         /// <summary>
         /// Registers a pose space backed by a Transform. All peers must use the same ID for the same logical space.
+        /// Pose-space selection is synchronized out-of-band and is not encoded in protocol v4 pose payloads.
         /// </summary>
         public void RegisterPoseSpace(string spaceId, Transform origin)
         {
-            if (string.IsNullOrEmpty(spaceId))
-            {
-                return;
-            }
-
-            RegisterPoseSpace(new TransformNetSyncPoseSpace(spaceId, origin));
+            PoseSpaces.RegisterPoseSpace(spaceId, origin);
         }
 
         /// <summary>
-        /// Registers a custom pose space. Pose-space selection is intentionally synchronized out-of-band.
+        /// Registers a custom pose space. Pose-space selection is synchronized out-of-band and is not encoded in protocol v4 pose payloads.
         /// </summary>
         public void RegisterPoseSpace(INetSyncPoseSpace poseSpace)
         {
-            if (poseSpace == null || string.IsNullOrEmpty(poseSpace.SpaceId))
-            {
-                return;
-            }
-
-            _poseSpaces[poseSpace.SpaceId] = poseSpace;
-            ClearPoseSpaceDrivenSnapshots();
+            PoseSpaces.RegisterPoseSpace(poseSpace);
         }
 
         public void UnregisterPoseSpace(string spaceId)
         {
-            if (string.IsNullOrEmpty(spaceId) || IsWorldPoseSpaceId(spaceId))
-            {
-                return;
-            }
-
-            _poseSpaces.Remove(spaceId);
-            ClearPoseSpaceDrivenSnapshots();
+            PoseSpaces.UnregisterPoseSpace(spaceId);
         }
 
         public void SetDefaultPoseSpace(string spaceId)
         {
-            _defaultPoseSpaceId = NormalizePoseSpaceId(spaceId);
-            ClearPoseSpaceDrivenSnapshots();
+            PoseSpaces.SetDefaultPoseSpace(spaceId);
         }
 
         public void ClearDefaultPoseSpace()
         {
-            _defaultPoseSpaceId = null;
-            ClearPoseSpaceDrivenSnapshots();
+            PoseSpaces.ClearDefaultPoseSpace();
         }
 
         public void SetLocalAvatarPoseSpace(string spaceId)
         {
-            _localAvatarPoseSpaceId = NormalizePoseSpaceId(spaceId);
+            PoseSpaces.SetLocalAvatarPoseSpace(spaceId);
         }
 
         public void ClearLocalAvatarPoseSpace()
         {
-            _localAvatarPoseSpaceId = null;
+            PoseSpaces.ClearLocalAvatarPoseSpace();
         }
 
         public void SetClientPoseSpace(int clientNo, string spaceId)
         {
-            if (clientNo <= 0)
-            {
-                return;
-            }
-
-            var normalized = NormalizePoseSpaceId(spaceId);
-            if (string.IsNullOrEmpty(normalized))
-            {
-                _clientPoseSpaceIds.Remove(clientNo);
-                ClearClientDrivenSnapshots(clientNo);
-                return;
-            }
-
-            _clientPoseSpaceIds[clientNo] = normalized;
-            ClearClientDrivenSnapshots(clientNo);
+            PoseSpaces.SetClientPoseSpace(clientNo, spaceId);
         }
 
         public void ClearClientPoseSpace(int clientNo)
         {
-            _clientPoseSpaceIds.Remove(clientNo);
-            ClearClientDrivenSnapshots(clientNo);
+            PoseSpaces.ClearClientPoseSpace(clientNo);
         }
 
+        /// <summary>
+        /// Sets the local object's pose-space override. This is local state only;
+        /// applications must synchronize object pose-space selection out-of-band before
+        /// sending non-world object poses.
+        /// </summary>
         public void SetObjectPoseSpace(uint objectId, string spaceId)
         {
-            if (objectId == 0u)
-            {
-                return;
-            }
-
-            var normalized = NormalizePoseSpaceId(spaceId);
-            if (string.IsNullOrEmpty(normalized))
-            {
-                _objectPoseSpaceIds.Remove(objectId);
-                if (_objectSyncManager != null) { _objectSyncManager.ClearObjectSnapshots(objectId); }
-                return;
-            }
-
-            _objectPoseSpaceIds[objectId] = normalized;
-            if (_objectSyncManager != null) { _objectSyncManager.ClearObjectSnapshots(objectId); }
+            PoseSpaces.SetObjectPoseSpace(objectId, spaceId);
         }
 
         public void ClearObjectPoseSpace(uint objectId)
         {
-            _objectPoseSpaceIds.Remove(objectId);
-            if (_objectSyncManager != null) { _objectSyncManager.ClearObjectSnapshots(objectId); }
+            PoseSpaces.ClearObjectPoseSpace(objectId);
         }
 
         internal void NotifyObjectPoseSpaceChanged(NetSyncObject obj)
         {
-            if (obj == null || obj.ObjectId == 0u)
-            {
-                return;
-            }
-
-            if (_objectSyncManager != null) { _objectSyncManager.ClearObjectSnapshots(obj.ObjectId); }
+            PoseSpaces.NotifyObjectPoseSpaceChanged(obj);
         }
         #endregion ------------------------------------------------------------------------
 
@@ -313,7 +265,7 @@ namespace Styly.NetSync
         /// </summary>
         public void RegisterPlatform(string platformId, Transform platform)
         {
-            if (string.IsNullOrEmpty(platformId) || IsWorldPoseSpaceId(platformId))
+            if (string.IsNullOrEmpty(platformId) || PoseSpaceManager.IsWorldPoseSpaceId(platformId))
             {
                 Debug.LogWarning("[NetSync] RegisterPlatform: platformId must be non-empty and not 'world'.");
                 return;
@@ -355,14 +307,14 @@ namespace Styly.NetSync
         /// </summary>
         public bool AttachLocalAvatarToPlatform(string platformId)
         {
-            var normalized = NormalizePoseSpaceId(platformId);
+            var normalized = PoseSpaceManager.NormalizePoseSpaceId(platformId);
             if (string.IsNullOrEmpty(normalized))
             {
                 Debug.LogWarning("[NetSync] AttachLocalAvatarToPlatform: platformId must be non-empty and not 'world'.");
                 return false;
             }
 
-            if (!_poseSpaces.TryGetValue(normalized, out var poseSpace) || poseSpace == null)
+            if (!PoseSpaces.HasPoseSpace(normalized))
             {
                 Debug.LogWarning($"[NetSync] AttachLocalAvatarToPlatform: platform '{normalized}' is not registered.");
                 return false;
@@ -370,22 +322,6 @@ namespace Styly.NetSync
 
             SetLocalAvatarPoseSpace(normalized);
             return SetClientVariable(PlatformPoseSpaceClientVariableName, normalized);
-        }
-
-        /// <summary>
-        /// Registers the platform locally, then attaches the local avatar to it.
-        /// </summary>
-        [Obsolete("Use AttachLocalAvatarToPlatform(string platformId, GameObject platform).")]
-        public bool AttachLocalAvatarToPlatform(GameObject platform, string platformId)
-        {
-            if (platform == null)
-            {
-                Debug.LogWarning("[NetSync] AttachLocalAvatarToPlatform: platform must be non-null.");
-                return false;
-            }
-
-            RegisterPlatform(platformId, platform);
-            return AttachLocalAvatarToPlatform(platformId);
         }
 
         /// <summary>
@@ -413,13 +349,6 @@ namespace Styly.NetSync
             return SetClientVariable(PlatformPoseSpaceClientVariableName, string.Empty);
         }
 
-        /// <summary>
-        /// Compatibility alias for callers that model platform use as attach/detach.
-        /// </summary>
-        public bool DetachLocalAvatar()
-        {
-            return DetachLocalAvatarFromPlatform();
-        }
         #endregion ------------------------------------------------------------------------
 
         /// <summary>
@@ -580,6 +509,7 @@ namespace Styly.NetSync
         private NetworkVariableManager _networkVariableManager;
         private HumanPresenceManager _humanPresenceManager;
         private ObjectSyncManager _objectSyncManager;
+        private PoseSpaceManager _poseSpaceManager;
         private readonly NetSyncTimeEstimator _timeEstimator = new NetSyncTimeEstimator();
 
         // State
@@ -598,11 +528,6 @@ namespace Styly.NetSync
         private bool _hasInvokedReady = false;
         private bool _shouldCheckReady = false;
         private bool _shouldSendHandshake = false;
-        private readonly Dictionary<string, INetSyncPoseSpace> _poseSpaces = new Dictionary<string, INetSyncPoseSpace>();
-        private readonly Dictionary<int, string> _clientPoseSpaceIds = new Dictionary<int, string>();
-        private readonly Dictionary<uint, string> _objectPoseSpaceIds = new Dictionary<uint, string>();
-        private string _defaultPoseSpaceId;
-        private string _localAvatarPoseSpaceId;
         // Battery monitoring fields
         private float _batteryUpdateInterval = 60.0f; // Update every 60 seconds
         private float _lastBatteryUpdate = 0.0f; // Last time we updated battery level
@@ -646,6 +571,22 @@ namespace Styly.NetSync
         private DeviceIdResolver _deviceIdResolver;
         private bool _networkingPending;
         #endregion ------------------------------------------------------------------------
+
+        private PoseSpaceManager PoseSpaces
+        {
+            get
+            {
+                if (_poseSpaceManager == null)
+                {
+                    _poseSpaceManager = new PoseSpaceManager(
+                        ClearPoseSpaceDrivenSnapshots,
+                        ClearClientDrivenSnapshots,
+                        ClearObjectSnapshots);
+                }
+
+                return _poseSpaceManager;
+            }
+        }
 
         #region === Public Properties ===
         public string DeviceId => _deviceId;
@@ -1105,7 +1046,7 @@ namespace Styly.NetSync
 
         private void OnRemoteAvatarDisconnected(int clientNo)
         {
-            _clientPoseSpaceIds.Remove(clientNo);
+            PoseSpaces.ClearClientPoseSpace(clientNo);
             OnAvatarDisconnected?.Invoke(clientNo);
         }
 
@@ -1162,7 +1103,7 @@ namespace Styly.NetSync
                 return;
             }
 
-            if (string.IsNullOrEmpty(platformId) || IsWorldPoseSpaceId(platformId))
+            if (string.IsNullOrEmpty(platformId) || PoseSpaceManager.IsWorldPoseSpaceId(platformId))
             {
                 ClearClientPoseSpace(clientNo);
                 return;
@@ -1170,7 +1111,7 @@ namespace Styly.NetSync
 
             SetClientPoseSpace(clientNo, platformId);
 
-            if (!_poseSpaces.ContainsKey(platformId))
+            if (!PoseSpaces.HasPoseSpace(platformId))
             {
                 Debug.LogWarning($"[NetSync] Client#{clientNo} selected platform pose space '{platformId}', but it is not registered on this client yet.");
             }
@@ -1184,9 +1125,7 @@ namespace Styly.NetSync
 
         private void ClearRoomScopedPoseSpaceSelections()
         {
-            _localAvatarPoseSpaceId = null;
-            _clientPoseSpaceIds.Clear();
-            _objectPoseSpaceIds.Clear();
+            PoseSpaces.ClearRoomScopedSelections();
         }
 
         private void OnLocalClientNoAssigned(int clientNo)
@@ -1590,83 +1529,24 @@ namespace Styly.NetSync
             }
         }
 
-        private static bool IsWorldPoseSpaceId(string spaceId)
-        {
-            return string.Equals(spaceId, NetSyncWorldPoseSpace.Instance.SpaceId, StringComparison.Ordinal);
-        }
-
-        private static string NormalizePoseSpaceId(string spaceId)
-        {
-            if (string.IsNullOrEmpty(spaceId) || IsWorldPoseSpaceId(spaceId))
-            {
-                return null;
-            }
-
-            return spaceId;
-        }
-
-        private INetSyncPoseSpace ResolvePoseSpaceById(string spaceId)
-        {
-            if (string.IsNullOrEmpty(spaceId) || IsWorldPoseSpaceId(spaceId))
-            {
-                return NetSyncWorldPoseSpace.Instance;
-            }
-
-            if (_poseSpaces.TryGetValue(spaceId, out var poseSpace) && poseSpace != null)
-            {
-                return poseSpace;
-            }
-
-            return NetSyncWorldPoseSpace.Instance;
-        }
-
-        private INetSyncPoseSpace ResolveDefaultPoseSpace()
-        {
-            return ResolvePoseSpaceById(_defaultPoseSpaceId);
-        }
-
         internal INetSyncPoseSpace ResolveLocalAvatarPoseSpace()
         {
-            if (!string.IsNullOrEmpty(_localAvatarPoseSpaceId))
-            {
-                return ResolvePoseSpaceById(_localAvatarPoseSpaceId);
-            }
-
-            return ResolveDefaultPoseSpace();
+            return PoseSpaces.ResolveLocalAvatarPoseSpace();
         }
 
         internal INetSyncPoseSpace ResolveClientPoseSpace(int clientNo)
         {
-            if (clientNo > 0 && _clientPoseSpaceIds.TryGetValue(clientNo, out var spaceId))
-            {
-                return ResolvePoseSpaceById(spaceId);
-            }
-
-            return ResolveDefaultPoseSpace();
+            return PoseSpaces.ResolveClientPoseSpace(clientNo);
         }
 
         internal INetSyncPoseSpace ResolveObjectPoseSpace(NetSyncObject obj)
         {
-            if (obj != null)
-            {
-                var objectId = obj.ObjectId;
-                if (objectId != 0u && _objectPoseSpaceIds.TryGetValue(objectId, out var spaceId))
-                {
-                    return ResolvePoseSpaceById(spaceId);
-                }
-
-                if (!string.IsNullOrEmpty(obj.PoseSpaceId))
-                {
-                    return ResolvePoseSpaceById(obj.PoseSpaceId);
-                }
-            }
-
-            return ResolveDefaultPoseSpace();
+            return PoseSpaces.ResolveObjectPoseSpace(obj);
         }
 
         internal static bool IsWorldPoseSpace(INetSyncPoseSpace poseSpace)
         {
-            return poseSpace == null || ReferenceEquals(poseSpace, NetSyncWorldPoseSpace.Instance) || IsWorldPoseSpaceId(poseSpace.SpaceId);
+            return PoseSpaceManager.IsWorldPoseSpace(poseSpace);
         }
 
         private void ClearPoseSpaceDrivenSnapshots()
@@ -1674,6 +1554,11 @@ namespace Styly.NetSync
             if (_avatarManager != null) { _avatarManager.ClearAllRemoteAvatarSnapshots(); }
             if (_objectSyncManager != null) { _objectSyncManager.ClearAllObjectSnapshots(); }
             if (_humanPresenceManager != null) { _humanPresenceManager.ClearAllSnapshots(); }
+        }
+
+        private void ClearObjectSnapshots(uint objectId)
+        {
+            if (_objectSyncManager != null) { _objectSyncManager.ClearObjectSnapshots(objectId); }
         }
         #endregion ------------------------------------------------------------------------
 
@@ -1759,13 +1644,13 @@ namespace Styly.NetSync
             var poseSpace = ResolveClientPoseSpace(clientNo);
             if (poseSpace != null && !IsWorldPoseSpace(poseSpace))
             {
-                // Reconstruct the remote rig's pose in its active pose space, mirroring
-                // MessageProcessor's physical decode of the wire payload. If this method
-                // diverges from MessageProcessor.ProcessRoomTransform's pose math, the
-                // Human Presence transform will silently desync from the avatar.
-                var deltaRot = Quaternion.Euler(0f, xrOriginDeltaYaw, 0f);
-                var spacePos = deltaRot * position + xrOriginDeltaPosition;
-                var spaceYawRotation = deltaRot * Quaternion.Euler(0f, rotation.eulerAngles.y, 0f);
+                NetSyncPoseMath.ApplyXrOriginDelta(
+                    position,
+                    rotation,
+                    xrOriginDeltaPosition,
+                    xrOriginDeltaYaw,
+                    out var spacePos,
+                    out var spaceYawRotation);
 
                 if (poseSpace.TrySpaceToWorld(spacePos, spaceYawRotation, out var spaceWorldPos, out var spaceWorldRotation))
                 {
@@ -1774,10 +1659,6 @@ namespace Styly.NetSync
                     // documented as yaw-only.
                     var spaceWorldYaw = Quaternion.Euler(0f, spaceWorldRotation.eulerAngles.y, 0f);
                     _humanPresenceManager.UpdateTransform(clientNo, spaceWorldPos, spaceWorldYaw, poseTime, poseSeq);
-                }
-                else
-                {
-                    _humanPresenceManager.UpdateTransform(clientNo, spacePos, spaceYawRotation, poseTime, poseSeq);
                 }
 
                 return;

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/NetSyncManager.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/NetSyncManager.cs
@@ -1673,6 +1673,7 @@ namespace Styly.NetSync
         {
             if (_avatarManager != null) { _avatarManager.ClearAllRemoteAvatarSnapshots(); }
             if (_objectSyncManager != null) { _objectSyncManager.ClearAllObjectSnapshots(); }
+            if (_humanPresenceManager != null) { _humanPresenceManager.ClearAllSnapshots(); }
         }
         #endregion ------------------------------------------------------------------------
 
@@ -1756,19 +1757,27 @@ namespace Styly.NetSync
             if (_humanPresenceManager == null) { return; }
 
             var poseSpace = ResolveClientPoseSpace(clientNo);
-            if (!IsWorldPoseSpace(poseSpace))
+            if (poseSpace != null && !IsWorldPoseSpace(poseSpace))
             {
+                // Reconstruct the remote rig's pose in its active pose space, mirroring
+                // MessageProcessor's physical decode of the wire payload. If this method
+                // diverges from MessageProcessor.ProcessRoomTransform's pose math, the
+                // Human Presence transform will silently desync from the avatar.
                 var deltaRot = Quaternion.Euler(0f, xrOriginDeltaYaw, 0f);
                 var spacePos = deltaRot * position + xrOriginDeltaPosition;
-                var spaceYaw = deltaRot * Quaternion.Euler(0f, rotation.eulerAngles.y, 0f);
+                var spaceYawRotation = deltaRot * Quaternion.Euler(0f, rotation.eulerAngles.y, 0f);
 
-                if (poseSpace.TrySpaceToWorld(spacePos, spaceYaw, out var poseSpaceWorldPos, out var poseSpaceWorldYaw))
+                if (poseSpace.TrySpaceToWorld(spacePos, spaceYawRotation, out var spaceWorldPos, out var spaceWorldRotation))
                 {
-                    _humanPresenceManager.UpdateTransform(clientNo, poseSpaceWorldPos, poseSpaceWorldYaw, poseTime, poseSeq);
+                    // Force yaw-only on the way out — a tilted/rolled pose-space transform
+                    // would otherwise leak non-yaw components into Human Presence, which is
+                    // documented as yaw-only.
+                    var spaceWorldYaw = Quaternion.Euler(0f, spaceWorldRotation.eulerAngles.y, 0f);
+                    _humanPresenceManager.UpdateTransform(clientNo, spaceWorldPos, spaceWorldYaw, poseTime, poseSeq);
                 }
                 else
                 {
-                    _humanPresenceManager.UpdateTransform(clientNo, spacePos, spaceYaw, poseTime, poseSeq);
+                    _humanPresenceManager.UpdateTransform(clientNo, spacePos, spaceYawRotation, poseTime, poseSeq);
                 }
 
                 return;

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/NetSyncManager.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/NetSyncManager.cs
@@ -67,6 +67,7 @@ namespace Styly.NetSync
         private float _discoveryTimeout = 10f;
 
         internal const string PrefixForSystem = "@system:"; // Prefix for system-only message names
+        private const string PlatformPoseSpaceClientVariableName = PrefixForSystem + "platformPoseSpace";
 
         #endregion ------------------------------------------------------------------------
 
@@ -183,11 +184,17 @@ namespace Styly.NetSync
             return _networkVariableManager != null ? _networkVariableManager.GetClientVariable(name, clientNo, defaultValue) : defaultValue;
         }
 
+        #region === Pose Space API ===
         /// <summary>
         /// Registers a pose space backed by a Transform. All peers must use the same ID for the same logical space.
         /// </summary>
         public void RegisterPoseSpace(string spaceId, Transform origin)
         {
+            if (string.IsNullOrEmpty(spaceId))
+            {
+                return;
+            }
+
             RegisterPoseSpace(new TransformNetSyncPoseSpace(spaceId, origin));
         }
 
@@ -202,6 +209,7 @@ namespace Styly.NetSync
             }
 
             _poseSpaces[poseSpace.SpaceId] = poseSpace;
+            ClearPoseSpaceDrivenSnapshots();
         }
 
         public void UnregisterPoseSpace(string spaceId)
@@ -212,6 +220,7 @@ namespace Styly.NetSync
             }
 
             _poseSpaces.Remove(spaceId);
+            ClearPoseSpaceDrivenSnapshots();
         }
 
         public void SetDefaultPoseSpace(string spaceId)
@@ -285,6 +294,107 @@ namespace Styly.NetSync
             _objectPoseSpaceIds.Remove(objectId);
             if (_objectSyncManager != null) { _objectSyncManager.ClearObjectSnapshots(objectId); }
         }
+        #endregion ------------------------------------------------------------------------
+
+        #region === Platform Pose Space API ===
+        /// <summary>
+        /// Registers a moving platform as a pose space. All peers must use the same
+        /// platform ID for the same logical platform.
+        /// </summary>
+        public void RegisterPlatform(string platformId, Transform platform)
+        {
+            if (string.IsNullOrEmpty(platformId) || IsWorldPoseSpaceId(platformId))
+            {
+                Debug.LogWarning("[NetSync] RegisterPlatform: platformId must be non-empty and not 'world'.");
+                return;
+            }
+
+            if (platform == null)
+            {
+                Debug.LogWarning("[NetSync] RegisterPlatform: platform must be non-null.");
+                return;
+            }
+
+            RegisterPoseSpace(platformId, platform);
+        }
+
+        /// <summary>
+        /// Registers a moving platform as a pose space. All peers must use the same
+        /// platform ID for the same logical platform.
+        /// </summary>
+        public void RegisterPlatform(string platformId, GameObject platform)
+        {
+            if (platform == null)
+            {
+                Debug.LogWarning("[NetSync] RegisterPlatform: platform must be non-null.");
+                return;
+            }
+
+            RegisterPlatform(platformId, platform.transform);
+        }
+
+        public void UnregisterPlatform(string platformId)
+        {
+            UnregisterPoseSpace(platformId);
+        }
+
+        /// <summary>
+        /// Sends the local avatar in a registered platform's pose space and
+        /// synchronizes that selection so receivers resolve this client in the
+        /// same logical platform space.
+        /// </summary>
+        public bool AttachLocalAvatarToPlatform(string platformId)
+        {
+            var normalized = NormalizePoseSpaceId(platformId);
+            if (string.IsNullOrEmpty(normalized))
+            {
+                Debug.LogWarning("[NetSync] AttachLocalAvatarToPlatform: platformId must be non-empty and not 'world'.");
+                return false;
+            }
+
+            if (!_poseSpaces.TryGetValue(normalized, out var poseSpace) || poseSpace == null)
+            {
+                Debug.LogWarning($"[NetSync] AttachLocalAvatarToPlatform: platform '{normalized}' is not registered.");
+                return false;
+            }
+
+            SetLocalAvatarPoseSpace(normalized);
+            return SetClientVariable(PlatformPoseSpaceClientVariableName, normalized);
+        }
+
+        /// <summary>
+        /// Registers the platform locally, then attaches the local avatar to it.
+        /// </summary>
+        public bool AttachLocalAvatarToPlatform(GameObject platform, string platformId)
+        {
+            if (platform == null)
+            {
+                Debug.LogWarning("[NetSync] AttachLocalAvatarToPlatform: platform must be non-null.");
+                return false;
+            }
+
+            RegisterPlatform(platformId, platform);
+            return AttachLocalAvatarToPlatform(platformId);
+        }
+
+        /// <summary>
+        /// Returns the local avatar to the default/world pose space and notifies
+        /// receivers to clear this client's platform pose-space binding.
+        /// </summary>
+        public bool DetachLocalAvatarFromPlatform()
+        {
+            ClearLocalAvatarPoseSpace();
+            return SetClientVariable(PlatformPoseSpaceClientVariableName, string.Empty);
+        }
+
+        /// <summary>
+        /// Compatibility alias for callers that model platform use as attach/detach.
+        /// </summary>
+        public bool DetachLocalAvatar()
+        {
+            return DetachLocalAvatarFromPlatform();
+        }
+        #endregion ------------------------------------------------------------------------
 
         /// <summary>
         /// Gets all variables for a specific client (for debugging)
@@ -1012,7 +1122,33 @@ namespace Styly.NetSync
         private void OnClientVariableChangedHandler(int clientNo, string name, string oldValue, string newValue)
         {
             Debug.Log($"[NetSyncManager] Client Variable Changed - Client#{clientNo}, Name: {name}, Old: {oldValue ?? "null"}, New: {newValue ?? "null"}");
+            if (string.Equals(name, PlatformPoseSpaceClientVariableName, StringComparison.Ordinal))
+            {
+                ApplyPlatformPoseSpaceClientVariable(clientNo, newValue);
+            }
+
             OnClientVariableChanged?.Invoke(clientNo, name, oldValue, newValue);
+        }
+
+        private void ApplyPlatformPoseSpaceClientVariable(int clientNo, string platformId)
+        {
+            if (clientNo <= 0 || clientNo == _clientNo)
+            {
+                return;
+            }
+
+            if (string.IsNullOrEmpty(platformId) || IsWorldPoseSpaceId(platformId))
+            {
+                ClearClientPoseSpace(clientNo);
+                return;
+            }
+
+            SetClientPoseSpace(clientNo, platformId);
+
+            if (!_poseSpaces.ContainsKey(platformId))
+            {
+                Debug.LogWarning($"[NetSync] Client#{clientNo} selected platform pose space '{platformId}', but it is not registered on this client yet.");
+            }
         }
 
         private void OnLocalClientNoAssigned(int clientNo)
@@ -1568,14 +1704,33 @@ namespace Styly.NetSync
         /// <param name="clientNo">Remote client number</param>
         /// <param name="position">Local position (physical, relative to remote head's parent)</param>
         /// <param name="rotation">Local rotation (physical); only yaw is used</param>
+        /// <param name="xrOriginDeltaPosition">Remote client's locomotion delta in its active pose space</param>
+        /// <param name="xrOriginDeltaYaw">Remote client's yaw delta in its active pose space</param>
         internal void UpdateHumanPresenceTransform(
             int clientNo,
             Vector3 position,
             Quaternion rotation,
+            Vector3 xrOriginDeltaPosition,
+            float xrOriginDeltaYaw,
             double poseTime,
             ushort poseSeq)
         {
             if (_humanPresenceManager == null) { return; }
+
+            var poseSpace = ResolveClientPoseSpace(clientNo);
+            if (!IsWorldPoseSpace(poseSpace))
+            {
+                var deltaRot = Quaternion.Euler(0f, xrOriginDeltaYaw, 0f);
+                var spacePos = deltaRot * position + xrOriginDeltaPosition;
+                var spaceYaw = deltaRot * Quaternion.Euler(0f, rotation.eulerAngles.y, 0f);
+
+                if (poseSpace.TrySpaceToWorld(spacePos, spaceYaw, out var poseSpaceWorldPos, out var poseSpaceWorldYaw))
+                {
+                    _humanPresenceManager.UpdateTransform(clientNo, poseSpaceWorldPos, poseSpaceWorldYaw, poseTime, poseSeq);
+                }
+
+                return;
+            }
 
             // Find the remote avatar and its head parent to resolve local->world.
             Transform parent = null;

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/NetSyncManager.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/NetSyncManager.cs
@@ -256,18 +256,18 @@ namespace Styly.NetSync
             if (string.IsNullOrEmpty(normalized))
             {
                 _clientPoseSpaceIds.Remove(clientNo);
-                if (_avatarManager != null) { _avatarManager.ClearRemoteAvatarSnapshots(clientNo); }
+                ClearClientDrivenSnapshots(clientNo);
                 return;
             }
 
             _clientPoseSpaceIds[clientNo] = normalized;
-            if (_avatarManager != null) { _avatarManager.ClearRemoteAvatarSnapshots(clientNo); }
+            ClearClientDrivenSnapshots(clientNo);
         }
 
         public void ClearClientPoseSpace(int clientNo)
         {
             _clientPoseSpaceIds.Remove(clientNo);
-            if (_avatarManager != null) { _avatarManager.ClearRemoteAvatarSnapshots(clientNo); }
+            ClearClientDrivenSnapshots(clientNo);
         }
 
         public void SetObjectPoseSpace(uint objectId, string spaceId)
@@ -293,6 +293,16 @@ namespace Styly.NetSync
         {
             _objectPoseSpaceIds.Remove(objectId);
             if (_objectSyncManager != null) { _objectSyncManager.ClearObjectSnapshots(objectId); }
+        }
+
+        internal void NotifyObjectPoseSpaceChanged(NetSyncObject obj)
+        {
+            if (obj == null || obj.ObjectId == 0u)
+            {
+                return;
+            }
+
+            if (_objectSyncManager != null) { _objectSyncManager.ClearObjectSnapshots(obj.ObjectId); }
         }
         #endregion ------------------------------------------------------------------------
 
@@ -365,7 +375,23 @@ namespace Styly.NetSync
         /// <summary>
         /// Registers the platform locally, then attaches the local avatar to it.
         /// </summary>
+        [Obsolete("Use AttachLocalAvatarToPlatform(string platformId, GameObject platform).")]
         public bool AttachLocalAvatarToPlatform(GameObject platform, string platformId)
+        {
+            if (platform == null)
+            {
+                Debug.LogWarning("[NetSync] AttachLocalAvatarToPlatform: platform must be non-null.");
+                return false;
+            }
+
+            RegisterPlatform(platformId, platform);
+            return AttachLocalAvatarToPlatform(platformId);
+        }
+
+        /// <summary>
+        /// Registers the platform locally, then attaches the local avatar to it.
+        /// </summary>
+        public bool AttachLocalAvatarToPlatform(string platformId, GameObject platform)
         {
             if (platform == null)
             {
@@ -526,8 +552,7 @@ namespace Styly.NetSync
             // Clear room-scoped state to prevent leaks across rooms
             _messageProcessor?.ClearRoomScopedState();
             _objectSyncManager?.ClearRoomScopedState();
-            _clientPoseSpaceIds.Clear();
-            _objectPoseSpaceIds.Clear();
+            ClearRoomScopedPoseSpaceSelections();
             _timeEstimator.Reset();
             _networkVariableManager?.ResetInitialSyncFlag();
             _avatarManager?.CleanupRemoteAvatars();
@@ -1151,6 +1176,19 @@ namespace Styly.NetSync
             }
         }
 
+        private void ClearClientDrivenSnapshots(int clientNo)
+        {
+            if (_avatarManager != null) { _avatarManager.ClearRemoteAvatarSnapshots(clientNo); }
+            if (_humanPresenceManager != null) { _humanPresenceManager.ClearSnapshots(clientNo); }
+        }
+
+        private void ClearRoomScopedPoseSpaceSelections()
+        {
+            _localAvatarPoseSpaceId = null;
+            _clientPoseSpaceIds.Clear();
+            _objectPoseSpaceIds.Clear();
+        }
+
         private void OnLocalClientNoAssigned(int clientNo)
         {
             _clientNo = clientNo;
@@ -1428,7 +1466,7 @@ namespace Styly.NetSync
                 // Cleanup avatars and presence
                 _avatarManager?.CleanupRemoteAvatars();
                 _humanPresenceManager?.CleanupAll();
-                _clientPoseSpaceIds.Clear();
+                ClearRoomScopedPoseSpaceSelections();
 
                 // Clear error state for next reconnect attempt
                 _connectionManager?.ClearConnectionError();
@@ -1727,6 +1765,10 @@ namespace Styly.NetSync
                 if (poseSpace.TrySpaceToWorld(spacePos, spaceYaw, out var poseSpaceWorldPos, out var poseSpaceWorldYaw))
                 {
                     _humanPresenceManager.UpdateTransform(clientNo, poseSpaceWorldPos, poseSpaceWorldYaw, poseTime, poseSeq);
+                }
+                else
+                {
+                    _humanPresenceManager.UpdateTransform(clientNo, spacePos, spaceYaw, poseTime, poseSeq);
                 }
 
                 return;

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/NetSyncManager.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/NetSyncManager.cs
@@ -184,6 +184,109 @@ namespace Styly.NetSync
         }
 
         /// <summary>
+        /// Registers a pose space backed by a Transform. All peers must use the same ID for the same logical space.
+        /// </summary>
+        public void RegisterPoseSpace(string spaceId, Transform origin)
+        {
+            RegisterPoseSpace(new TransformNetSyncPoseSpace(spaceId, origin));
+        }
+
+        /// <summary>
+        /// Registers a custom pose space. Pose-space selection is intentionally synchronized out-of-band.
+        /// </summary>
+        public void RegisterPoseSpace(INetSyncPoseSpace poseSpace)
+        {
+            if (poseSpace == null || string.IsNullOrEmpty(poseSpace.SpaceId))
+            {
+                return;
+            }
+
+            _poseSpaces[poseSpace.SpaceId] = poseSpace;
+        }
+
+        public void UnregisterPoseSpace(string spaceId)
+        {
+            if (string.IsNullOrEmpty(spaceId) || IsWorldPoseSpaceId(spaceId))
+            {
+                return;
+            }
+
+            _poseSpaces.Remove(spaceId);
+        }
+
+        public void SetDefaultPoseSpace(string spaceId)
+        {
+            _defaultPoseSpaceId = NormalizePoseSpaceId(spaceId);
+            ClearPoseSpaceDrivenSnapshots();
+        }
+
+        public void ClearDefaultPoseSpace()
+        {
+            _defaultPoseSpaceId = null;
+            ClearPoseSpaceDrivenSnapshots();
+        }
+
+        public void SetLocalAvatarPoseSpace(string spaceId)
+        {
+            _localAvatarPoseSpaceId = NormalizePoseSpaceId(spaceId);
+        }
+
+        public void ClearLocalAvatarPoseSpace()
+        {
+            _localAvatarPoseSpaceId = null;
+        }
+
+        public void SetClientPoseSpace(int clientNo, string spaceId)
+        {
+            if (clientNo <= 0)
+            {
+                return;
+            }
+
+            var normalized = NormalizePoseSpaceId(spaceId);
+            if (string.IsNullOrEmpty(normalized))
+            {
+                _clientPoseSpaceIds.Remove(clientNo);
+                if (_avatarManager != null) { _avatarManager.ClearRemoteAvatarSnapshots(clientNo); }
+                return;
+            }
+
+            _clientPoseSpaceIds[clientNo] = normalized;
+            if (_avatarManager != null) { _avatarManager.ClearRemoteAvatarSnapshots(clientNo); }
+        }
+
+        public void ClearClientPoseSpace(int clientNo)
+        {
+            _clientPoseSpaceIds.Remove(clientNo);
+            if (_avatarManager != null) { _avatarManager.ClearRemoteAvatarSnapshots(clientNo); }
+        }
+
+        public void SetObjectPoseSpace(uint objectId, string spaceId)
+        {
+            if (objectId == 0u)
+            {
+                return;
+            }
+
+            var normalized = NormalizePoseSpaceId(spaceId);
+            if (string.IsNullOrEmpty(normalized))
+            {
+                _objectPoseSpaceIds.Remove(objectId);
+                if (_objectSyncManager != null) { _objectSyncManager.ClearObjectSnapshots(objectId); }
+                return;
+            }
+
+            _objectPoseSpaceIds[objectId] = normalized;
+            if (_objectSyncManager != null) { _objectSyncManager.ClearObjectSnapshots(objectId); }
+        }
+
+        public void ClearObjectPoseSpace(uint objectId)
+        {
+            _objectPoseSpaceIds.Remove(objectId);
+            if (_objectSyncManager != null) { _objectSyncManager.ClearObjectSnapshots(objectId); }
+        }
+
+        /// <summary>
         /// Gets all variables for a specific client (for debugging)
         /// </summary>
         public Dictionary<string, string> GetAllClientVariables(int clientNo)
@@ -313,6 +416,8 @@ namespace Styly.NetSync
             // Clear room-scoped state to prevent leaks across rooms
             _messageProcessor?.ClearRoomScopedState();
             _objectSyncManager?.ClearRoomScopedState();
+            _clientPoseSpaceIds.Clear();
+            _objectPoseSpaceIds.Clear();
             _timeEstimator.Reset();
             _networkVariableManager?.ResetInitialSyncFlag();
             _avatarManager?.CleanupRemoteAvatars();
@@ -358,6 +463,11 @@ namespace Styly.NetSync
         private bool _hasInvokedReady = false;
         private bool _shouldCheckReady = false;
         private bool _shouldSendHandshake = false;
+        private readonly Dictionary<string, INetSyncPoseSpace> _poseSpaces = new Dictionary<string, INetSyncPoseSpace>();
+        private readonly Dictionary<int, string> _clientPoseSpaceIds = new Dictionary<int, string>();
+        private readonly Dictionary<uint, string> _objectPoseSpaceIds = new Dictionary<uint, string>();
+        private string _defaultPoseSpaceId;
+        private string _localAvatarPoseSpaceId;
         // Battery monitoring fields
         private float _batteryUpdateInterval = 60.0f; // Update every 60 seconds
         private float _lastBatteryUpdate = 0.0f; // Last time we updated battery level
@@ -860,6 +970,7 @@ namespace Styly.NetSync
 
         private void OnRemoteAvatarDisconnected(int clientNo)
         {
+            _clientPoseSpaceIds.Remove(clientNo);
             OnAvatarDisconnected?.Invoke(clientNo);
         }
 
@@ -1181,6 +1292,7 @@ namespace Styly.NetSync
                 // Cleanup avatars and presence
                 _avatarManager?.CleanupRemoteAvatars();
                 _humanPresenceManager?.CleanupAll();
+                _clientPoseSpaceIds.Clear();
 
                 // Clear error state for next reconnect attempt
                 _connectionManager?.ClearConnectionError();
@@ -1303,6 +1415,91 @@ namespace Styly.NetSync
                 }
             }
         }
+
+        private static bool IsWorldPoseSpaceId(string spaceId)
+        {
+            return string.Equals(spaceId, NetSyncWorldPoseSpace.Instance.SpaceId, StringComparison.Ordinal);
+        }
+
+        private static string NormalizePoseSpaceId(string spaceId)
+        {
+            if (string.IsNullOrEmpty(spaceId) || IsWorldPoseSpaceId(spaceId))
+            {
+                return null;
+            }
+
+            return spaceId;
+        }
+
+        private INetSyncPoseSpace ResolvePoseSpaceById(string spaceId)
+        {
+            if (string.IsNullOrEmpty(spaceId) || IsWorldPoseSpaceId(spaceId))
+            {
+                return NetSyncWorldPoseSpace.Instance;
+            }
+
+            if (_poseSpaces.TryGetValue(spaceId, out var poseSpace) && poseSpace != null)
+            {
+                return poseSpace;
+            }
+
+            return NetSyncWorldPoseSpace.Instance;
+        }
+
+        private INetSyncPoseSpace ResolveDefaultPoseSpace()
+        {
+            return ResolvePoseSpaceById(_defaultPoseSpaceId);
+        }
+
+        internal INetSyncPoseSpace ResolveLocalAvatarPoseSpace()
+        {
+            if (!string.IsNullOrEmpty(_localAvatarPoseSpaceId))
+            {
+                return ResolvePoseSpaceById(_localAvatarPoseSpaceId);
+            }
+
+            return ResolveDefaultPoseSpace();
+        }
+
+        internal INetSyncPoseSpace ResolveClientPoseSpace(int clientNo)
+        {
+            if (clientNo > 0 && _clientPoseSpaceIds.TryGetValue(clientNo, out var spaceId))
+            {
+                return ResolvePoseSpaceById(spaceId);
+            }
+
+            return ResolveDefaultPoseSpace();
+        }
+
+        internal INetSyncPoseSpace ResolveObjectPoseSpace(NetSyncObject obj)
+        {
+            if (obj != null)
+            {
+                var objectId = obj.ObjectId;
+                if (objectId != 0u && _objectPoseSpaceIds.TryGetValue(objectId, out var spaceId))
+                {
+                    return ResolvePoseSpaceById(spaceId);
+                }
+
+                if (!string.IsNullOrEmpty(obj.PoseSpaceId))
+                {
+                    return ResolvePoseSpaceById(obj.PoseSpaceId);
+                }
+            }
+
+            return ResolveDefaultPoseSpace();
+        }
+
+        internal static bool IsWorldPoseSpace(INetSyncPoseSpace poseSpace)
+        {
+            return poseSpace == null || ReferenceEquals(poseSpace, NetSyncWorldPoseSpace.Instance) || IsWorldPoseSpaceId(poseSpace.SpaceId);
+        }
+
+        private void ClearPoseSpaceDrivenSnapshots()
+        {
+            if (_avatarManager != null) { _avatarManager.ClearAllRemoteAvatarSnapshots(); }
+            if (_objectSyncManager != null) { _objectSyncManager.ClearAllObjectSnapshots(); }
+        }
         #endregion ------------------------------------------------------------------------
 
         /// <summary>
@@ -1326,6 +1523,40 @@ namespace Styly.NetSync
             dyawDeg = Mathf.DeltaAngle(yaw0, yaw1);
             var deltaRotation = Quaternion.Euler(0f, dyawDeg, 0f);
             t = p1 - (deltaRotation * p0);
+        }
+
+        internal void ComputeXrOriginDelta(INetSyncPoseSpace poseSpace, out Vector3 t, out float dyawDeg)
+        {
+            if (IsWorldPoseSpace(poseSpace))
+            {
+                ComputeXrOriginDelta(out t, out dyawDeg);
+                return;
+            }
+
+            var p0 = _physicalOffsetPosition;
+            var yaw0 = _physicalOffsetRotation.y;
+            var p1 = p0;
+            var yaw1 = yaw0;
+            if (_XrOriginTransform != null)
+            {
+                p1 = _XrOriginTransform.position;
+                yaw1 = _XrOriginTransform.eulerAngles.y;
+            }
+
+            var r0 = Quaternion.Euler(0f, yaw0, 0f);
+            var r1 = Quaternion.Euler(0f, yaw1, 0f);
+            if (!poseSpace.TryWorldToSpace(p0, r0, out var spaceP0, out var spaceR0) ||
+                !poseSpace.TryWorldToSpace(p1, r1, out var spaceP1, out var spaceR1))
+            {
+                ComputeXrOriginDelta(out t, out dyawDeg);
+                return;
+            }
+
+            var spaceYaw0 = spaceR0.eulerAngles.y;
+            var spaceYaw1 = spaceR1.eulerAngles.y;
+            dyawDeg = Mathf.DeltaAngle(spaceYaw0, spaceYaw1);
+            var deltaRotation = Quaternion.Euler(0f, dyawDeg, 0f);
+            t = spaceP1 - (deltaRotation * spaceP0);
         }
 
         /// <summary>

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/NetSyncObject.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/NetSyncObject.cs
@@ -29,7 +29,20 @@ namespace Styly.NetSync
         public string PoseSpaceId
         {
             get => _poseSpaceId;
-            set => _poseSpaceId = value;
+            set
+            {
+                if (string.Equals(_poseSpaceId, value, System.StringComparison.Ordinal))
+                {
+                    return;
+                }
+
+                _poseSpaceId = value;
+                var manager = NetSyncManager.Instance;
+                if (manager != null)
+                {
+                    manager.NotifyObjectPoseSpaceChanged(this);
+                }
+            }
         }
 
         public bool IsOwnedByMe

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/NetSyncObject.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/NetSyncObject.cs
@@ -18,11 +18,19 @@ namespace Styly.NetSync
         [SerializeField, HideInInspector]
         private bool _manualObjectId;
 
+        [SerializeField, Tooltip("Optional pose space ID used for this object. Leave empty to use the NetSyncManager default pose space.")]
+        private string _poseSpaceId;
+
         private int _ownerClientNo;
         private NetSyncTransformApplier _transformApplier;
 
         public uint ObjectId => _objectId;
         public int OwnerClientNo => _ownerClientNo;
+        public string PoseSpaceId
+        {
+            get => _poseSpaceId;
+            set => _poseSpaceId = value;
+        }
 
         public bool IsOwnedByMe
         {
@@ -99,7 +107,8 @@ namespace Styly.NetSync
                     NetSyncTransformApplier.SpaceMode.World,
                     manager.TimeEstimator,
                     null,
-                    manager.TransformSendRate);
+                    manager.TransformSendRate,
+                    () => manager.ResolveObjectPoseSpace(this));
                 manager.RegisterNetSyncObject(this);
             }
         }

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/NetSyncPoseSpace.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/NetSyncPoseSpace.cs
@@ -1,0 +1,85 @@
+using System;
+using UnityEngine;
+
+namespace Styly.NetSync
+{
+    public interface INetSyncPoseSpace
+    {
+        string SpaceId { get; }
+        bool TryWorldToSpace(Vector3 worldPosition, Quaternion worldRotation, out Vector3 spacePosition, out Quaternion spaceRotation);
+        bool TrySpaceToWorld(Vector3 spacePosition, Quaternion spaceRotation, out Vector3 worldPosition, out Quaternion worldRotation);
+    }
+
+    public sealed class NetSyncWorldPoseSpace : INetSyncPoseSpace
+    {
+        public static readonly NetSyncWorldPoseSpace Instance = new NetSyncWorldPoseSpace();
+
+        public string SpaceId => "world";
+
+        private NetSyncWorldPoseSpace()
+        {
+        }
+
+        public bool TryWorldToSpace(Vector3 worldPosition, Quaternion worldRotation, out Vector3 spacePosition, out Quaternion spaceRotation)
+        {
+            spacePosition = worldPosition;
+            spaceRotation = worldRotation;
+            return true;
+        }
+
+        public bool TrySpaceToWorld(Vector3 spacePosition, Quaternion spaceRotation, out Vector3 worldPosition, out Quaternion worldRotation)
+        {
+            worldPosition = spacePosition;
+            worldRotation = spaceRotation;
+            return true;
+        }
+    }
+
+    public sealed class TransformNetSyncPoseSpace : INetSyncPoseSpace
+    {
+        private readonly string _spaceId;
+        private readonly Transform _origin;
+
+        public string SpaceId => _spaceId;
+        public Transform Origin => _origin;
+
+        public TransformNetSyncPoseSpace(string spaceId, Transform origin)
+        {
+            if (string.IsNullOrEmpty(spaceId))
+            {
+                throw new ArgumentException("Pose space ID cannot be null or empty.", nameof(spaceId));
+            }
+
+            _spaceId = spaceId;
+            _origin = origin;
+        }
+
+        public bool TryWorldToSpace(Vector3 worldPosition, Quaternion worldRotation, out Vector3 spacePosition, out Quaternion spaceRotation)
+        {
+            if (_origin == null)
+            {
+                spacePosition = worldPosition;
+                spaceRotation = worldRotation;
+                return false;
+            }
+
+            spacePosition = _origin.InverseTransformPoint(worldPosition);
+            spaceRotation = Quaternion.Inverse(_origin.rotation) * worldRotation;
+            return true;
+        }
+
+        public bool TrySpaceToWorld(Vector3 spacePosition, Quaternion spaceRotation, out Vector3 worldPosition, out Quaternion worldRotation)
+        {
+            if (_origin == null)
+            {
+                worldPosition = spacePosition;
+                worldRotation = spaceRotation;
+                return false;
+            }
+
+            worldPosition = _origin.TransformPoint(spacePosition);
+            worldRotation = _origin.rotation * spaceRotation;
+            return true;
+        }
+    }
+}

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/NetSyncPoseSpace.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/NetSyncPoseSpace.cs
@@ -6,6 +6,10 @@ namespace Styly.NetSync
     public interface INetSyncPoseSpace
     {
         string SpaceId { get; }
+        /// <summary>
+        /// True when this pose space is the identity world space.
+        /// </summary>
+        bool IsIdentity { get; }
         bool TryWorldToSpace(Vector3 worldPosition, Quaternion worldRotation, out Vector3 spacePosition, out Quaternion spaceRotation);
         bool TrySpaceToWorld(Vector3 spacePosition, Quaternion spaceRotation, out Vector3 worldPosition, out Quaternion worldRotation);
     }
@@ -15,6 +19,7 @@ namespace Styly.NetSync
         public static readonly NetSyncWorldPoseSpace Instance = new NetSyncWorldPoseSpace();
 
         public string SpaceId => "world";
+        public bool IsIdentity => true;
 
         private NetSyncWorldPoseSpace()
         {
@@ -41,6 +46,7 @@ namespace Styly.NetSync
         private readonly Transform _origin;
 
         public string SpaceId => _spaceId;
+        public bool IsIdentity => false;
         public Transform Origin => _origin;
 
         public TransformNetSyncPoseSpace(string spaceId, Transform origin)
@@ -80,6 +86,38 @@ namespace Styly.NetSync
             worldPosition = _origin.TransformPoint(spacePosition);
             worldRotation = _origin.rotation * spaceRotation;
             return true;
+        }
+    }
+
+    internal static class NetSyncPoseMath
+    {
+        public static void ReconstructPhysicalFromHead(
+            Vector3 headPosition,
+            Quaternion headRotation,
+            Vector3 xrOriginDeltaPosition,
+            float xrOriginDeltaYaw,
+            out Vector3 physicalPosition,
+            out Quaternion physicalRotation)
+        {
+            var deltaRot = Quaternion.Euler(0f, xrOriginDeltaYaw, 0f);
+            var invDeltaRot = Quaternion.Inverse(deltaRot);
+            physicalPosition = invDeltaRot * (headPosition - xrOriginDeltaPosition);
+            var headYaw = headRotation.eulerAngles.y;
+            var physicalYaw = Mathf.DeltaAngle(0f, headYaw - xrOriginDeltaYaw);
+            physicalRotation = Quaternion.Euler(0f, physicalYaw, 0f);
+        }
+
+        public static void ApplyXrOriginDelta(
+            Vector3 physicalPosition,
+            Quaternion physicalRotation,
+            Vector3 xrOriginDeltaPosition,
+            float xrOriginDeltaYaw,
+            out Vector3 headPosition,
+            out Quaternion headRotation)
+        {
+            var deltaRot = Quaternion.Euler(0f, xrOriginDeltaYaw, 0f);
+            headPosition = deltaRot * physicalPosition + xrOriginDeltaPosition;
+            headRotation = deltaRot * Quaternion.Euler(0f, physicalRotation.eulerAngles.y, 0f);
         }
     }
 }

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/NetSyncPoseSpace.cs.meta
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/NetSyncPoseSpace.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 5cdc8ebdbf0b54e44a5fd6ef77a8178a


### PR DESCRIPTION
## Summary

Adds a shared pose-space layer to NetSync transform synchronization so apps can opt into non-world coordinate systems without changing the default behavior.

- Adds `INetSyncPoseSpace`, identity world space, and Transform-backed pose spaces.
- Adds `NetSyncManager` APIs to register pose spaces and select default, local avatar, remote client, or object pose spaces.
- Converts local avatar and owned object poses from world to the active pose space before serialization.
- Converts remote avatar and object samples back to local world space at applier tick time, so moving reference spaces such as platforms can keep updating between network samples.
- Clears buffered snapshots when pose-space bindings change to avoid interpreting old samples in a new coordinate frame.

## Why

World-space transform sync breaks when peers do not share the same Unity world origin, such as LBE shared-anchor alignment, and it also cannot cleanly represent movement relative to a moving platform. This change keeps normal world-space sync as the implicit default while giving LBE/platform code a common opt-in conversion layer.

## Scope and Constraints

- The binary v4 pose payload is unchanged and does not carry pose-space IDs.
- Pose-space IDs are synchronized out-of-band by the application, for example via GlobalVariable or ClientVariable.
- Dynamic pose-space switching is only safe after the application has made all peers agree on the active pose-space ID; this PR does not provide packet-level ordering or tag validation for transform frames.
- Object pose-space selection is local state only. Runtime object pose-space changes must be synchronized by app/package code before non-world object poses are sent.
- Python client mixed sessions are world-space compatible. Non-world pose spaces require matching app-level coordination and are not implemented in the Python client in this PR.

## Validation

- `uloop compile --force-recompile false --wait-for-domain-reload true` in `STYLY-NetSync-Unity/` succeeded with 0 errors and 7 pre-existing warnings.

## Notes

- This is the common foundation for LBE venue-space sync and PR #433-style platform binding.
- Platform binding still needs app/package code to agree on each client's active pose-space ID across peers.
