### PR TITLE
refactor: remove unused private/internal code and dead comments

### DIFF
--- a/STYLY-NetSync-Server/src/styly_netsync/client.py
+++ b/STYLY-NetSync-Server/src/styly_netsync/client.py
@@ -166,7 +166,6 @@ class net_sync_manager:
         self._sub_port = sub_port
         self._room = room
         self._auto_dispatch = auto_dispatch
-        self._queue_max = queue_max
         self._reconnect_delay = reconnect_delay
         self._receive_timeout = receive_timeout
 

--- a/STYLY-NetSync-Server/src/styly_netsync/rest_bridge.py
+++ b/STYLY-NetSync-Server/src/styly_netsync/rest_bridge.py
@@ -284,7 +284,6 @@ def create_app(
     """Create the FastAPI application hosting the REST bridge."""
     app = FastAPI(title="NetSync REST Bridge", version="1.0.0")
 
-    # Add CORS middleware
     app.add_middleware(
         CORSMiddleware,
         allow_origins=["*"],

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/AvatarManager.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/AvatarManager.cs
@@ -19,11 +19,6 @@ namespace Styly.NetSync
         private NetSyncAvatar _localAvatar;
         private bool _enableDebugLogs;
 
-        // Hand pose normalizer references for tracking state events
-        private HandPoseNormalizer _leftHandNormalizer;
-        private HandPoseNormalizer _rightHandNormalizer;
-
-        public UnityEvent<int> OnAvatarConnected { get; } = new();
         public UnityEvent<int> OnAvatarDisconnected { get; } = new();
 
         public NetSyncAvatar LocalAvatar => _localAvatar;
@@ -285,7 +280,6 @@ namespace Styly.NetSync
 
                 // Subscribe to hand tracking state changes
                 rightNormalizer.OnTrackingStateChanged += HandleHandTrackingStateChanged;
-                _rightHandNormalizer = rightNormalizer;
             }
 
             if (leftHand != null)
@@ -320,7 +314,6 @@ namespace Styly.NetSync
 
                 // Subscribe to hand tracking state changes
                 leftNormalizer.OnTrackingStateChanged += HandleHandTrackingStateChanged;
-                _leftHandNormalizer = leftNormalizer;
             }
         }
 

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/BinarySerializer.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/BinarySerializer.cs
@@ -651,8 +651,6 @@ namespace Styly.NetSync
 
                 switch (messageType)
                 {
-                    // case MSG_CLIENT_TRANSFORM:
-                    //     return (messageType, DeserializeClientTransform(reader));
                     case MSG_ROOM_POSE:
                         return (messageType, DeserializeRoomTransform(reader));
                     case MSG_RPC:

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/NetSyncSmoothing.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/NetSyncSmoothing.cs
@@ -221,7 +221,6 @@ namespace Styly.NetSync
     {
         public SampleState State;
         public PoseSampleData Target;
-        public double SnapshotDt;
         public float LinearSpeed;
         public float AngularSpeedDeg;
     }
@@ -238,7 +237,6 @@ namespace Styly.NetSync
         }
 
         public int Count => _count;
-        public PoseSnapshot Oldest => _items[0];
         public PoseSnapshot Newest => _items[_count - 1];
 
         public void Clear()
@@ -545,7 +543,6 @@ namespace Styly.NetSync
                 {
                     State = SampleState.Interpolating,
                     Target = target,
-                    SnapshotDt = dt,
                     LinearSpeed = linearSpeed,
                     AngularSpeedDeg = angularSpeed
                 };
@@ -563,7 +560,6 @@ namespace Styly.NetSync
                 {
                     State = SampleState.Extrapolating,
                     Target = target,
-                    SnapshotDt = dt,
                     LinearSpeed = linearSpeed,
                     AngularSpeedDeg = angularSpeed
                 };
@@ -573,7 +569,6 @@ namespace Styly.NetSync
             {
                 State = SampleState.HoldSingle,
                 Target = b.Pose,
-                SnapshotDt = dt,
                 LinearSpeed = linearSpeed,
                 AngularSpeedDeg = angularSpeed
             };

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/ServerDiscoveryManager.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/ServerDiscoveryManager.cs
@@ -13,7 +13,6 @@ namespace Styly.NetSync
 {
     internal class ServerDiscoveryManager
     {
-        private UdpClient _discoveryClient; // Legacy: points to first client for backward compat
         private List<UdpClient> _discoveryClients = new List<UdpClient>();
         private Thread _discoveryThread;
         private bool _isDiscovering;
@@ -107,9 +106,6 @@ namespace Styly.NetSync
                     _discoveryClients.Add(fallback);
                     DebugLog("Using fallback unbound discovery socket");
                 }
-
-                // Keep legacy field pointing to first client
-                _discoveryClient = _discoveryClients[0];
 
                 // Start discovery thread that sends requests and waits for responses
                 _discoveryThread = new Thread(() =>
@@ -543,7 +539,6 @@ namespace Styly.NetSync
                     catch (Exception) { /* best-effort cleanup */ }
                 }
                 _discoveryClients.Clear();
-                _discoveryClient = null;
 
                 // Wait for discovery thread to exit
                 if (_discoveryThread != null)

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/TransformSyncManager.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/TransformSyncManager.cs
@@ -128,11 +128,6 @@ namespace Styly.NetSync
             }
         }
 
