### PR TITLE
[codex] Support multiple NetSync MovingFloors

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,15 +36,15 @@ black src/ tests/ && ruff check src/ tests/ && mypy src/ && pytest --cov=src
 
 - **Server**: Multi-threaded Python (receive, periodic, discovery threads) with ZeroMQ DEALER-ROUTER + PUB-SUB and group-based room management
 - **Unity Client**: Manager pattern with internal components (connection, transform sync, RPC, network variables, avatars)
-- **Protocol**: Binary v6 with quantized positions and smallest-three quaternion compression
+- **Protocol**: Binary v7 with quantized positions and smallest-three quaternion compression
 - **Technology**: Python 3.11+ / pyzmq / FastAPI / msgpack (server), Unity 6 / NetMQ / Newtonsoft.Json (client)
 
 ## Protocol Rules
 
-- Binary protocol is `protocolVersion=6` only (earlier versions removed); the version byte rides on transform/object messages and bumps on any breaking wire change, including Network Variable message changes
+- Binary protocol is `protocolVersion=7` only (earlier versions removed); the version byte rides on transform/object messages and bumps on any breaking wire change, including Network Variable message changes
 - Message IDs: `MSG_CLIENT_POSE=11`, `MSG_ROOM_POSE=12`, `MSG_CLIENT_VAR_CLEAR=18`
 - Unbound `Head` is absolute; `Right/Left/Virtual` are head-relative
-- Moving-floor-local poses set `PoseFlags.MovingFloorLocal`; `Head` is moving-floor local while `Right/Left/Virtual` remain head-relative within that floor
+- Moving-floor-local poses set `PoseFlags.MovingFloorLocal` and include the moving floor's 32-bit Floor ID in the pose body; `Head` is moving-floor local while `Right/Left/Virtual` remain head-relative within that floor
 - Unbound `xrOriginDelta` is `(dx, dy, dz, dyaw)` quantized as 4×`int16` (`LOCO_POS_SCALE = 0.01m` for translation, `PHYSICAL_YAW_SCALE = 0.1°` for yaw); receivers reconstruct physical pose as `physical = invDeltaRot * (headPos − deltaPos)`
 - Moving-floor-local poses reuse the same 8-byte physical slot as direct physical position/yaw instead of `xrOriginDelta`
 - Position quantization: absolute `int24 @ 0.01m`, head-relative `int16 @ 0.005m`; out-of-range values clamped

--- a/STYLY-NetSync-Server/AGENTS.md
+++ b/STYLY-NetSync-Server/AGENTS.md
@@ -32,7 +32,7 @@ styly-netsync-simulator --clients 100 --server localhost --room default_room
 ## Architecture
 
 - **NetSyncServer** (`server.py`): Multi-threaded (receive, periodic, discovery threads)
-- **BinarySerializer** (`binary_serializer.py`): Protocol v5 transform serializer
+- **BinarySerializer** (`binary_serializer.py`): Protocol v7 transform serializer
 - **Python Client API** (`client.py`): `net_sync_manager` class for Python clients
 - **REST Bridge** (`rest_bridge.py`): FastAPI REST API for external integrations
 

--- a/STYLY-NetSync-Server/README.md
+++ b/STYLY-NetSync-Server/README.md
@@ -42,13 +42,13 @@ styly-netsync-simulator --server tcp://localhost --room my_room --clients 50
 
 ## Wire protocol compatibility
 
