### PR TITLE
[codex] Clarify Unity meta file handling

### DIFF
--- a/.github/instructions/csharp-instructions.md
+++ b/.github/instructions/csharp-instructions.md
@@ -13,4 +13,5 @@ description: "Unity C# coding guidelines and critical rules for the STYLY-NetSyn
   - ✅ **Correct:** `return transform != null ? transform : null;`
 - If Claude produced any `?.` on Unity objects, immediately refactor to explicit null checks.
 - Do **not** call any `UnityEngine` APIs from background threads — all Unity object access must run on the main Unity thread.
-- Don't generate .meta file for Unity C# script. Meta files will be automatically generated once Unity editor is opened.
+- Do not create or edit Unity `.meta` files manually or with an LLM.
+- Commit Unity-generated `.meta` files together with the corresponding new, renamed, or moved asset/script.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,7 +69,8 @@ Key mappings: `NetSyncManager.cs` ↔ `client.py`, `ConnectionManager.cs` ↔ co
 
 - **Never use null propagation (`?.` / `??`) with UnityEngine.Object types**
 - All Unity API calls must be on main thread — no background thread access
-- Do not add `.meta` files manually
+- Do not create or edit Unity `.meta` files manually or with an LLM.
+- Commit Unity-generated `.meta` files together with the corresponding new, renamed, or moved asset/script.
 - Namespace: `Styly.NetSync` (public) / `Styly.NetSync.Internal` (internal)
 - Naming: private fields `_camelCase`, public `PascalCase`, 4-space indent
 


### PR DESCRIPTION
## Summary
- Clarify that Unity `.meta` files must not be created or edited manually or with an LLM.
- Clarify that Unity-generated `.meta` files should be committed with corresponding new, renamed, or moved assets/scripts.
- Align the root agent instructions and GitHub C# instructions to avoid future review confusion.

## Validation
- Documentation-only change; no tests run.