-        public void IncrementMessagesSent()
-        {
-            _messagesSent++;
-        }
-
         public bool ShouldSendTransform(float currentTime)
         {
             return currentTime - _lastSendTime >= 1f / SendRate;

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/NetSyncAvatar.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/NetSyncAvatar.cs
@@ -1,5 +1,4 @@
 // NetSyncAvatar.cs
-using System;
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.Events;

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/NetSyncManager.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/NetSyncManager.cs
@@ -75,7 +75,6 @@ namespace Styly.NetSync
         internal Transform _XrOriginTransform;
         internal Vector3 _physicalOffsetPosition;
         internal Vector3 _physicalOffsetRotation;
-        private Styly.XRRig.StylyXrRig stylyXrRig;
 
         #region === Singleton & Public API ===
         private static NetSyncManager _instance;
@@ -539,12 +538,6 @@ namespace Styly.NetSync
         private volatile Exception _pendingConnectionException;
 
         /// <summary>
-        /// Unix timestamp (milliseconds) when the last connection error occurred.
-        /// Written on receive thread, read on main thread. Stored via Interlocked for visibility.
-        /// </summary>
-        private long _pendingConnectionErrorAtUnixMs;
-
-        /// <summary>
         /// Re-entrancy guard for ProcessPendingConnectionErrorOnMainThread.
         /// Main-thread only, prevents concurrent error handling.
         /// </summary>
@@ -661,8 +654,6 @@ namespace Styly.NetSync
                 _physicalOffsetPosition = rigTransform.position;
                 _physicalOffsetRotation = rigTransform.eulerAngles;
             }
-
-            stylyXrRig = FindFirstObjectByType<Styly.XRRig.StylyXrRig>();
         }
 
         private void OnEnable()
@@ -1328,16 +1319,6 @@ namespace Styly.NetSync
         {
             // Statistics logging is currently disabled
             // Uncomment to enable periodic statistics logging
-            /*
-            if (_enableDebugLogs && Time.time - _lastLogTime >= 5f)
-            {
-                var sent = _transformSyncManager.MessagesSent;
-                var recv = _messageProcessor.MessagesReceived;
-                var peers = _playerManager.ConnectedPeers.Count;
-                DebugLog($"Stats — Sent:{sent} Recv:{recv} Peers:{peers}");
-                _lastLogTime = Time.time;
-            }
-            */
         }
         #endregion ------------------------------------------------------------------------
 
@@ -1444,10 +1425,8 @@ namespace Styly.NetSync
             if (_connectionManager != null)
             {
                 // Read volatile fields - they are written in order (timestamp first, then exception)
-                var timestamp = _connectionManager.LastExceptionAtUnixMs;
                 var exception = _connectionManager.LastException;
 
-                System.Threading.Interlocked.Exchange(ref _pendingConnectionErrorAtUnixMs, timestamp);
                 _pendingConnectionException = exception;
             }
 


### PR DESCRIPTION
## Summary

Conservative dead-code cleanup (deletions only) across the Unity client and Python server — **9 files, 48 deletions, 0 additions**. Removes unused private/internal symbols, dead stores, an unused \`using\`, dead commented-out code, and one redundant comment. No public API, protocol, or Unity↔Python parity changes.

## Changes
- **client.py**: drop unused \`self._queue_max\` assignment (\`queue_max\` param retained, still used for queue sizing)
- **rest_bridge.py**: remove redundant \`# Add CORS middleware\` comment
- **AvatarManager.cs**: remove write-only \`_leftHandNormalizer\`/\`_rightHandNormalizer\` fields and unused internal \`OnAvatarConnected\` (distinct from the public \`NetSyncManager.OnAvatarConnected\`, which is untouched)
- **BinarySerializer.cs**: remove commented-out \`MSG_CLIENT_TRANSFORM\` case (constant & range-validation kept)
- **NetSyncSmoothing.cs**: remove write-only \`SnapshotDt\` field + initializers and unused \`Oldest\` property
- **ServerDiscoveryManager.cs**: remove legacy \`_discoveryClient\` field and its dead stores (\`_discoveryClients\` list is the live data)
- **TransformSyncManager.cs**: remove uncalled \`IncrementMessagesSent()\` (\`_messagesSent\`/\`MessagesSent\` intact)
- **NetSyncAvatar.cs**: remove unused \`using System;\`
- **NetSyncManager.cs**: remove unused \`stylyXrRig\` field + \`FindFirstObjectByType\` call, write-only \`_pendingConnectionErrorAtUnixMs\`, and a dead \`/* */\` comment block

## Test evidence
- Python: \`ruff check src/\` → All checks passed; \`mypy src/\` → Success (15 files); \`py_compile\` OK
- Reviewed by 4 models (review-netsync, Claude built-in /review, Codex gpt-5.5, Copilot GPT-5.4): no Critical/High; all "verify reference" flags confirmed unreferenced repo-wide
- Generated via the \`dead-code-cleanup\` workflow with adversarial per-finding verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)