-- Current transform wire protocol is `protocolVersion = 5`.
-- Transform messages use `MSG_CLIENT_POSE` (11) and `MSG_ROOM_POSE` (12) with the compact V5 pose body.
-- v5 adds an optional `MovingFloorLocal` pose flag. Bound avatars send head, hands, and virtual transforms in the registered moving floor's local coordinates, and reuse the existing 8-byte physical slot as direct physical position/yaw.
-- Unbound v5 poses keep the v4 `xrOriginDelta` semantics: `xrOriginDelta` carries a Y component as a 4th `int16` (`dx, dy, dz, dyaw` = 8 bytes vs. v3's 6), so receivers can reconstruct the sender's rig-Y motion.
+- Current transform wire protocol is `protocolVersion = 7`.
+- Transform messages use `MSG_CLIENT_POSE` (11) and `MSG_ROOM_POSE` (12) with the compact V7 pose body.
+- v7 `MovingFloorLocal` pose bodies include the sender's 32-bit Floor ID. Bound avatars send head, hands, and virtual transforms in that registered moving floor's local coordinates, and reuse the existing 8-byte physical slot as direct physical position/yaw.
+- Unbound v7 poses keep the `xrOriginDelta` semantics: `xrOriginDelta` carries a Y component as a 4th `int16` (`dx, dy, dz, dyaw` = 8 bytes), so receivers can reconstruct the sender's rig-Y motion.
 - Legacy transform protocols (v2/v3) and JSON transform fallback are not supported.
 - Deploy Unity and Python updates together when changing transform protocol behavior.
-- Protocol v5 position quantization ranges:
+- Protocol v7 position quantization ranges:
   - Absolute (`headPosAbs` only): signed `int24` at `0.01 m` per unit, per-axis range `[-83,886.08 m, 83,886.07 m]`.
   - XROrigin locomotion delta for unbound poses (`xrOriginDelta`, 4×`int16`: `dx, dy, dz, dyaw`): `0.01 m` per unit for translation, `0.1°` for yaw. Receivers reconstruct `physicalPos = invDeltaRot * (headPos − deltaPos)`; it is not on the wire as a separate absolute field.
   - Direct physical payload for moving-floor-local poses (`physical`, 4×`int16`: `x, y, z, yaw`): `0.01 m` per unit for translation, `0.1°` for yaw.
@@ -59,9 +59,10 @@ styly-netsync-simulator --server tcp://localhost --room my_room --clients 50
 
 The following options summarize trade-offs when expanding absolute-position range.
 
-Assumed unbound baseline (`protocolVersion=5`, `MovingFloorLocal` off):
+Assumed unbound baseline (`protocolVersion=7`, `MovingFloorLocal` off):
 - Client pose body with `Physical+Head+Right+Left` valid and `virtualCount=0`: `46 bytes` (matches `test_client_body_size_with_full_pose_no_virtuals`).
 - Room per-client entry (`clientNo + poseTime + clientBody`): `56 bytes`.
+- Moving-floor-local baseline adds `movingFloorId` (`uint32`): `50 bytes` per client pose body and `60 bytes` per room client entry.
 
 | Option | Absolute Position Encoding | Per-axis Range | Client Body Delta | Room Per-client Delta |
 |---|---|---:|---:|---:|

--- a/STYLY-NetSync-Server/src/styly_netsync/adapters.py
+++ b/STYLY-NetSync-Server/src/styly_netsync/adapters.py
@@ -52,6 +52,8 @@ def client_transform_to_wire(ct: client_transform_data) -> dict[str, Any]:
         result["poseSeq"] = ct.pose_seq
     if ct.flags is not None:
         result["flags"] = ct.flags
+    if ct.moving_floor_id is not None:
+        result["movingFloorId"] = ct.moving_floor_id
     if ct.physical is not None:
         result["physical"] = transform_to_wire(ct.physical)
     if ct.head is not None:
@@ -75,6 +77,7 @@ def client_transform_from_wire(data: dict[str, Any]) -> client_transform_data:
     result.pose_time = data.get("poseTime")
     result.pose_seq = data.get("poseSeq")
     result.flags = data.get("flags")
+    result.moving_floor_id = data.get("movingFloorId")
 
     if "physical" in data and data["physical"]:
         result.physical = transform_from_wire(data["physical"])

--- a/STYLY-NetSync-Server/src/styly_netsync/binary_serializer.py
+++ b/STYLY-NetSync-Server/src/styly_netsync/binary_serializer.py
@@ -6,10 +6,10 @@ from typing import Any
 logger = logging.getLogger(__name__)
 
 # Message type identifiers
-# v6: Network Variable wire messages dropped the per-write timestamp field.
+# v7: MovingFloorLocal pose bodies carry the sender's moving floor id.
 # Bumped so mixed old/new builds fail the handshake instead of silently
-# misparsing NV traffic (the version byte rides on transform/object messages).
-PROTOCOL_VERSION = 6
+# projecting floor-local poses through the wrong registered floor.
+PROTOCOL_VERSION = 7
 MSG_CLIENT_TRANSFORM = 1
 MSG_ROOM_TRANSFORM = 2  # Legacy room transform with short IDs only
 MSG_RPC = 3  # Remote procedure call
@@ -36,7 +36,7 @@ MSG_CLIENT_VAR_CLEAR = 18  # Clear all client variables for the sender
 _max_virtual_transforms = 50
 MAX_VIRTUAL_TRANSFORMS = _max_virtual_transforms  # Legacy alias for backward compat
 
-# Protocol v5 transform encoding constants
+# Protocol v7 transform encoding constants
 ABS_POS_SCALE = 0.01
 LOCO_POS_SCALE = 0.01
 REL_POS_SCALE = 0.005
@@ -385,7 +385,7 @@ def _create_transform_dict(
 
 
 def _serialize_client_body(buffer: bytearray, client: dict[str, Any]) -> None:
-    """Serialize a client body in protocol v5 compact format."""
+    """Serialize a client body in protocol v7 compact format."""
     pose_seq = int(client.get("poseSeq", 0)) & 0xFFFF
     head = client.get("head", {}) or {}
     right = client.get("rightHand", {}) or {}
@@ -435,6 +435,10 @@ def _serialize_client_body(buffer: bytearray, client: dict[str, Any]) -> None:
     left_valid = head_valid and bool(flags & POSE_FLAG_LEFT_VALID)
     virtual_valid = head_valid and bool(flags & POSE_FLAG_VIRTUALS_VALID)
     moving_floor_local = bool(flags & POSE_FLAG_MOVING_FLOOR_LOCAL)
+
+    if moving_floor_local:
+        moving_floor_id = int(client.get("movingFloorId", 0)) & 0xFFFFFFFF
+        buffer.extend(struct.pack("<I", moving_floor_id))
 
     xr_origin_delta_x = float(client.get("xrOriginDeltaX", 0.0))
     xr_origin_delta_y = float(client.get("xrOriginDeltaY", 0.0))
@@ -891,7 +895,7 @@ def deserialize(data: bytes) -> tuple[int, dict[str, Any] | None, bytes]:
 
 
 def _deserialize_client_body(data: bytes, offset: int) -> tuple[dict[str, Any], int]:
-    """Deserialize protocol v5 compact pose body."""
+    """Deserialize protocol v7 compact pose body."""
     result: dict[str, Any] = {}
     result["poseSeq"] = struct.unpack("<H", data[offset : offset + 2])[0]
     offset += 2
@@ -908,6 +912,10 @@ def _deserialize_client_body(data: bytes, offset: int) -> tuple[dict[str, Any], 
     left_valid = head_valid and bool(flags & POSE_FLAG_LEFT_VALID)
     virtual_valid = head_valid and bool(flags & POSE_FLAG_VIRTUALS_VALID)
     moving_floor_local = bool(flags & POSE_FLAG_MOVING_FLOOR_LOCAL)
+    moving_floor_id = 0
+    if moving_floor_local:
+        moving_floor_id = struct.unpack("<I", data[offset : offset + 4])[0]
+        offset += 4
 
     physical = _create_transform_dict(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, True)
     head = _create_transform_dict(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, moving_floor_local)
@@ -1114,6 +1122,7 @@ def _deserialize_client_body(data: bytes, offset: int) -> tuple[dict[str, Any], 
     result["xrOriginDeltaY"] = xr_origin_delta_y
     result["xrOriginDeltaZ"] = xr_origin_delta_z
     result["xrOriginDeltaYaw"] = xr_origin_delta_yaw
+    result["movingFloorId"] = moving_floor_id
     result["physical"] = physical
     result["head"] = head
     result["rightHand"] = right
@@ -1123,7 +1132,7 @@ def _deserialize_client_body(data: bytes, offset: int) -> tuple[dict[str, Any], 
 
 
 def _deserialize_client_transform(data: bytes, offset: int) -> dict[str, Any]:
-    """Deserialize client pose (v5) from binary data."""
+    """Deserialize client pose (v7) from binary data."""
     result: dict[str, Any] = {}
 
     protocol_version = data[offset]
@@ -1161,7 +1170,7 @@ def _deserialize_rpc_message(data: bytes, offset: int) -> dict[str, Any]:
 
 
 def _deserialize_room_transform(data: bytes, offset: int) -> dict[str, Any]:
-    """Deserialize room pose (v5) with client numbers only."""
+    """Deserialize room pose (v7) with client numbers only."""
     result: dict[str, Any] = {}
 
     protocol_version = data[offset]

--- a/STYLY-NetSync-Server/src/styly_netsync/server.py
+++ b/STYLY-NetSync-Server/src/styly_netsync/server.py
@@ -1067,7 +1067,7 @@ class NetSyncServer:
                         except UnicodeDecodeError as e:
                             logger.error(f"Failed to decode room ID: {e}")
                             continue
-                        # Protocol v5 binary-only handling (no JSON fallback)
+                        # Protocol v7 binary-only handling (no JSON fallback)
                         try:
                             msg_type, data, raw_payload = binary_serializer.deserialize(
                                 message_bytes
@@ -1142,7 +1142,7 @@ class NetSyncServer:
                                 logger.warning(f"Unknown binary msg_type: {msg_type}")
                         except Exception as e:
                             logger.warning(
-                                "Failed to decode protocol v5 message from room %s: %s",
+                                "Failed to decode protocol v7 message from room %s: %s",
                                 room_id,
                                 e,
                             )

--- a/STYLY-NetSync-Server/src/styly_netsync/types.py
+++ b/STYLY-NetSync-Server/src/styly_netsync/types.py
@@ -30,6 +30,7 @@ class client_transform_data:
     pose_time: float | None = None
     pose_seq: int | None = None
     flags: int | None = None
+    moving_floor_id: int | None = None
     physical: transform_data | None = None
     head: transform_data | None = None
     right_hand: transform_data | None = None

--- a/STYLY-NetSync-Server/tests/test_binary_serializer.py
+++ b/STYLY-NetSync-Server/tests/test_binary_serializer.py
@@ -288,12 +288,12 @@ def _reconstruct_physical_from_head_and_delta(
     return (px, ty, pz), physical_rot
 
 
-class TestTransformSerializationV5:
-    """Tests for protocol v6 transform compact serialization."""
+class TestTransformSerializationV7:
+    """Tests for protocol v7 transform compact serialization."""
 
-    def test_protocol_version_is_v6(self) -> None:
-        """Protocol version constant should be at v6."""
-        assert binary_serializer.PROTOCOL_VERSION == 6
+    def test_protocol_version_is_v7(self) -> None:
+        """Protocol version constant should be at v7."""
+        assert binary_serializer.PROTOCOL_VERSION == 7
 
     def test_client_roundtrip_without_flags_infers_valid_bits(self) -> None:
         """Serializer should infer valid bits when flags are omitted."""
@@ -418,7 +418,7 @@ class TestTransformSerializationV5:
 
             assert msg_type == binary_serializer.MSG_CLIENT_POSE
             assert decoded is not None
-            assert decoded["protocolVersion"] == 6
+            assert decoded["protocolVersion"] == 7
             assert len(raw) > 0
 
             o_head = original["head"]
@@ -640,8 +640,8 @@ class TestTransformSerializationV5:
         )
         assert len(raw) == 46
 
-    def test_moving_floor_local_body_size_matches_unbound(self) -> None:
-        """Moving-floor-local pose should not add bytes to the pose body."""
+    def test_moving_floor_local_body_size_adds_floor_id(self) -> None:
+        """Moving-floor-local pose should add one uint32 floor id to the pose body."""
         rng = random.Random(4242)
         unbound = _build_random_client_pose(rng, virtual_count=0)
         unbound["flags"] = (
@@ -654,6 +654,7 @@ class TestTransformSerializationV5:
         bound["flags"] = (
             unbound["flags"] | binary_serializer.POSE_FLAG_MOVING_FLOOR_LOCAL
         )
+        bound["movingFloorId"] = 0xAABBCCDD
         bound["physical"] = _build_transform(
             (0.15, 1.62, -0.08),
             (
@@ -672,7 +673,7 @@ class TestTransformSerializationV5:
         )
 
         assert len(unbound_raw) == 46
-        assert len(bound_raw) == len(unbound_raw)
+        assert len(bound_raw) == len(unbound_raw) + 4
 
     def test_moving_floor_local_roundtrip_uses_direct_physical(self) -> None:
         """Bound poses use direct physical pose and keep head-relative channels intact."""
@@ -694,6 +695,7 @@ class TestTransformSerializationV5:
                 | binary_serializer.POSE_FLAG_VIRTUALS_VALID
                 | binary_serializer.POSE_FLAG_MOVING_FLOOR_LOCAL
             ),
+            "movingFloorId": 0x11223344,
             "xrOriginDeltaX": 99.0,
             "xrOriginDeltaY": 99.0,
             "xrOriginDeltaZ": 99.0,
@@ -720,6 +722,7 @@ class TestTransformSerializationV5:
         )
         assert decoded is not None
         assert decoded["flags"] & binary_serializer.POSE_FLAG_MOVING_FLOOR_LOCAL
+        assert decoded["movingFloorId"] == 0x11223344
         assert (
             decoded["encodingFlags"]
             & binary_serializer.ENCODING_PHYSICAL_IS_XRORIGIN_DELTA
@@ -813,7 +816,7 @@ class TestTransformSerializationV5:
         c2["poseTime"] = 223.456
 
         room_payload = {
-            "roomId": "room-v5",
+            "roomId": "room-v7",
             "broadcastTime": 999.123,
             "clients": [c1, c2],
         }
@@ -822,8 +825,8 @@ class TestTransformSerializationV5:
 
         assert msg_type == binary_serializer.MSG_ROOM_POSE
         assert decoded is not None
-        assert decoded["protocolVersion"] == 6
-        assert decoded["roomId"] == "room-v5"
+        assert decoded["protocolVersion"] == 7
+        assert decoded["roomId"] == "room-v7"
         assert len(decoded["clients"]) == 2
 
         for src, dst in zip(room_payload["clients"], decoded["clients"], strict=True):
@@ -845,6 +848,7 @@ class TestTransformSerializationV5:
         bound["flags"] = (
             int(bound["flags"]) | binary_serializer.POSE_FLAG_MOVING_FLOOR_LOCAL
         )
+        bound["movingFloorId"] = 0x55667788
         bound["physical"] = _build_transform(
             (0.2, 1.65, 0.05),
             (
@@ -869,6 +873,7 @@ class TestTransformSerializationV5:
         assert len(decoded["clients"]) == 1
         client = decoded["clients"][0]
         assert client["flags"] & binary_serializer.POSE_FLAG_MOVING_FLOOR_LOCAL
+        assert client["movingFloorId"] == 0x55667788
         assert (
             client["encodingFlags"]
             & binary_serializer.ENCODING_PHYSICAL_IS_XRORIGIN_DELTA

--- a/STYLY-NetSync-Unity/AGENTS.md
+++ b/STYLY-NetSync-Unity/AGENTS.md
@@ -36,7 +36,7 @@
 - **TransformSyncManager**: Transform sync with SendRate cap, only-on-change filtering, 1Hz idle heartbeat
 - **RPCManager**: Remote procedure calls with priority-based sending and targeted delivery
 - **NetworkVariableManager**: Synchronized key-value storage
-- **BinarySerializer**: Protocol v6 pose serialization/deserialization
+- **BinarySerializer**: Protocol v7 pose serialization/deserialization
 - **MessageProcessor**: Binary protocol message handling
 - **AvatarManager**: Player spawn/despawn management
 

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/BinarySerializer.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/BinarySerializer.cs
@@ -7,10 +7,10 @@ namespace Styly.NetSync
 {
     internal static class BinarySerializer
     {
-        // v6: Network Variable wire messages dropped the per-write timestamp field.
+        // v7: MovingFloorLocal pose bodies carry the sender's moving floor id.
         // Bumped so mixed old/new builds fail the handshake instead of silently
-        // misparsing NV traffic (the version byte rides on transform/object messages).
-        public const byte PROTOCOL_VERSION = 6;
+        // projecting floor-local poses through the wrong registered floor.
+        public const byte PROTOCOL_VERSION = 7;
 
         // Message type identifiers
         public const byte MSG_CLIENT_TRANSFORM = 1;
@@ -32,7 +32,7 @@ namespace Styly.NetSync
         public const byte MSG_OBJECT_OWNERSHIP_REJECTED = 17; // Server → Client: request rejected
         public const byte MSG_CLIENT_VAR_CLEAR = 18; // Clear all client variables for the sender
 
-        // Protocol v5 pose encoding constants
+        // Protocol v7 pose encoding constants
         private const float ABS_POS_SCALE = 0.01f;
         private const float LOCO_POS_SCALE = 0.01f;
         private const float REL_POS_SCALE = 0.005f;
@@ -357,6 +357,7 @@ namespace Styly.NetSync
 
             var xrOriginDelta = data != null ? data.xrOriginDeltaPosition : Vector3.zero;
             var xrOriginDeltaYaw = data != null ? data.xrOriginDeltaYaw : 0f;
+            var movingFloorId = data != null ? data.movingFloorId : MovingFloorManager.UnassignedFloorId;
             var physical = EnsureTransform(data != null ? data.physical : null);
             var head = EnsureTransform(data != null ? data.head : null);
             var right = EnsureTransform(data != null ? data.rightHand : null);
@@ -371,6 +372,11 @@ namespace Styly.NetSync
                 hash *= 1099511628211UL;
                 hash ^= encodingFlags;
                 hash *= 1099511628211UL;
+            }
+
+            if (movingFloorLocal)
+            {
+                HashUInt(ref hash, movingFloorId);
             }
 
             if (physicalValid)
@@ -491,11 +497,17 @@ namespace Styly.NetSync
 
             var xrOriginDelta = data != null ? data.xrOriginDeltaPosition : Vector3.zero;
             var xrOriginDeltaYaw = data != null ? data.xrOriginDeltaYaw : 0f;
+            var movingFloorId = data != null ? data.movingFloorId : MovingFloorManager.UnassignedFloorId;
             var physical = EnsureTransform(data != null ? data.physical : null);
             var head = EnsureTransform(data != null ? data.head : null);
             var right = EnsureTransform(data != null ? data.rightHand : null);
             var left = EnsureTransform(data != null ? data.leftHand : null);
             var headRot = NormalizeQuaternionSafe(head.rotation);
+
+            if (movingFloorLocal)
+            {
+                writer.Write(movingFloorId);
+            }
 
             if (physicalValid)
             {
@@ -732,6 +744,11 @@ namespace Styly.NetSync
                 bool leftValid = headValid && ((client.flags & PoseFlags.LeftValid) != 0);
                 bool virtualValid = headValid && ((client.flags & PoseFlags.VirtualsValid) != 0);
                 bool movingFloorLocal = (client.flags & PoseFlags.MovingFloorLocal) != 0;
+                client.movingFloorId = MovingFloorManager.UnassignedFloorId;
+                if (movingFloorLocal)
+                {
+                    client.movingFloorId = reader.ReadUInt32();
+                }
 
                 short dxQ = 0;
                 short dyQ = 0;

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/DataStructure.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/DataStructure.cs
@@ -61,6 +61,8 @@ namespace Styly.NetSync
         public double poseTime;
         public ushort poseSeq;
         public PoseFlags flags;
+        // Moving floor id embedded in protocol v7 pose bodies when MovingFloorLocal is set.
+        public uint movingFloorId;
         // XROrigin locomotion delta (SE(2)): x/z translation in meters and yaw delta in degrees.
         public Vector3 xrOriginDeltaPosition;
         public float xrOriginDeltaYaw;

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/MessageProcessor.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/MessageProcessor.cs
@@ -369,6 +369,12 @@ namespace Styly.NetSync
 
                     alive.Add(c.clientNo);
 
+                    bool movingFloorLocal = (c.flags & PoseFlags.MovingFloorLocal) != 0;
+                    if (netSyncManager != null)
+                    {
+                        netSyncManager.UpdateMovingFloorPoseStateForClient(c.clientNo, c.movingFloorId, movingFloorLocal);
+                    }
+
                     // Check if avatar already exists and just needs update
                     if (avatarManager.ConnectedPeers.ContainsKey(c.clientNo))
                     {
@@ -386,7 +392,6 @@ namespace Styly.NetSync
                     // by BinarySerializer from the world-space head pose and XROrigin delta.
                     // Moving-floor-local poses update presence from the smoothed remote avatar path instead.
                     var physical = c.physical;
-                    bool movingFloorLocal = (c.flags & PoseFlags.MovingFloorLocal) != 0;
                     if (!movingFloorLocal && physical != null && netSyncManager != null)
                     {
                         var physicalPos = physical.GetPosition();

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/MovingFloorManager.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/MovingFloorManager.cs
@@ -7,7 +7,7 @@ using UnityEngine;
 namespace Styly.NetSync
 {
     /// <summary>
-    /// Tracks moving floors for protocol v5 moving-floor-local avatar poses.
+    /// Tracks moving floors for moving-floor-local avatar poses.
     /// A moving floor is any scene-stable Transform known by the same 32-bit id on each client.
     /// </summary>
     internal class MovingFloorManager
@@ -17,6 +17,7 @@ namespace Styly.NetSync
         public const uint UnassignedFloorId = 0u;
 
         private readonly Dictionary<uint, Transform> _floors = new Dictionary<uint, Transform>();
+        private readonly Dictionary<int, uint> _clientPoseFloorIds = new Dictionary<int, uint>();
         private readonly Dictionary<int, uint> _clientFloorIds = new Dictionary<int, uint>();
         private readonly HashSet<(int clientNo, uint floorId)> _missingWarnings = new HashSet<(int clientNo, uint floorId)>();
 
@@ -114,8 +115,36 @@ namespace Styly.NetSync
             _clientFloorIds[clientNo] = floorId;
         }
 
+        public void SetClientPoseFloorId(int clientNo, uint floorId, bool movingFloorLocal)
+        {
+            if (clientNo <= 0)
+            {
+                return;
+            }
+
+            bool hadPoseFloorId = _clientPoseFloorIds.TryGetValue(clientNo, out var previousFloorId);
+            if (!movingFloorLocal || floorId == UnassignedFloorId)
+            {
+                if (hadPoseFloorId)
+                {
+                    _clientPoseFloorIds.Remove(clientNo);
+                    RemoveWarningKeysForClient(clientNo);
+                }
+                return;
+            }
+
+            if (hadPoseFloorId && previousFloorId == floorId)
+            {
+                return;
+            }
+
+            _clientPoseFloorIds[clientNo] = floorId;
+            RemoveWarningKeysForClient(clientNo);
+        }
+
         public void RemoveClient(int clientNo)
         {
+            _clientPoseFloorIds.Remove(clientNo);
             _clientFloorIds.Remove(clientNo);
             RemoveWarningKeysForClient(clientNo);
         }
@@ -123,14 +152,20 @@ namespace Styly.NetSync
         public bool TryGetFloorForClient(int clientNo, bool warnIfMissingId, out Transform floor)
         {
             floor = null;
-            if (!_clientFloorIds.TryGetValue(clientNo, out var floorId) || floorId == UnassignedFloorId)
+            if (!_clientPoseFloorIds.TryGetValue(clientNo, out var floorId) &&
+                !_clientFloorIds.TryGetValue(clientNo, out floorId))
+            {
+                floorId = UnassignedFloorId;
+            }
+
+            if (floorId == UnassignedFloorId)
             {
                 if (warnIfMissingId)
                 {
                     WarnOnce(
                         clientNo,
                         UnassignedFloorId,
-                        $"[NetSync] Moving-floor-local pose received for client#{clientNo}, but {ClientVariableName} is missing. Holding the last applied avatar pose until the floor id is received.");
+                        $"[NetSync] Moving-floor-local pose received for client#{clientNo}, but its floor id is missing. Holding the last applied avatar pose until the floor id is received.");
                 }
                 return false;
             }
@@ -150,6 +185,7 @@ namespace Styly.NetSync
 
         public void ClearClientStates(bool clearLocal)
         {
+            _clientPoseFloorIds.Clear();
             _clientFloorIds.Clear();
             _missingWarnings.Clear();
             if (clearLocal)

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/NetSyncTransformApplier.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/NetSyncTransformApplier.cs
@@ -66,10 +66,12 @@ namespace Styly.NetSync
         private PoseSampleData _lastPhysicalSample;
         private bool _hasPhysicalSample;
         private bool _isMovingFloorLocal;
+        private uint _movingFloorId;
         private bool _lastTickApplied;
         public PoseSampleData LastPhysicalSample => _lastPhysicalSample;
         public bool HasPhysicalSample => _hasPhysicalSample;
         public bool IsMovingFloorLocal => _isMovingFloorLocal;
+        public uint MovingFloorId => _movingFloorId;
         public bool LastTickApplied => _lastTickApplied;
 
         public void InitializeForAvatar(
@@ -114,6 +116,7 @@ namespace Styly.NetSync
             _singleChannel = null;
             _hasAnySnapshot = false;
             _isMovingFloorLocal = false;
+            _movingFloorId = MovingFloorManager.UnassignedFloorId;
             _lastTickApplied = false;
             ClearLastAvatarSamples();
             _intervalEstimator.Reset();
@@ -144,6 +147,7 @@ namespace Styly.NetSync
 
             _hasAnySnapshot = false;
             _isMovingFloorLocal = false;
+            _movingFloorId = MovingFloorManager.UnassignedFloorId;
             _lastTickApplied = false;
             ClearLastAvatarSamples();
             _intervalEstimator.Reset();
@@ -163,11 +167,15 @@ namespace Styly.NetSync
             }
 
             var movingFloorLocal = (data.flags & PoseFlags.MovingFloorLocal) != 0;
-            if (_hasAnySnapshot && movingFloorLocal != _isMovingFloorLocal)
+            var movingFloorId = movingFloorLocal ? data.movingFloorId : MovingFloorManager.UnassignedFloorId;
+            if (_hasAnySnapshot &&
+                (movingFloorLocal != _isMovingFloorLocal ||
+                 (movingFloorLocal && movingFloorId != _movingFloorId)))
             {
                 Clear();
             }
             _isMovingFloorLocal = movingFloorLocal;
+            _movingFloorId = movingFloorId;
             _hasAnySnapshot = true;
             _intervalEstimator.OnPoseTime(data.poseTime);
 
@@ -253,6 +261,7 @@ namespace Styly.NetSync
             _hasAnySnapshot = false;
             _hasPhysicalSample = false;
             _isMovingFloorLocal = false;
+            _movingFloorId = MovingFloorManager.UnassignedFloorId;
             _lastTickApplied = false;
             ClearLastAvatarSamples();
         }

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/TransformSyncManager.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/TransformSyncManager.cs
@@ -158,6 +158,12 @@ namespace Styly.NetSync
             bool rightValid = headValid && ((flags & PoseFlags.RightValid) != 0);
             bool leftValid = headValid && ((flags & PoseFlags.LeftValid) != 0);
             bool virtualValid = headValid && ((flags & PoseFlags.VirtualsValid) != 0);
+            bool movingFloorLocal = (flags & PoseFlags.MovingFloorLocal) != 0;
+
+            if (movingFloorLocal)
+            {
+                bodySize += sizeof(uint);
+            }
 
             if (physicalValid)
             {

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/NetSyncAvatar.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/NetSyncAvatar.cs
@@ -325,6 +325,9 @@ namespace Styly.NetSync
             Transform movingFloor = null;
             bool movingFloorLocal = _netSyncManager != null && _netSyncManager.TryGetLocalMovingFloor(out movingFloor);
             _tx.flags = BuildPoseFlags(movingFloorLocal);
+            _tx.movingFloorId = movingFloorLocal && _netSyncManager != null
+                ? _netSyncManager.LocalMovingFloorId
+                : MovingFloorManager.UnassignedFloorId;
 
             // AvatarManager wires a ParentConstraint from this avatar root to XROrigin
             // so the avatar follows the rig. Unity evaluates ParentConstraint between

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/NetSyncManager.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/NetSyncManager.cs
@@ -348,7 +348,7 @@ namespace Styly.NetSync
         }
 
         /// <summary>
-        /// Register a scene-stable moving floor used by protocol v5 moving-floor-local avatar poses.
+        /// Register a scene-stable moving floor used by moving-floor-local avatar poses.
         /// The same floor id must resolve to the corresponding local Transform on every client.
         /// </summary>
         public bool RegisterMovingFloor(uint floorId, Transform floor)
@@ -1521,6 +1521,16 @@ namespace Styly.NetSync
             }
 
             return _movingFloorManager.TryGetFloorForClient(clientNo, warnIfMissingId, out floor);
+        }
+
+        internal void UpdateMovingFloorPoseStateForClient(int clientNo, uint floorId, bool movingFloorLocal)
+        {
+            if (_movingFloorManager == null)
+            {
+                return;
+            }
+
+            _movingFloorManager.SetClientPoseFloorId(clientNo, floorId, movingFloorLocal);
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
- Embed the sender's moving floor ID in `MovingFloorLocal` pose bodies and bump the binary protocol to v7.
- Resolve remote moving-floor-local avatars from the pose-embedded floor ID before applying snapshots.
- Keep Unity and Python serializers/adapters/tests aligned and update protocol documentation.

## Root Cause
Moving-floor-local poses previously depended on a separate client variable to identify the sender's floor. That variable can arrive out of band from transform snapshots, so receivers could temporarily project an avatar through the wrong registered moving floor when multiple floors exist or when a client switches floors.

## Impact
This is a breaking wire protocol change. Unity clients, Python clients, and the Python server must be deployed together with `protocolVersion=7`.

## Validation
- Unity compile: error 0
- Unity console errors: 0
- `python -m pytest tests/test_binary_serializer.py`
- `python -m compileall src/styly_netsync`
- `python -m black --check src/styly_netsync/adapters.py src/styly_netsync/binary_serializer.py src/styly_netsync/server.py src/styly_netsync/types.py tests/test_binary_serializer.py`
- `python -m ruff check src/styly_netsync/adapters.py src/styly_netsync/binary_serializer.py src/styly_netsync/server.py src/styly_netsync/types.py tests/test_binary_serializer.py`
- `python -m mypy src/`
- `python -m pytest` (269 passed, 2 skipped)

Fixes #451