### PR TITLE
[codex] docs: document sibling project context

### DIFF
--- a/STYLY-NetSync-Server/AGENTS.md
+++ b/STYLY-NetSync-Server/AGENTS.md
@@ -6,18 +6,10 @@
 - **Tests**: `tests/` (unit + integration)
 - **Config**: `pyproject.toml`, `default.toml`
 
-## Sibling Project Context
+## Repository Context
 
-This Python server is one half of the STYLY-NetSync repository. When Codex is
-started with `STYLY-NetSync-Server/` as the current directory, also treat
-`../STYLY-NetSync-Unity/` as relevant project context when it is available.
-
-- Use `../AGENTS.md` for repository-wide protocol, parity, and workflow rules.
-- Inspect `../STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/`
-  for Unity client behavior before changing networking, protocol serialization,
-  RPC, Network Variable, discovery, or connection behavior.
-- Keep Python and Unity feature parity in mind even when the immediate task
-  starts from the server directory.
+- Also check `../AGENTS.md` and `../STYLY-NetSync-Unity/`.
+- Keep Python/Unity behavior aligned for networking, protocol, RPC, Network Variable, discovery, and connection changes.
 
 ## Development Commands
 

--- a/STYLY-NetSync-Server/AGENTS.md
+++ b/STYLY-NetSync-Server/AGENTS.md
@@ -6,6 +6,19 @@
 - **Tests**: `tests/` (unit + integration)
 - **Config**: `pyproject.toml`, `default.toml`
 
+## Sibling Project Context
+
+This Python server is one half of the STYLY-NetSync repository. When Codex is
+started with `STYLY-NetSync-Server/` as the current directory, also treat
+`../STYLY-NetSync-Unity/` as relevant project context when it is available.
+
+- Use `../AGENTS.md` for repository-wide protocol, parity, and workflow rules.
+- Inspect `../STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/`
+  for Unity client behavior before changing networking, protocol serialization,
+  RPC, Network Variable, discovery, or connection behavior.
+- Keep Python and Unity feature parity in mind even when the immediate task
+  starts from the server directory.
+
 ## Development Commands
 
 ```bash

--- a/STYLY-NetSync-Unity/AGENTS.md
+++ b/STYLY-NetSync-Unity/AGENTS.md
@@ -17,18 +17,10 @@
   - `Assets/Samples_Dev/HandTest/` - Hand tracking testing
   - `Assets/Samples_Dev/SimpleSyncCheck/` - Network sync verification
 
-## Sibling Project Context
+## Repository Context
 
-This Unity project is one half of the STYLY-NetSync repository. When Codex is
-started with `STYLY-NetSync-Unity/` as the current directory, also treat
-`../STYLY-NetSync-Server/` as relevant project context when it is available.
-
-- Use `../AGENTS.md` for repository-wide protocol, parity, and workflow rules.
-- Inspect `../STYLY-NetSync-Server/src/styly_netsync/` for Python server and
-  Python client behavior before changing networking, protocol serialization,
-  RPC, Network Variable, discovery, or connection behavior.
-- Keep Unity and Python feature parity in mind even when the immediate task
-  starts from the Unity directory.
+- Also check `../AGENTS.md` and `../STYLY-NetSync-Server/`.
+- Keep Unity/Python behavior aligned for networking, protocol, RPC, Network Variable, discovery, and connection changes.
 
 ## Development
 

--- a/STYLY-NetSync-Unity/AGENTS.md
+++ b/STYLY-NetSync-Unity/AGENTS.md
@@ -17,6 +17,19 @@
   - `Assets/Samples_Dev/HandTest/` - Hand tracking testing
   - `Assets/Samples_Dev/SimpleSyncCheck/` - Network sync verification
 
+## Sibling Project Context
+
+This Unity project is one half of the STYLY-NetSync repository. When Codex is
+started with `STYLY-NetSync-Unity/` as the current directory, also treat
+`../STYLY-NetSync-Server/` as relevant project context when it is available.
+
+- Use `../AGENTS.md` for repository-wide protocol, parity, and workflow rules.
+- Inspect `../STYLY-NetSync-Server/src/styly_netsync/` for Python server and
+  Python client behavior before changing networking, protocol serialization,
+  RPC, Network Variable, discovery, or connection behavior.
+- Keep Unity and Python feature parity in mind even when the immediate task
+  starts from the Unity directory.
+
 ## Development
 
 - **Play Mode**: Test in Unity Editor with demo scenes


### PR DESCRIPTION
## Summary

- Document that `STYLY-NetSync-Unity/` should treat `../STYLY-NetSync-Server/` as relevant sibling context when Codex starts from the Unity directory.
- Document that `STYLY-NetSync-Server/` should treat `../STYLY-NetSync-Unity/` as relevant sibling context when Codex starts from the server directory.
- Point both subproject instructions back to the repository-wide `../AGENTS.md` rules.

## Validation

- `git diff --cached --check`
- Documentation-only change; no runtime tests run.