### PR TITLE
[codex] Split control and transform sockets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,4 +36,5 @@ gha-creds-*.json
 *_clone_*/
 
 # Misc
+/cache/
 nanobanana-output/*

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,27 @@ STYLY-NetSync is designed exclusively for XR (VR/MR/AR) applications:
 - **Motion-Adaptive Sending**: Transform sending uses `SendRate` as an upper bound with `Only-on-change` filtering plus a `1Hz` heartbeat while idle.
 - **Bandwidth Planning**: Assume motion-dependent traffic with an idle heartbeat floor, not continuous full-payload flow.
 
+## Deployment Assumptions & Threat Model
+
+STYLY-NetSync targets on-site LBE installations. These assumptions are intentional
+and bound what counts as a real issue during review:
+
+- **Trusted LAN, no malicious devices**: The server and all clients run on a
+  closed, operator-controlled local network. There is no untrusted participant on
+  the wire. Therefore client-identity spoofing, control-lane takeover, message
+  forgery, and similar adversarial scenarios are **out of scope** — do not treat
+  them as findings. (Functional correctness for *legitimate* clients — e.g.
+  socket-ordering races between the control and transform lanes — is still in
+  scope.)
+- **Server and clients always upgrade together**: A given deployment runs a single
+  matching version everywhere. There is **no backward/forward compatibility
+  requirement** on the network protocol or discovery format. Prefer the simplest
+  implementation; do not add legacy-version fallbacks or compatibility shims for
+  the wire protocol. See [Backward Compatibility Policy](#backward-compatibility-policy).
+- **No transport-level authentication/encryption**: Security is provided by the
+  trusted-network boundary, not by the protocol. Do not propose adding authn/crypto
+  to the ZeroMQ transport unless the deployment model itself changes.
+
 ## Quick Start
 
 ### Python Server
@@ -56,6 +77,7 @@ black src/ tests/ && ruff check src/ tests/ && mypy src/ && pytest --cov=src
 ### Backward Compatibility Policy
 
 - Network protocol changes do NOT require backward compatibility — deploy server and clients together
+- This also covers the discovery handshake (`STYLY-NETSYNC2`): a reply that is not the current format is simply "not a compatible server"; do not add legacy-version detection branches or fallbacks
 - Avoid unnecessary breaking changes to non-networking code
 - Always notify the user of breaking changes
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,15 +34,15 @@ black src/ tests/ && ruff check src/ tests/ && mypy src/ && pytest --cov=src
 
 ## Architecture Overview
 
-- **Server**: Multi-threaded Python (receive, periodic, discovery threads) with ZeroMQ DEALER-ROUTER + PUB-SUB and group-based room management
+- **Server**: Multi-threaded Python (receive, periodic, discovery threads) with ZeroMQ control/transform DEALER-ROUTER sockets + PUB-SUB and group-based room management
 - **Unity Client**: Manager pattern with internal components (connection, transform sync, RPC, network variables, avatars)
-- **Protocol**: Binary v6 with quantized positions and smallest-three quaternion compression
+- **Protocol**: Binary v7 with quantized positions and smallest-three quaternion compression
 - **Technology**: Python 3.11+ / pyzmq / FastAPI / msgpack (server), Unity 6 / NetMQ / Newtonsoft.Json (client)
 
 ## Protocol Rules
 
-- Binary protocol is `protocolVersion=6` only (earlier versions removed); the version byte rides on transform/object messages and bumps on any breaking wire change, including Network Variable message changes
-- Message IDs: `MSG_CLIENT_POSE=11`, `MSG_ROOM_POSE=12`, `MSG_CLIENT_VAR_CLEAR=18`
+- Binary protocol is `protocolVersion=7` only (earlier versions removed); the version byte rides on transform/object/hello messages and bumps on any breaking wire change, including Network Variable message changes
+- Message IDs: `MSG_CLIENT_POSE=11`, `MSG_ROOM_POSE=12`, `MSG_CLIENT_VAR_CLEAR=18`, `MSG_CLIENT_HELLO=19`
 - Unbound `Head` is absolute; `Right/Left/Virtual` are head-relative
 - Moving-floor-local poses set `PoseFlags.MovingFloorLocal`; `Head` is moving-floor local while `Right/Left/Virtual` remain head-relative within that floor
 - Unbound `xrOriginDelta` is `(dx, dy, dz, dyaw)` quantized as 4×`int16` (`LOCO_POS_SCALE = 0.01m` for translation, `PHYSICAL_YAW_SCALE = 0.1°` for yaw); receivers reconstruct physical pose as `physical = invDeltaRot * (headPos − deltaPos)`

--- a/README.md
+++ b/README.md
@@ -85,10 +85,11 @@ The uvx command automatically downloads the package, creates an isolated virtual
 ### Version compatibility note
 
 - Keep Unity package and server versions aligned.
-- Transform synchronization uses protocol version `4` and does not provide backward compatibility with older transform protocols.
-- v4 vs. v3: `xrOriginDelta` adds a Y component (4×`int16`: `dx, dy, dz, dyaw`) so receivers can reconstruct vertical rig motion (e.g. elevators).
-- Protocol v4 position quantization uses:
-  - Absolute scale (`Head`/`Physical`): signed `int24` at `0.01 m` per unit, per-axis range `[-83,886.08 m, 83,886.07 m]`.
+- The current wire protocol is `protocolVersion = 7`; it is not backward compatible with older clients or servers.
+- Transport uses separate ports for control (`5555`), transform uplink (`5557`), and PUB/SUB downlink (`5556`). Legacy discovery responses are treated as incompatible.
+- `xrOriginDelta` carries a Y component (4×`int16`: `dx, dy, dz, dyaw`) so receivers can reconstruct vertical rig motion (e.g. elevators).
+- Protocol v7 position quantization uses:
+  - Absolute scale (`Head`): signed `int24` at `0.01 m` per unit, per-axis range `[-83,886.08 m, 83,886.07 m]`.
   - Head-relative scale (`Right`/`Left`/`Virtual`): `0.005 m` per unit, per-axis range `[-163.84 m, 163.835 m]`.
 - This is an encoding range, not a hard world-size limit. Large virtual worlds are supported as long as each encoded value stays in range (out-of-range values are clamped).
 - Coordinate range expansion options (range + bandwidth delta comparison) are documented in `STYLY-NetSync-Server/README.md`.

--- a/STYLY-NetSync-Server/AGENTS.md
+++ b/STYLY-NetSync-Server/AGENTS.md
@@ -19,7 +19,7 @@ pip install -e ".[dev]"
 
 # Run server
 styly-netsync-server
-styly-netsync-server --dealer-port 5555 --pub-port 5556 --server-discovery-port 9999
+styly-netsync-server --control-port 5555 --transform-port 5557 --pub-port 5556 --server-discovery-port 9999
 styly-netsync-server --config my-config.toml
 
 # Quality pipeline (run before committing)
@@ -32,7 +32,7 @@ styly-netsync-simulator --clients 100 --server localhost --room default_room
 ## Architecture
 
 - **NetSyncServer** (`server.py`): Multi-threaded (receive, periodic, discovery threads)
-- **BinarySerializer** (`binary_serializer.py`): Protocol v5 transform serializer
+- **BinarySerializer** (`binary_serializer.py`): Protocol v7 binary serializer
 - **Python Client API** (`client.py`): `net_sync_manager` class for Python clients
 - **REST Bridge** (`rest_bridge.py`): FastAPI REST API for external integrations
 

--- a/STYLY-NetSync-Server/README.md
+++ b/STYLY-NetSync-Server/README.md
@@ -42,13 +42,16 @@ styly-netsync-simulator --server tcp://localhost --room my_room --clients 50
 
 ## Wire protocol compatibility
 
-- Current transform wire protocol is `protocolVersion = 5`.
-- Transform messages use `MSG_CLIENT_POSE` (11) and `MSG_ROOM_POSE` (12) with the compact V5 pose body.
-- v5 adds an optional `MovingFloorLocal` pose flag. Bound avatars send head, hands, and virtual transforms in the registered moving floor's local coordinates, and reuse the existing 8-byte physical slot as direct physical position/yaw.
-- Unbound v5 poses keep the v4 `xrOriginDelta` semantics: `xrOriginDelta` carries a Y component as a 4th `int16` (`dx, dy, dz, dyaw` = 8 bytes vs. v3's 6), so receivers can reconstruct the sender's rig-Y motion.
+- Current wire protocol is `protocolVersion = 7`.
+- Transport uses three sockets: control (`control_port`, default `5555`) for RPC, Network Variables, ownership, ID mapping, and client hello; transform uplink (`transform_port`, default `5557`) for client/object poses; PUB/SUB (`pub_port`, default `5556`) for room pose and room object downlink.
+- Discovery responses use `STYLY-NETSYNC2|controlPort|transformPort|pubPort|serverName`; legacy `STYLY-NETSYNC|...` responses are explicitly incompatible.
+- `dealer_port` / `--dealer-port` remain a one-release compatibility alias for `control_port` / `--control-port`.
+- Transform messages use `MSG_CLIENT_POSE` (11) and `MSG_ROOM_POSE` (12) with the compact pose body. Clients register control identity with `MSG_CLIENT_HELLO` (19).
+- Moving-floor-local poses set the `MovingFloorLocal` pose flag. Bound avatars send head, hands, and virtual transforms in the registered moving floor's local coordinates, and reuse the existing 8-byte physical slot as direct physical position/yaw.
+- Unbound poses keep the `xrOriginDelta` semantics: `xrOriginDelta` carries a Y component as a 4th `int16` (`dx, dy, dz, dyaw` = 8 bytes), so receivers can reconstruct the sender's rig-Y motion.
 - Legacy transform protocols (v2/v3) and JSON transform fallback are not supported.
 - Deploy Unity and Python updates together when changing transform protocol behavior.
-- Protocol v5 position quantization ranges:
+- Protocol v7 position quantization ranges:
   - Absolute (`headPosAbs` only): signed `int24` at `0.01 m` per unit, per-axis range `[-83,886.08 m, 83,886.07 m]`.
   - XROrigin locomotion delta for unbound poses (`xrOriginDelta`, 4×`int16`: `dx, dy, dz, dyaw`): `0.01 m` per unit for translation, `0.1°` for yaw. Receivers reconstruct `physicalPos = invDeltaRot * (headPos − deltaPos)`; it is not on the wire as a separate absolute field.
   - Direct physical payload for moving-floor-local poses (`physical`, 4×`int16`: `x, y, z, yaw`): `0.01 m` per unit for translation, `0.1°` for yaw.
@@ -59,7 +62,7 @@ styly-netsync-simulator --server tcp://localhost --room my_room --clients 50
 
 The following options summarize trade-offs when expanding absolute-position range.
 
-Assumed unbound baseline (`protocolVersion=5`, `MovingFloorLocal` off):
+Assumed unbound baseline (`protocolVersion=7`, `MovingFloorLocal` off):
 - Client pose body with `Physical+Head+Right+Left` valid and `virtualCount=0`: `46 bytes` (matches `test_client_body_size_with_full_pose_no_virtuals`).
 - Room per-client entry (`clientNo + poseTime + clientBody`): `56 bytes`.
 
@@ -228,4 +231,4 @@ The response includes the room ID and whether each key was `"applied"`, `"queued
 
 ### Read consistency
 
-GET endpoints return a snapshot of the REST bridge's in-process cache, which is populated by PUB-SUB broadcasts from the server. The first request to a room lazily creates a bridge and may return an empty snapshot until the initial broadcasts arrive — retry after a short delay if needed.
+GET endpoints return a snapshot of the REST bridge's in-process cache, which is populated by control-lane sync messages from the server. The first request to a room lazily creates a bridge and may return an empty snapshot until the initial sync arrives — retry after a short delay if needed.

--- a/STYLY-NetSync-Server/src/styly_netsync/__init__.py
+++ b/STYLY-NetSync-Server/src/styly_netsync/__init__.py
@@ -16,7 +16,7 @@ Examples:
 
     # Use server programmatically
     from styly_netsync import NetSyncServer
-    server = NetSyncServer(dealer_port=5555, pub_port=5556)
+    server = NetSyncServer(control_port=5555, transform_port=5557, pub_port=5556)
     server.start()
 
     # Use client programmatically

--- a/STYLY-NetSync-Server/src/styly_netsync/binary_serializer.py
+++ b/STYLY-NetSync-Server/src/styly_netsync/binary_serializer.py
@@ -1369,6 +1369,10 @@ def serialize_object_pose(data: dict[str, Any]) -> bytes:
     buffer = bytearray()
     buffer.append(MSG_OBJECT_POSE)
     buffer.append(PROTOCOL_VERSION)
+    # Sender device ID: lets the server attribute the pose by identity carried in
+    # the payload rather than the transform-lane socket identity (which a stealth
+    # owner never binds because it sends no MSG_CLIENT_POSE).
+    _pack_string(buffer, str(data.get("deviceId", "")))
     object_id = int(data.get("objectId", 0)) & 0xFFFFFFFF
     buffer.extend(struct.pack("<I", object_id))
     buffer.extend(struct.pack("<H", int(data.get("poseSeq", 0)) & 0xFFFF))
@@ -1466,6 +1470,8 @@ def _deserialize_object_pose(data: bytes, offset: int) -> dict[str, Any]:
     offset += 1
     if protocol_version != PROTOCOL_VERSION:
         raise ValueError(f"Unsupported protocol version: {protocol_version}")
+    device_id, offset = _unpack_string(data, offset)
+    result["deviceId"] = device_id
     result["objectId"] = struct.unpack("<I", data[offset : offset + 4])[0]
     offset += 4
     result["poseSeq"] = struct.unpack("<H", data[offset : offset + 2])[0]

--- a/STYLY-NetSync-Server/src/styly_netsync/binary_serializer.py
+++ b/STYLY-NetSync-Server/src/styly_netsync/binary_serializer.py
@@ -6,10 +6,11 @@ from typing import Any
 logger = logging.getLogger(__name__)
 
 # Message type identifiers
-# v6: Network Variable wire messages dropped the per-write timestamp field.
+# v7: Control and transform traffic use separate sockets, and clients register
+# their control identity with MSG_CLIENT_HELLO.
 # Bumped so mixed old/new builds fail the handshake instead of silently
 # misparsing NV traffic (the version byte rides on transform/object messages).
-PROTOCOL_VERSION = 6
+PROTOCOL_VERSION = 7
 MSG_CLIENT_TRANSFORM = 1
 MSG_ROOM_TRANSFORM = 2  # Legacy room transform with short IDs only
 MSG_RPC = 3  # Remote procedure call
@@ -28,6 +29,9 @@ MSG_OBJECT_OWNERSHIP_REQUEST = 15  # Client → Server: RequestOwnership/Release
 MSG_OBJECT_OWNERSHIP_CHANGED = 16  # Server → Clients (ROUTER): ownership changed
 MSG_OBJECT_OWNERSHIP_REJECTED = 17  # Server → Client (ROUTER): request rejected
 MSG_CLIENT_VAR_CLEAR = 18  # Clear all client variables for the sender
+MSG_CLIENT_HELLO = 19  # Client → Server: bind control identity to device ID
+
+CLIENT_HELLO_FLAG_STEALTH = 0x01
 
 # Transform data type identifiers (deprecated - kept for reference)
 
@@ -36,7 +40,7 @@ MSG_CLIENT_VAR_CLEAR = 18  # Clear all client variables for the sender
 _max_virtual_transforms = 50
 MAX_VIRTUAL_TRANSFORMS = _max_virtual_transforms  # Legacy alias for backward compat
 
-# Protocol v5 transform encoding constants
+# Protocol v7 pose encoding constants
 ABS_POS_SCALE = 0.01
 LOCO_POS_SCALE = 0.01
 REL_POS_SCALE = 0.005
@@ -632,6 +636,17 @@ def serialize_rpc_message(data: dict[str, Any]) -> bytes:
     return bytes(buffer)
 
 
+def serialize_client_hello(device_id: str, is_stealth: bool = False) -> bytes:
+    """Serialize client hello for control-lane identity registration."""
+    buffer = bytearray()
+    buffer.append(MSG_CLIENT_HELLO)
+    buffer.append(PROTOCOL_VERSION)
+    flags = CLIENT_HELLO_FLAG_STEALTH if is_stealth else 0
+    buffer.append(flags)
+    _pack_string(buffer, device_id)
+    return bytes(buffer)
+
+
 def parse_version(version_str: str) -> tuple[int, int, int]:
     """Parse semantic version string into (major, minor, patch) tuple.
 
@@ -825,7 +840,7 @@ def deserialize(data: bytes) -> tuple[int, dict[str, Any] | None, bytes]:
     offset += 1
 
     # Validate message type is within valid range
-    if message_type < MSG_CLIENT_TRANSFORM or message_type > MSG_CLIENT_VAR_CLEAR:
+    if message_type < MSG_CLIENT_TRANSFORM or message_type > MSG_CLIENT_HELLO:
         # Return invalid message type with None data instead of raising exception
         return message_type, None, b""
 
@@ -856,6 +871,8 @@ def deserialize(data: bytes) -> tuple[int, dict[str, Any] | None, bytes]:
             return message_type, _deserialize_client_var_sync(data, offset), b""
         elif message_type == MSG_CLIENT_VAR_CLEAR:
             return message_type, _deserialize_client_var_clear(data, offset), b""
+        elif message_type == MSG_CLIENT_HELLO:
+            return message_type, _deserialize_client_hello(data, offset), b""
         elif message_type == MSG_OBJECT_POSE:
             return message_type, _deserialize_object_pose(data, offset), b""
         elif message_type == MSG_ROOM_OBJECTS:
@@ -888,6 +905,22 @@ def deserialize(data: bytes) -> tuple[int, dict[str, Any] | None, bytes]:
             str(e),
         )
         return message_type, None, b""
+
+
+def _deserialize_client_hello(data: bytes, offset: int) -> dict[str, Any]:
+    """Deserialize client hello control message."""
+    protocol_version = data[offset]
+    offset += 1
+    if protocol_version != PROTOCOL_VERSION:
+        raise ValueError(f"Unsupported protocol version: {protocol_version}")
+    flags = data[offset]
+    offset += 1
+    device_id, offset = _unpack_string(data, offset)
+    return {
+        "deviceId": device_id,
+        "flags": flags,
+        "isStealthMode": bool(flags & CLIENT_HELLO_FLAG_STEALTH),
+    }
 
 
 def _deserialize_client_body(data: bytes, offset: int) -> tuple[dict[str, Any], int]:

--- a/STYLY-NetSync-Server/src/styly_netsync/client.py
+++ b/STYLY-NetSync-Server/src/styly_netsync/client.py
@@ -9,7 +9,8 @@ Key features (mirroring Unity ConnectionManager PR #311 and #316):
 - Latest-wins transform sending: Only the most recent transform is sent
 - Control message queue with TTL expiration
 - SUB receive draining: Only process the last payload to reduce CPU
-- DEALER receive for control messages from server (ROUTER unicast)
+    - Separate control and transform DEALER sockets
+    - DEALER receive for control messages from server (ROUTER unicast)
 """
 
 import json
@@ -36,7 +37,6 @@ from . import binary_serializer
 from .adapters import (
     client_transform_from_wire,
     client_transform_to_wire,
-    create_stealth_transform,
     is_stealth_transform,
 )
 from .events import EventHandler
@@ -140,6 +140,7 @@ class net_sync_manager:
         self,
         server: str = "tcp://localhost",
         dealer_port: int = 5555,
+        transform_port: int | None = None,
         sub_port: int = 5556,
         room: str = "default_room",
         auto_dispatch: bool = True,
@@ -152,7 +153,8 @@ class net_sync_manager:
 
         Args:
             server: ZeroMQ base address (e.g., "tcp://localhost")
-            dealer_port: Server ROUTER port for uplink
+            dealer_port: Deprecated alias for the server control ROUTER port
+            transform_port: Server ROUTER port for transform uplink
             sub_port: Server PUB port for downlink
             room: Room topic to subscribe to
             auto_dispatch: If True, callbacks fire on receive thread
@@ -162,7 +164,11 @@ class net_sync_manager:
                 (default: 30.0; pass None to disable silence detection)
         """
         self._server = server
-        self._dealer_port = dealer_port
+        self._control_port = dealer_port
+        self._dealer_port = self._control_port  # Deprecated compatibility alias
+        self._transform_port = (
+            transform_port if transform_port is not None else self._control_port + 2
+        )
         self._sub_port = sub_port
         self._room = room
         self._auto_dispatch = auto_dispatch
@@ -172,6 +178,7 @@ class net_sync_manager:
         # ZeroMQ context and sockets
         self._context: zmq.Context | None = None
         self._dealer_socket: zmq.Socket | None = None
+        self._transform_socket: zmq.Socket | None = None
         self._sub_socket: zmq.Socket | None = None
 
         # Threading
@@ -224,6 +231,7 @@ class net_sync_manager:
         # Priority-based sending (mirroring Unity ConnectionManager)
         # Control messages (RPC, NV) have priority over transforms
         self._ctrl_outbox: Queue[OutboundPacket] = Queue(maxsize=256)
+        self._pending_control: OutboundPacket | None = None
         self._latest_transform: OutboundPacket | None = None
         self._transform_lock = threading.Lock()
 
@@ -320,8 +328,18 @@ class net_sync_manager:
 
     @property
     def dealer_port(self) -> int:
-        """Dealer port."""
+        """Deprecated alias for the control port."""
         return self._dealer_port
+
+    @property
+    def control_port(self) -> int:
+        """Control socket port."""
+        return self._control_port
+
+    @property
+    def transform_port(self) -> int:
+        """Transform uplink socket port."""
+        return self._transform_port
 
     @property
     def sub_port(self) -> int:
@@ -338,18 +356,22 @@ class net_sync_manager:
                 # Initialize ZeroMQ
                 self._context = zmq.Context()
 
-                # DEALER socket for uplink and control message receive
+                # DEALER socket for control uplink and control message receive
                 self._dealer_socket = self._context.socket(zmq.DEALER)
                 self._dealer_socket.setsockopt(zmq.LINGER, 0)
-                self._dealer_socket.setsockopt(
-                    zmq.SNDHWM, 10
-                )  # Low HWM for backpressure
-                self._dealer_socket.setsockopt(
-                    zmq.RCVHWM, 10
-                )  # Bound receive queue for control messages
+                self._dealer_socket.setsockopt(zmq.SNDHWM, 1024)
+                self._dealer_socket.setsockopt(zmq.RCVHWM, 1024)
                 self._dealer_socket.setsockopt(zmq.RCVTIMEO, 0)  # Non-blocking receive
-                dealer_addr = self._build_connect_addr(self._dealer_port)
-                self._dealer_socket.connect(dealer_addr)
+                control_addr = self._build_connect_addr(self._control_port)
+                self._dealer_socket.connect(control_addr)
+
+                # DEALER socket for transform uplink only. Low HWM preserves
+                # latest-wins freshness under slow receivers.
+                self._transform_socket = self._context.socket(zmq.DEALER)
+                self._transform_socket.setsockopt(zmq.LINGER, 0)
+                self._transform_socket.setsockopt(zmq.SNDHWM, 2)
+                transform_addr = self._build_connect_addr(self._transform_port)
+                self._transform_socket.connect(transform_addr)
 
                 # SUB socket for downlink (transform broadcasts)
                 # Low RCVHWM (2) to prefer recent updates and drop stale messages
@@ -359,6 +381,8 @@ class net_sync_manager:
                 sub_addr = self._build_connect_addr(self._sub_port)
                 self._sub_socket.connect(sub_addr)
                 self._sub_socket.setsockopt(zmq.SUBSCRIBE, self._room.encode("utf-8"))
+
+                self._enqueue_client_hello(is_stealth=False)
 
                 # Start receive thread
                 self._running = True
@@ -370,7 +394,8 @@ class net_sync_manager:
                 self._receive_thread.start()
 
                 logger.info(
-                    f"NetSync client started: {dealer_addr}, {sub_addr}, room={self._room}"
+                    "NetSync client started: "
+                    f"{control_addr}, {transform_addr}, {sub_addr}, room={self._room}"
                 )
 
             except Exception as e:
@@ -415,6 +440,9 @@ class net_sync_manager:
         if self._dealer_socket:
             self._dealer_socket.close()
             self._dealer_socket = None
+        if self._transform_socket:
+            self._transform_socket.close()
+            self._transform_socket = None
         if self._sub_socket:
             self._sub_socket.close()
             self._sub_socket = None
@@ -469,7 +497,7 @@ class net_sync_manager:
         logger.info("Attempting socket reconnect...")
 
         # Close old sockets
-        for sock_attr in ("_dealer_socket", "_sub_socket"):
+        for sock_attr in ("_dealer_socket", "_transform_socket", "_sub_socket"):
             sock = getattr(self, sock_attr, None)
             if sock is not None:
                 try:
@@ -487,14 +515,21 @@ class net_sync_manager:
                 return False
 
         try:
-            # DEALER socket (same options as start())
+            # Control DEALER socket (same options as start())
             self._dealer_socket = self._context.socket(zmq.DEALER)
             self._dealer_socket.setsockopt(zmq.LINGER, 0)
-            self._dealer_socket.setsockopt(zmq.SNDHWM, 10)
-            self._dealer_socket.setsockopt(zmq.RCVHWM, 10)
+            self._dealer_socket.setsockopt(zmq.SNDHWM, 1024)
+            self._dealer_socket.setsockopt(zmq.RCVHWM, 1024)
             self._dealer_socket.setsockopt(zmq.RCVTIMEO, 0)
-            dealer_addr = self._build_connect_addr(self._dealer_port)
-            self._dealer_socket.connect(dealer_addr)
+            control_addr = self._build_connect_addr(self._control_port)
+            self._dealer_socket.connect(control_addr)
+
+            # Transform DEALER socket (same options as start())
+            self._transform_socket = self._context.socket(zmq.DEALER)
+            self._transform_socket.setsockopt(zmq.LINGER, 0)
+            self._transform_socket.setsockopt(zmq.SNDHWM, 2)
+            transform_addr = self._build_connect_addr(self._transform_port)
+            self._transform_socket.connect(transform_addr)
 
             # SUB socket (same options as start())
             self._sub_socket = self._context.socket(zmq.SUB)
@@ -509,8 +544,10 @@ class net_sync_manager:
 
             logger.info(
                 f"Reconnected (#{self._stats['reconnect_count']}): "
-                f"{dealer_addr}, {sub_addr}, room={self._room}"
+                f"{control_addr}, {transform_addr}, {sub_addr}, room={self._room}"
             )
+
+            self._enqueue_client_hello(is_stealth=self._is_stealth_mode)
 
             # Restart discovery if it was active before the connection error
             if self._discovery_port is not None:
@@ -521,7 +558,7 @@ class net_sync_manager:
         except Exception as e:
             logger.error(f"Socket reconnect failed: {e}")
             # Cleanup partial setup
-            for sock_attr in ("_dealer_socket", "_sub_socket"):
+            for sock_attr in ("_dealer_socket", "_transform_socket", "_sub_socket"):
                 sock = getattr(self, sock_attr, None)
                 if sock is not None:
                     try:
@@ -539,6 +576,7 @@ class net_sync_manager:
                 self._ctrl_outbox.get_nowait()
             except Empty:
                 break
+        self._pending_control = None
 
         # Clear latest transform
         with self._transform_lock:
@@ -758,7 +796,7 @@ class net_sync_manager:
 
         # Priority-based send drain:
         # 1. Drain control messages first (higher priority)
-        # 2. Then try to send latest transform (lower priority)
+        # 2. Then try to send latest transform through transform socket
         did_work |= self._drain_control_sends()
         did_work |= self._try_send_latest_transform()
 
@@ -777,41 +815,34 @@ class net_sync_manager:
         now = time.monotonic()
 
         while sent < self._ctrl_drain_batch:
-            try:
-                packet = self._ctrl_outbox.get_nowait()
-            except Empty:
-                break
+            if self._pending_control is not None:
+                packet = self._pending_control
+            else:
+                try:
+                    packet = self._ctrl_outbox.get_nowait()
+                except Empty:
+                    break
 
             # TTL check - skip expired packets
             if now - packet.enqueued_at > self._ctrl_ttl_seconds:
                 logger.warning(
                     f"Control packet expired (TTL {self._ctrl_ttl_seconds}s exceeded)"
                 )
+                self._pending_control = None
                 continue
 
             # Try to send
-            outcome = self._try_send_dealer(packet.room_id, packet.payload)
+            outcome = self._try_send_socket(
+                self._dealer_socket, packet.room_id, packet.payload
+            )
             if outcome.is_sent:
+                self._pending_control = None
                 did_work = True
                 sent += 1
             elif outcome.is_backpressure:
-                # Backpressure - increment counter and attempt to re-queue the packet
                 with self._lock:
                     self._stats["would_block_count"] += 1
-                try:
-                    # Re-queue the control packet so it can be retried later
-                    self._ctrl_outbox.put_nowait(packet)
-                except Full:
-                    # Queue is full: this control packet is dropped; log prominently
-                    with self._lock:
-                        self._stats["ctrl_queue_drops"] += 1
-                    logger.warning(
-                        "Control packet dropped due to backpressure and full queue; "
-                        "would_block=%s, queue_drops=%s",
-                        self._stats.get("would_block_count"),
-                        self._stats.get("ctrl_queue_drops"),
-                    )
-                # Stop draining on backpressure to respect socket backpressure signal
+                self._pending_control = packet
                 break
             else:
                 # Fatal error
@@ -825,7 +856,7 @@ class net_sync_manager:
 
         Returns True if a transform was sent.
         """
-        if not self._dealer_socket:
+        if not self._transform_socket:
             return False
 
         with self._transform_lock:
@@ -834,7 +865,9 @@ class net_sync_manager:
                 return False
 
             # Try to send
-            outcome = self._try_send_dealer(packet.room_id, packet.payload)
+            outcome = self._try_send_socket(
+                self._transform_socket, packet.room_id, packet.payload
+            )
             if outcome.is_sent:
                 # Success - clear the packet
                 self._latest_transform = None
@@ -849,17 +882,19 @@ class net_sync_manager:
                 logger.error(f"Fatal send error: {outcome.error}")
                 return False
 
-    def _try_send_dealer(self, room_id: str, payload: bytes) -> SendOutcome:
-        """Try to send a message via DEALER socket.
+    def _try_send_socket(
+        self, socket_obj: zmq.Socket | None, room_id: str, payload: bytes
+    ) -> SendOutcome:
+        """Try to send a message via a DEALER socket.
 
         Returns SendOutcome indicating success, backpressure, or fatal error.
         """
-        if not self._dealer_socket:
+        if not socket_obj:
             return SendOutcome.fatal("Socket not available")
 
         try:
             # Use NOBLOCK to detect backpressure
-            self._dealer_socket.send_multipart(
+            socket_obj.send_multipart(
                 [room_id.encode("utf-8"), payload], flags=zmq.NOBLOCK
             )
             return SendOutcome.sent()
@@ -1108,7 +1143,7 @@ class net_sync_manager:
         Only the most recent transform is retained. Calling this multiple times
         before the network thread sends will only send the last one.
         """
-        if not self._running or not self._dealer_socket:
+        if not self._running or not self._transform_socket:
             return False
 
         try:
@@ -1145,20 +1180,14 @@ class net_sync_manager:
         return result
 
     def _send_stealth_heartbeat(self) -> bool:
-        """Serialize and enqueue one stealth heartbeat packet.
+        """Serialize and enqueue one stealth control hello packet.
 
-        Uses the control queue (matching Unity's TryEnqueueControl for stealth handshakes).
+        Uses the control queue so stealth clients maintain membership without
+        sending pose-shaped transform payloads.
         Updates _last_stealth_heartbeat_time on success to drive the 1 Hz interval.
         """
-        stealth_tx = create_stealth_transform()
-        stealth_tx.device_id = self._device_id
-
         try:
-            wire_data = client_transform_to_wire(stealth_tx)
-            message = binary_serializer.serialize_client_transform(wire_data)
-            result = self._enqueue_control(
-                self._room, message, msg_type="stealth_heartbeat"
-            )
+            result = self._enqueue_client_hello(is_stealth=True)
             if result:
                 self._last_stealth_heartbeat_time = time.monotonic()
             return result
@@ -1302,6 +1331,13 @@ class net_sync_manager:
                 self._stats.get("ctrl_queue_drops"),
             )
             return False
+
+    def _enqueue_client_hello(self, is_stealth: bool) -> bool:
+        """Enqueue a client hello control message."""
+        message = binary_serializer.serialize_client_hello(
+            self._device_id, is_stealth=is_stealth
+        )
+        return self._enqueue_control(self._room, message, msg_type="client_hello")
 
     def get_global_variable(self, name: str, default: str | None = None) -> str | None:
         """Get global variable from local cache."""
@@ -1576,26 +1612,32 @@ class net_sync_manager:
                         data, addr = sock.recvfrom(1024)
                         response = data.decode("utf-8")
 
-                        if response.startswith("STYLY-NETSYNC|"):
+                        if response.startswith("STYLY-NETSYNC2|"):
                             parts = response.split("|")
-                            if len(parts) >= 4:
-                                dealer_port = int(parts[1])
-                                sub_port = int(parts[2])
-                                server_name = parts[3]
+                            if len(parts) >= 5:
+                                control_port = int(parts[1])
+                                transform_port = int(parts[2])
+                                sub_port = int(parts[3])
+                                server_name = parts[4]
 
                                 logger.info(
                                     f"Discovered server: {server_name} at "
-                                    f"{addr[0]}:{dealer_port}/{sub_port}"
+                                    f"{addr[0]}:{control_port}/{transform_port}/{sub_port}"
                                 )
                                 server_address = f"tcp://{addr[0]}"
                                 self.on_server_discovered.invoke(
-                                    server_address, dealer_port, sub_port
+                                    server_address,
+                                    control_port,
+                                    transform_port,
+                                    sub_port,
                                 )
 
                                 # Auto-connect after discovery
                                 if not self._running:
                                     self._server = server_address
-                                    self._dealer_port = dealer_port
+                                    self._control_port = control_port
+                                    self._dealer_port = control_port
+                                    self._transform_port = transform_port
                                     self._sub_port = sub_port
                                     try:
                                         self.start()
@@ -1607,6 +1649,11 @@ class net_sync_manager:
                                         break
                                 self._stop_discovery_internal()
                                 return
+                        elif response.startswith("STYLY-NETSYNC|"):
+                            logger.warning(
+                                "Ignoring incompatible legacy discovery response from %s",
+                                addr[0],
+                            )
                     except TimeoutError:
                         pass
                     except Exception:

--- a/STYLY-NetSync-Server/src/styly_netsync/client_simulator.py
+++ b/STYLY-NetSync-Server/src/styly_netsync/client_simulator.py
@@ -45,6 +45,7 @@ import zmq
 
 # Import public APIs from styly_netsync module
 from styly_netsync.binary_serializer import (
+    MSG_CLIENT_HELLO,
     MSG_CLIENT_POSE,
     MSG_CLIENT_VAR_CLEAR,
     MSG_CLIENT_VAR_SET,
@@ -60,6 +61,7 @@ from styly_netsync.binary_serializer import (
     MSG_ROOM_POSE,
     MSG_RPC,
     deserialize,
+    serialize_client_hello,
     serialize_client_transform,
     serialize_client_var_set,
 )
@@ -97,6 +99,7 @@ MESSAGE_TYPE_NAMES: dict[int, str] = {
     MSG_CLIENT_VAR_SET: "CLIENT_VAR_SET",
     MSG_CLIENT_VAR_SYNC: "CLIENT_VAR_SYNC",
     MSG_CLIENT_VAR_CLEAR: "CLIENT_VAR_CLEAR",
+    MSG_CLIENT_HELLO: "CLIENT_HELLO",
     MSG_OBJECT_POSE: "OBJECT_POSE",
     MSG_ROOM_OBJECTS: "ROOM_OBJECTS",
     MSG_OBJECT_OWNERSHIP_REQUEST: "OBJECT_OWNERSHIP_REQUEST",
@@ -515,13 +518,14 @@ class TransformBuilder:
 
 
 class NetworkTransport:
-    """Handles ZeroMQ network communication (DEALER for send, optional SUB for recv)."""
+    """Handles ZeroMQ transport sockets for simulated clients."""
 
     def __init__(
         self,
         context: zmq.Context,
         server_addr: str,
         dealer_port: int,
+        transform_port: int | None,
         sub_port: int,
         room_id: str,
         enable_sub: bool = True,
@@ -530,11 +534,16 @@ class NetworkTransport:
     ):
         self.context = context
         self.server_addr = server_addr
-        self.dealer_port = dealer_port
+        self.control_port = dealer_port
+        self.dealer_port = dealer_port  # Deprecated compatibility alias
+        self.transform_port = (
+            transform_port if transform_port is not None else self.control_port + 2
+        )
         self.sub_port = sub_port
         self.room_id = room_id
         self.enable_sub = enable_sub
         self.socket: zmq.Socket | None = None
+        self.transform_socket: zmq.Socket[Any] | None = None
         self.sub_socket: zmq.Socket[Any] | None = None
         self.logger = logging.getLogger(self.__class__.__name__)
         self._socket_register = socket_register
@@ -555,21 +564,33 @@ class NetworkTransport:
                 pass
 
     def connect(self) -> bool:
-        """Establish connection to server (both DEALER and SUB)."""
+        """Establish connection to server sockets."""
         try:
-            # DEALER for sending and control message receive
-            # Low HWM (10) for backpressure detection matching Unity client
+            # Control DEALER carries RPC, Network Variables, ownership, and hello.
             self.socket = self.context.socket(zmq.DEALER)
             self._register_socket(self.socket)
             self.socket.setsockopt(zmq.LINGER, 0)
             self.socket.setsockopt(zmq.IMMEDIATE, 1)
             self.socket.setsockopt(zmq.RCVTIMEO, 0)  # Non-blocking receive
             self.socket.setsockopt(zmq.SNDTIMEO, 1000)
-            self.socket.setsockopt(zmq.SNDHWM, 10)  # Low HWM for backpressure
+            self.socket.setsockopt(zmq.SNDHWM, 1024)
+            self.socket.setsockopt(zmq.RCVHWM, 1024)
 
-            dealer_endpoint = f"{self.server_addr}:{self.dealer_port}"
-            self.socket.connect(dealer_endpoint)
-            self.logger.debug(f"Connected DEALER to {dealer_endpoint}")
+            control_endpoint = f"{self.server_addr}:{self.control_port}"
+            self.socket.connect(control_endpoint)
+            self.logger.debug(f"Connected control DEALER to {control_endpoint}")
+
+            # Transform DEALER carries only client/object pose uplink and may drop.
+            self.transform_socket = self.context.socket(zmq.DEALER)
+            self._register_socket(self.transform_socket)
+            self.transform_socket.setsockopt(zmq.LINGER, 0)
+            self.transform_socket.setsockopt(zmq.IMMEDIATE, 1)
+            self.transform_socket.setsockopt(zmq.SNDTIMEO, 0)
+            self.transform_socket.setsockopt(zmq.SNDHWM, 2)
+
+            transform_endpoint = f"{self.server_addr}:{self.transform_port}"
+            self.transform_socket.connect(transform_endpoint)
+            self.logger.debug(f"Connected transform DEALER to {transform_endpoint}")
 
             # Optional SUB for receiving broadcasts (ID mappings, NV syncs, etc.)
             # Low RCVHWM (2) to prefer recent updates and drop stale messages
@@ -615,12 +636,12 @@ class NetworkTransport:
 
     def send_transform(self, room_id: str, transform_data: dict[str, Any]) -> bool:
         """Send transform data to server."""
-        if not self.socket:
+        if not self.transform_socket:
             return False
 
         try:
             binary_data = serialize_client_transform(transform_data)
-            self.socket.send_multipart(
+            self.transform_socket.send_multipart(
                 [
                     room_id.encode("utf-8"),
                     binary_data,
@@ -633,6 +654,27 @@ class NetworkTransport:
             return False
         except Exception as e:
             self.logger.error(f"Failed to send transform: {e}")
+            return False
+
+    def send_client_hello(self, room_id: str, device_id: str) -> bool:
+        """Register the control identity for this simulated client."""
+        if not self.socket:
+            return False
+
+        try:
+            binary_data = serialize_client_hello(device_id, is_stealth=False)
+            self.socket.send_multipart(
+                [
+                    room_id.encode("utf-8"),
+                    binary_data,
+                ],
+                flags=zmq.NOBLOCK,
+            )
+            return True
+        except zmq.Again:
+            return False
+        except Exception as e:
+            self.logger.error(f"Failed to send client hello: {e}")
             return False
 
     def send_client_variable(
@@ -792,6 +834,12 @@ class NetworkTransport:
             finally:
                 self._unregister_socket(self.socket)
             self.socket = None
+        if self.transform_socket:
+            try:
+                self.transform_socket.close()
+            finally:
+                self._unregister_socket(self.transform_socket)
+            self.transform_socket = None
         if self.sub_socket:
             try:
                 self.sub_socket.close()
@@ -1031,6 +1079,15 @@ class SimulatedClient:
         if not self.transport.connect():
             self.logger.error("Failed to connect to server")
             return
+
+        hello_sent = False
+        for _ in range(20):
+            if self.transport.send_client_hello(self.room_id, self.config.device_id):
+                hello_sent = True
+                break
+            time.sleep(0.05)
+        if not hello_sent:
+            self.logger.warning("Failed to send client hello before simulation start")
 
         self.running = True
         update_interval = 1.0 / self.transform_send_rate  # Calculate interval from rate
@@ -1538,6 +1595,7 @@ class ClientSimulator:
         self,
         server_addr: str,
         dealer_port: int,
+        transform_port: int | None,
         sub_port: int,  # Kept for future use
         room_id: str,
         num_clients: int,
@@ -1548,7 +1606,11 @@ class ClientSimulator:
         transform_send_rate: float = 10.0,
     ):
         self.server_addr = server_addr
-        self.dealer_port = dealer_port
+        self.control_port = dealer_port
+        self.dealer_port = dealer_port  # Deprecated compatibility alias
+        self.transform_port = (
+            transform_port if transform_port is not None else self.control_port + 2
+        )
         self.sub_port = sub_port  # Future use
         self.room_id = room_id
         self.num_clients = num_clients
@@ -1587,8 +1649,12 @@ class ClientSimulator:
         )
         ResourceManager.cleanup_ipc_socket(self.server_addr, self.logger)
         ResourceManager.log_port_occupancy(
-            self.server_addr, self.dealer_port, self.logger
+            self.server_addr, self.control_port, self.logger
         )
+        if self.transform_port != self.control_port:
+            ResourceManager.log_port_occupancy(
+                self.server_addr, self.transform_port, self.logger
+            )
 
     def _register_socket(self, socket: zmq.Socket[Any]) -> None:
         with self._sockets_lock:
@@ -1685,7 +1751,10 @@ class ClientSimulator:
             )
 
         self.logger.info(f"Starting simulation with {self.num_clients} clients")
-        self.logger.info(f"Server: {self.server_addr}:{self.dealer_port}")
+        self.logger.info(
+            f"Server control/transform: "
+            f"{self.server_addr}:{self.control_port}/{self.transform_port}"
+        )
         self.logger.info(f"Room: {self.room_id}")
         self.logger.info(
             f"Battery simulation: {'enabled' if self.simulate_battery else 'disabled'}"
@@ -1743,7 +1812,8 @@ class ClientSimulator:
             transport = NetworkTransport(
                 self.context,
                 self.server_addr,
-                self.dealer_port,
+                self.control_port,
+                self.transform_port,
                 self.sub_port,
                 self.room_id,
                 enable_sub=(
@@ -1877,10 +1947,22 @@ Examples:
         help="Server address (default: localhost)",
     )
     parser.add_argument(
+        "--control-port",
+        type=int,
+        default=None,
+        help="Server control port (default: 5555)",
+    )
+    parser.add_argument(
         "--dealer-port",
         type=int,
         default=5555,
-        help="Server DEALER port (default: 5555)",
+        help="Deprecated alias for --control-port (default: 5555)",
+    )
+    parser.add_argument(
+        "--transform-port",
+        type=int,
+        default=None,
+        help="Server transform port (default: control port + 2)",
     )
     parser.add_argument(
         "--sub-port",
@@ -1926,6 +2008,8 @@ Examples:
     )
 
     args = parser.parse_args()
+    if args.control_port is not None:
+        args.dealer_port = args.control_port
 
     # Normalize server address format: accept both "localhost" and "tcp://localhost"
     if not args.server.startswith("tcp://") and not args.server.startswith("ipc://"):
@@ -1948,6 +2032,7 @@ Examples:
     simulator = ClientSimulator(
         server_addr=args.server,
         dealer_port=args.dealer_port,
+        transform_port=args.transform_port,
         sub_port=args.sub_port,
         room_id=args.room,
         num_clients=args.clients,

--- a/STYLY-NetSync-Server/src/styly_netsync/config.py
+++ b/STYLY-NetSync-Server/src/styly_netsync/config.py
@@ -448,6 +448,7 @@ def create_config_from_args(
     # Step 1: Load default configuration (required)
     config = load_default_config()
     overrides: list[ConfigOverride] = []
+    user_config_keys: set[str] = set()
 
     # Step 2: Override with user config if specified
     if hasattr(args, "config") and args.config is not None:
@@ -466,6 +467,7 @@ def create_config_from_args(
 
         # Apply user config overrides
         if config_data:
+            user_config_keys = set(config_data.keys())
             # Track what values are being overridden (compare with existing config)
             for key, new_value in config_data.items():
                 default_value = getattr(config, key)
@@ -476,6 +478,20 @@ def create_config_from_args(
 
     # Step 3: Apply CLI overrides (highest priority)
     config = merge_cli_args(config, args)
+
+    # Step 3.5: Derive the transform port from the resolved control port unless
+    # the user set it explicitly. The transform lane defaults to
+    # control_port + 2 everywhere else (Python client/simulator and the
+    # NetSyncServer constructor), so a deployment that customizes only the
+    # control (or deprecated dealer) port must move the transform port with it;
+    # otherwise the server would bind the static default while clients send
+    # poses to control_port + 2. This is a no-op for the default ports
+    # (5555 + 2 == 5557).
+    transform_explicit = (
+        hasattr(args, "transform_port") and args.transform_port is not None
+    ) or "transform_port" in user_config_keys
+    if not transform_explicit:
+        config = dataclass_replace(config, transform_port=config.control_port + 2)
 
     # Step 4: Validate final configuration
     errors = validate_config(config)

--- a/STYLY-NetSync-Server/src/styly_netsync/config.py
+++ b/STYLY-NetSync-Server/src/styly_netsync/config.py
@@ -380,14 +380,17 @@ def merge_cli_args(config: ServerConfig, args: argparse.Namespace) -> ServerConf
     """
     updates: dict[str, Any] = {}
 
-    # Network settings from CLI
+    # Network settings from CLI.
+    # control_port is the canonical flag; --dealer-port is a deprecated alias
+    # kept for one release. When both are provided, the explicit --control-port
+    # wins so the deprecated alias can never silently override it.
     if hasattr(args, "control_port") and args.control_port is not None:
         updates["control_port"] = args.control_port
-        updates["dealer_port"] = args.control_port
-    if hasattr(args, "dealer_port") and args.dealer_port is not None:
-        # Deprecated alias for one release.
+    elif hasattr(args, "dealer_port") and args.dealer_port is not None:
         updates["control_port"] = args.dealer_port
-        updates["dealer_port"] = args.dealer_port
+    if "control_port" in updates:
+        # Keep the deprecated alias mirrored to the resolved control_port.
+        updates["dealer_port"] = updates["control_port"]
     if hasattr(args, "transform_port") and args.transform_port is not None:
         updates["transform_port"] = args.transform_port
     if hasattr(args, "pub_port") and args.pub_port is not None:

--- a/STYLY-NetSync-Server/src/styly_netsync/config.py
+++ b/STYLY-NetSync-Server/src/styly_netsync/config.py
@@ -62,7 +62,9 @@ class ServerConfig:
     """
 
     # Network settings
+    control_port: int
     dealer_port: int
+    transform_port: int
     pub_port: int
     server_discovery_port: int
     rest_api_port: int
@@ -105,7 +107,9 @@ class ServerConfig:
 # Valid config keys (for unknown key detection)
 _VALID_KEYS: set[str] = {
     # Network settings
+    "control_port",
     "dealer_port",
+    "transform_port",
     "pub_port",
     "server_discovery_port",
     "rest_api_port",
@@ -202,6 +206,12 @@ def process_toml_config(toml_data: dict[str, Any]) -> dict[str, Any]:
                     value = None
             result[key] = value
 
+    # dealer_port is a one-release compatibility alias for control_port.
+    if "control_port" not in result and "dealer_port" in result:
+        result["control_port"] = result["dealer_port"]
+    if "dealer_port" not in result and "control_port" in result:
+        result["dealer_port"] = result["control_port"]
+
     return result
 
 
@@ -235,11 +245,23 @@ def validate_config(config: ServerConfig) -> list[str]:
     errors: list[str] = []
 
     # Port validation (1-65535)
-    port_fields = ["dealer_port", "pub_port", "server_discovery_port", "rest_api_port"]
+    port_fields = [
+        "control_port",
+        "dealer_port",
+        "transform_port",
+        "pub_port",
+        "server_discovery_port",
+        "rest_api_port",
+    ]
     for field_name in port_fields:
         port = getattr(config, field_name)
         if not 1 <= port <= 65535:
             errors.append(f"{field_name} must be between 1 and 65535, got {port}")
+    if config.dealer_port != config.control_port:
+        errors.append(
+            "dealer_port is a deprecated alias and must match control_port "
+            f"({config.dealer_port} != {config.control_port})"
+        )
 
     # Timing validation (must be positive)
     timing_fields = [
@@ -359,8 +381,15 @@ def merge_cli_args(config: ServerConfig, args: argparse.Namespace) -> ServerConf
     updates: dict[str, Any] = {}
 
     # Network settings from CLI
+    if hasattr(args, "control_port") and args.control_port is not None:
+        updates["control_port"] = args.control_port
+        updates["dealer_port"] = args.control_port
     if hasattr(args, "dealer_port") and args.dealer_port is not None:
+        # Deprecated alias for one release.
+        updates["control_port"] = args.dealer_port
         updates["dealer_port"] = args.dealer_port
+    if hasattr(args, "transform_port") and args.transform_port is not None:
+        updates["transform_port"] = args.transform_port
     if hasattr(args, "pub_port") and args.pub_port is not None:
         updates["pub_port"] = args.pub_port
     if (

--- a/STYLY-NetSync-Server/src/styly_netsync/default.toml
+++ b/STYLY-NetSync-Server/src/styly_netsync/default.toml
@@ -11,8 +11,14 @@
 # Configuration priority: CLI arguments > user config > default config
 
 # Network Settings
-# ZeroMQ DEALER port for client-server communication
+# ZeroMQ DEALER/ROUTER control port for RPC, NV, ownership, and hello traffic
+control_port = 5555
+
+# Deprecated alias for control_port. Keep this equal to control_port for one release.
 dealer_port = 5555
+
+# ZeroMQ DEALER/ROUTER transform uplink port for client and object poses
+transform_port = 5557
 
 # ZeroMQ PUB port for server-to-client broadcasts
 pub_port = 5556

--- a/STYLY-NetSync-Server/src/styly_netsync/rest_bridge.py
+++ b/STYLY-NetSync-Server/src/styly_netsync/rest_bridge.py
@@ -91,11 +91,30 @@ class RoomBridge:
     """Internal client per room responsible for flushing queued variables."""
 
     def __init__(
-        self, server_addr: str, dealer_port: int, sub_port: int, room_id: str
+        self,
+        server_addr: str,
+        dealer_port: int,
+        transform_port: int,
+        sub_port: int | str | None = None,
+        room_id: str | None = None,
     ) -> None:
+        if room_id is None:
+            if isinstance(sub_port, str):
+                room_id = sub_port
+                sub_port = transform_port
+                transform_port = dealer_port + 2
+            else:
+                raise TypeError("room_id is required")
+        if sub_port is None or isinstance(sub_port, str):
+            raise TypeError("sub_port is required")
+
         self.room_id = room_id
         self._manager = net_sync_manager(
-            server=server_addr, dealer_port=dealer_port, sub_port=sub_port, room=room_id
+            server=server_addr,
+            dealer_port=dealer_port,
+            transform_port=transform_port,
+            sub_port=sub_port,
+            room=room_id,
         )
         self._running = False
         self._thread = threading.Thread(target=self._loop, daemon=True)
@@ -255,9 +274,12 @@ class RoomBridge:
 class BridgeManager:
     """Factory and cache for per-room bridges."""
 
-    def __init__(self, server_addr: str, dealer_port: int, sub_port: int) -> None:
+    def __init__(
+        self, server_addr: str, dealer_port: int, transform_port: int, sub_port: int
+    ) -> None:
         self._server_addr = server_addr
         self._dealer_port = dealer_port
+        self._transform_port = transform_port
         self._sub_port = sub_port
         self._bridges: dict[str, RoomBridge] = {}
         self._lock = threading.RLock()
@@ -268,7 +290,11 @@ class BridgeManager:
             bridge = self._bridges.get(room_id)
             if bridge is None:
                 bridge = RoomBridge(
-                    self._server_addr, self._dealer_port, self._sub_port, room_id
+                    self._server_addr,
+                    self._dealer_port,
+                    self._transform_port,
+                    self._sub_port,
+                    room_id,
                 )
                 bridge.start()
                 self._bridges[room_id] = bridge
@@ -279,6 +305,7 @@ def create_app(
     server_addr: str,
     dealer_port: int,
     sub_port: int,
+    transform_port: int = 5557,
     server: ClientVariableServer | None = None,
 ) -> FastAPI:
     """Create the FastAPI application hosting the REST bridge."""
@@ -293,7 +320,7 @@ def create_app(
         max_age=3600,  # Cache preflight requests for 1 hour
     )
 
-    manager = BridgeManager(server_addr, dealer_port, sub_port)
+    manager = BridgeManager(server_addr, dealer_port, transform_port, sub_port)
 
     @app.get("/")
     def health_check() -> dict[str, str]:

--- a/STYLY-NetSync-Server/src/styly_netsync/rest_bridge.py
+++ b/STYLY-NetSync-Server/src/styly_netsync/rest_bridge.py
@@ -100,6 +100,11 @@ class RoomBridge:
     ) -> None:
         if room_id is None:
             if isinstance(sub_port, str):
+                logger.warning(
+                    "RoomBridge(server_addr, dealer_port, sub_port, room_id) is "
+                    "deprecated; pass transform_port, sub_port, and room_id "
+                    "explicitly to avoid deriving transform_port from dealer_port"
+                )
                 room_id = sub_port
                 sub_port = transform_port
                 transform_port = dealer_port + 2

--- a/STYLY-NetSync-Server/src/styly_netsync/server.py
+++ b/STYLY-NetSync-Server/src/styly_netsync/server.py
@@ -797,14 +797,6 @@ class NetSyncServer:
             client_identity, room_id, "control_identity"
         )
 
-    def _get_device_id_from_transform_identity(
-        self, client_identity: bytes, room_id: str
-    ) -> str | None:
-        """Get device ID from a transform-lane identity."""
-        return self._get_device_id_from_lane_identity(
-            client_identity, room_id, "transform_identity"
-        )
-
     def _get_device_id_from_lane_identity(
         self, client_identity: bytes, room_id: str, identity_key: str
     ) -> str | None:
@@ -1195,14 +1187,18 @@ class NetSyncServer:
         if msg_type == binary_serializer.MSG_CLIENT_POSE:
             self._handle_client_transform(client_identity, room_id, data, raw_payload)
         elif msg_type == binary_serializer.MSG_OBJECT_POSE:
-            sender_device_id = self._get_device_id_from_transform_identity(
-                client_identity, room_id
-            )
+            # Attribute the pose using the deviceId carried in the payload, not the
+            # transform-lane socket identity. A stealth owner registers only on the
+            # control lane and never sends MSG_CLIENT_POSE, so it never binds a
+            # transform_identity; relying on that identity would silently drop its
+            # object poses.
+            sender_device_id = data.get("deviceId")
             if sender_device_id:
                 sender_client_no = self._get_client_no_for_device_id(
                     room_id, sender_device_id
                 )
-                self._handle_object_pose(room_id, sender_client_no, data)
+                if sender_client_no:
+                    self._handle_object_pose(room_id, sender_client_no, data)
         else:
             self._drop_wrong_lane("transform", room_id, msg_type)
 
@@ -1296,6 +1292,11 @@ class NetSyncServer:
             is_new_client = device_id not in self.rooms[room_id]
             is_reconnect = False
             stealth_changed = False
+            # True when the control lane binds for the first time on an entry
+            # that a transform message already created (transform-before-hello
+            # socket-ordering race). Such a client still needs the full
+            # new-client object-ownership sync.
+            control_was_unbound = False
 
             if is_new_client:
                 self.rooms[room_id][device_id] = {
@@ -1321,6 +1322,7 @@ class NetSyncServer:
                 old_identity = client_data.get("control_identity")
                 old_stealth = bool(client_data.get("is_stealth", False))
                 is_reconnect = old_identity != client_identity
+                control_was_unbound = old_identity is None
                 stealth_changed = old_stealth != is_stealth
                 client_data["control_identity"] = client_identity
                 client_data["last_update"] = now
@@ -1337,6 +1339,12 @@ class NetSyncServer:
             self._sync_objects_to_new_client(client_identity, room_id)
         elif is_reconnect:
             self._sync_network_variables_to_client(room_id, client_identity)
+            # If a transform message created this entry before the hello arrived,
+            # the control lane is binding for the first time here. Send the
+            # new-client object-ownership sync that the transform handler had to
+            # skip because no control identity existed yet.
+            if control_was_unbound:
+                self._sync_objects_to_new_client(client_identity, room_id)
 
     def _handle_client_transform(
         self,

--- a/STYLY-NetSync-Server/src/styly_netsync/server.py
+++ b/STYLY-NetSync-Server/src/styly_netsync/server.py
@@ -264,7 +264,6 @@ class NetSyncServer:
         self._router_queue_ctrl: Queue[tuple[bytes, bytes, bytes]] = Queue(
             maxsize=self.ROUTER_CTRL_QUEUE_MAXSIZE
         )
-        self._blocked_router_packet: tuple[bytes, bytes, bytes] | None = None
 
         # Statistics for router control messages
         self.ctrl_unicast_sent = 0
@@ -666,8 +665,8 @@ class NetSyncServer:
         """Thread-safe enqueue of a control message for unicast via ROUTER.
 
         Used for control-like messages (RPC, NV sync, ID mapping) that are
-        retried FIFO under socket backpressure. Messages are dropped only when
-        this application queue is already full.
+        retried after socket backpressure. Messages are dropped only when this
+        application queue is already full.
 
         Args:
             identity: Client's ZeroMQ identity (from ROUTER socket)
@@ -1204,12 +1203,11 @@ class NetSyncServer:
             # transform_identity; relying on that identity would silently drop its
             # object poses.
             sender_device_id = data.get("deviceId")
-            if sender_device_id:
-                sender_client_no = self._get_client_no_for_device_id(
+            if isinstance(sender_device_id, str) and sender_device_id:
+                sender_client_no = self._get_or_assign_client_no(
                     room_id, sender_device_id
                 )
-                if sender_client_no:
-                    self._handle_object_pose(room_id, sender_client_no, data)
+                self._handle_object_pose(room_id, sender_client_no, data)
         else:
             self._drop_wrong_lane("transform", room_id, msg_type)
 
@@ -1253,28 +1251,32 @@ class NetSyncServer:
         if router is None:
             return
 
+        deferred_packets: list[tuple[bytes, bytes, bytes]] = []
+        deferred_identities: set[bytes] = set()
+
         for _ in range(self.ROUTER_CTRL_DRAIN_BATCH):
-            if self._blocked_router_packet is not None:
-                ident, room_bytes, msg_bytes = self._blocked_router_packet
-            else:
-                try:
-                    ident, room_bytes, msg_bytes = self._router_queue_ctrl.get_nowait()
-                except Empty:
-                    break
+            try:
+                ident, room_bytes, msg_bytes = self._router_queue_ctrl.get_nowait()
+            except Empty:
+                break
+
+            if ident in deferred_identities:
+                deferred_packets.append((ident, room_bytes, msg_bytes))
+                continue
 
             try:
                 # Send via ROUTER: [identity, room_id, payload]
                 router.send_multipart(
                     [ident, room_bytes, msg_bytes], flags=zmq.DONTWAIT
                 )
-                self._blocked_router_packet = None
                 self._increment_stat("ctrl_unicast_sent")
             except zmq.Again:
-                self._blocked_router_packet = (ident, room_bytes, msg_bytes)
+                # Defer this identity to the tail so one slow client does not
+                # head-of-line block control messages for the rest of the room.
+                deferred_identities.add(ident)
+                deferred_packets.append((ident, room_bytes, msg_bytes))
                 self._increment_stat("ctrl_unicast_wouldblock")
-                break
             except Exception as exc:
-                self._blocked_router_packet = None
                 if isinstance(exc, zmq.ZMQError) and getattr(
                     exc, "errno", None
                 ) == getattr(zmq, "EHOSTUNREACH", None):
@@ -1283,6 +1285,15 @@ class NetSyncServer:
                 else:
                     self._increment_stat("ctrl_unicast_dropped")
                     logger.error(f"Router send error: {exc}")
+
+        for packet in deferred_packets:
+            try:
+                self._router_queue_ctrl.put_nowait(packet)
+            except Full:
+                self._increment_stat("ctrl_unicast_dropped")
+                logger.warning(
+                    "Router control queue full: dropping deferred control message"
+                )
 
     def _handle_client_hello(
         self, client_identity: bytes, room_id: str, data: dict[str, Any]
@@ -1295,11 +1306,10 @@ class NetSyncServer:
 
         device_id = device_id_raw
         is_stealth = bool(data.get("isStealthMode", False))
-        client_no = self._get_or_assign_client_no(room_id, device_id)
         now = time.monotonic()
 
         with self._rooms_lock:
-            self._initialize_room(room_id)
+            client_no = self._get_or_assign_client_no(room_id, device_id)
             is_new_client = device_id not in self.rooms[room_id]
             is_reconnect = False
             stealth_changed = False
@@ -1383,6 +1393,7 @@ class NetSyncServer:
         data_with_client_no["clientNo"] = client_no
         data_with_client_no["deviceId"] = device_id  # Keep device ID for reference
 
+        control_identity = None
         with self._rooms_lock:
             # Create room if it doesn't exist
             self._initialize_room(room_id)
@@ -1436,8 +1447,6 @@ class NetSyncServer:
             if is_new_client:
                 self.room_id_mapping_dirty[room_id] = True
 
-        control_identity = None
-        with self._rooms_lock:
             control_identity = self.rooms[room_id][device_id].get("control_identity")
 
         # Sync control state only through the control lane. If transform arrived

--- a/STYLY-NetSync-Server/src/styly_netsync/server.py
+++ b/STYLY-NetSync-Server/src/styly_netsync/server.py
@@ -1107,7 +1107,18 @@ class NetSyncServer:
                 break
 
             self._increment_stat("message_count")
-            self._handle_incoming_router_message(lane, parts)
+            # Isolate per-message failures: a single malformed message or a
+            # throwing handler must not abort draining the rest of this socket's
+            # backlog (which would stall every other client until the next poll).
+            try:
+                self._handle_incoming_router_message(lane, parts)
+            except Exception as exc:
+                logger.warning(
+                    "Failed to handle %s-lane message (%d parts): %s",
+                    lane,
+                    len(parts),
+                    exc,
+                )
 
     def _handle_incoming_router_message(self, lane: str, parts: list[bytes]) -> None:
         """Dispatch one incoming ROUTER multipart message for a specific lane."""

--- a/STYLY-NetSync-Server/src/styly_netsync/server.py
+++ b/STYLY-NetSync-Server/src/styly_netsync/server.py
@@ -170,6 +170,8 @@ class NetSyncServer:
     def __init__(
         self,
         dealer_port: int | None = None,
+        control_port: int | None = None,
+        transform_port: int | None = None,
         pub_port: int | None = None,
         enable_server_discovery: bool | None = None,
         server_discovery_port: int | None = None,
@@ -184,9 +186,19 @@ class NetSyncServer:
         self._config = config
 
         # Apply overrides from individual arguments (for backward compatibility)
-        self.dealer_port = (
-            dealer_port if dealer_port is not None else config.dealer_port
-        )
+        resolved_control_port = control_port
+        if resolved_control_port is None:
+            resolved_control_port = (
+                dealer_port if dealer_port is not None else config.control_port
+            )
+        self.control_port = resolved_control_port
+        self.dealer_port = self.control_port  # Deprecated compatibility alias
+        if transform_port is not None:
+            self.transform_port = transform_port
+        elif control_port is not None or dealer_port is not None:
+            self.transform_port = self.control_port + 2
+        else:
+            self.transform_port = config.transform_port
         self.pub_port = pub_port if pub_port is not None else config.pub_port
         self.context = zmq.Context()
 
@@ -228,6 +240,8 @@ class NetSyncServer:
         self.tcp_server_discovery_running = False
 
         # Sockets
+        self.control_router: zmq.sugar.socket.Socket[bytes] | None = None
+        self.transform_router: zmq.sugar.socket.Socket[bytes] | None = None
         self.router: zmq.sugar.socket.Socket[bytes] | None = None
         self.pub: zmq.sugar.socket.Socket[bytes] | None = (
             None  # Will be created/owned by Publisher thread only
@@ -250,11 +264,14 @@ class NetSyncServer:
         self._router_queue_ctrl: Queue[tuple[bytes, bytes, bytes]] = Queue(
             maxsize=self.ROUTER_CTRL_QUEUE_MAXSIZE
         )
+        self._blocked_router_packet: tuple[bytes, bytes, bytes] | None = None
 
         # Statistics for router control messages
         self.ctrl_unicast_sent = 0
         self.ctrl_unicast_wouldblock = 0
         self.ctrl_unicast_dropped = 0
+        self.ctrl_unicast_unreachable = 0
+        self.wrong_lane_dropped = 0
 
         # PUB socket monitor for tracking SUB connections
         self._pub_monitor: zmq.sugar.socket.Socket[bytes] | None = None
@@ -649,8 +666,8 @@ class NetSyncServer:
         """Thread-safe enqueue of a control message for unicast via ROUTER.
 
         Used for control-like messages (RPC, NV sync, ID mapping) that are
-        more reliable than PUB/SUB, but still drop under backpressure and
-        send failures (ring-buffer drop-on-full and non-blocking router drain).
+        retried FIFO under socket backpressure. Messages are dropped only when
+        this application queue is already full.
 
         Args:
             identity: Client's ZeroMQ identity (from ROUTER socket)
@@ -661,26 +678,8 @@ class NetSyncServer:
         try:
             self._router_queue_ctrl.put_nowait((identity, room_bytes, message_bytes))
         except Full:
-            # Ring-buffer behavior: drop oldest to make room for newest
-            try:
-                _ = self._router_queue_ctrl.get_nowait()
-            except Empty:
-                # Queue became empty between Full and get_nowait (rare race condition)
-                pass
-            else:
-                # Count and log the drop of the oldest message
-                self._increment_stat("ctrl_unicast_dropped")
-                logger.debug(
-                    "Router control queue full: dropping oldest control message"
-                )
-            try:
-                self._router_queue_ctrl.put_nowait(
-                    (identity, room_bytes, message_bytes)
-                )
-            except Full:
-                # If still full after removing one, count as dropped (another drop)
-                self._increment_stat("ctrl_unicast_dropped")
-                logger.debug("Router control queue full: dropping new message")
+            self._increment_stat("ctrl_unicast_dropped")
+            logger.warning("Router control queue full: dropping new control message")
 
     def _send_ctrl_to_room_via_router(
         self,
@@ -706,7 +705,7 @@ class NetSyncServer:
 
             # Collect all client identities in the room while holding the lock
             for _device_id, client_data in self.rooms[room_id].items():
-                identity = client_data.get("identity")
+                identity = client_data.get("control_identity")
                 if identity is None:
                     continue
                 if exclude_identity is not None and identity == exclude_identity:
@@ -783,11 +782,37 @@ class NetSyncServer:
     def _get_device_id_from_identity(
         self, client_identity: bytes, room_id: str
     ) -> str | None:
-        """Get device ID from client identity"""
+        """Get device ID from any known client identity."""
+        return self._get_device_id_from_lane_identity(
+            client_identity, room_id, "control_identity"
+        ) or self._get_device_id_from_lane_identity(
+            client_identity, room_id, "transform_identity"
+        )
+
+    def _get_device_id_from_control_identity(
+        self, client_identity: bytes, room_id: str
+    ) -> str | None:
+        """Get device ID from a control-lane identity."""
+        return self._get_device_id_from_lane_identity(
+            client_identity, room_id, "control_identity"
+        )
+
+    def _get_device_id_from_transform_identity(
+        self, client_identity: bytes, room_id: str
+    ) -> str | None:
+        """Get device ID from a transform-lane identity."""
+        return self._get_device_id_from_lane_identity(
+            client_identity, room_id, "transform_identity"
+        )
+
+    def _get_device_id_from_lane_identity(
+        self, client_identity: bytes, room_id: str, identity_key: str
+    ) -> str | None:
+        """Get device ID from a lane-specific ZeroMQ identity."""
         with self._rooms_lock:
             if room_id in self.rooms:
                 for device_id, client_data in self.rooms[room_id].items():
-                    if client_data.get("identity") == client_identity:
+                    if client_data.get(identity_key) == client_identity:
                         return device_id
         return None
 
@@ -869,22 +894,16 @@ class NetSyncServer:
             # Raise FD soft limit early to avoid connection drops when many clients connect
             self._bump_fd_soft_limit(self.DEFAULT_FD_LIMIT)
 
-            # Setup ROUTER socket
-            self.router = self.context.socket(zmq.ROUTER)
-            # Set LINGER=0 to prevent FD accumulation during rapid connect/disconnect
-            self.router.setsockopt(zmq.LINGER, 0)
-            # Increase accept backlog to survive connection stampedes from simulators
-            try:
-                self.router.setsockopt(zmq.BACKLOG, self.ROUTER_BACKLOG)
-            except Exception:
-                # Best effort; fall back to default backlog if unsupported
-                pass
-            try:
-                self.router.setsockopt(zmq.RCVHWM, 10000)
-            except Exception:
-                # Best effort; ignore if high-water mark option is unsupported
-                pass
-            self.router.bind(f"tcp://*:{self.dealer_port}")
+            # Setup ROUTER sockets. Control and transform traffic use separate
+            # pipes because they have different backpressure/drop semantics.
+            self.control_router = self.context.socket(zmq.ROUTER)
+            self._configure_router_socket(self.control_router, mandatory=True)
+            self.control_router.bind(f"tcp://*:{self.control_port}")
+            self.router = self.control_router  # Deprecated compatibility alias
+
+            self.transform_router = self.context.socket(zmq.ROUTER)
+            self._configure_router_socket(self.transform_router, mandatory=False)
+            self.transform_router.bind(f"tcp://*:{self.transform_port}")
 
             # Start Publisher thread (it creates/binds PUB)
             self._publisher_running = True
@@ -900,8 +919,7 @@ class NetSyncServer:
                 )
             if self._publisher_exception:
                 # Clean up and re-raise the failure so callers get a proper error
-                if self.router:
-                    self.router.close()
+                self._close_router_sockets()
                 self.context.term()
                 raise self._publisher_exception
 
@@ -927,7 +945,8 @@ class NetSyncServer:
 
                 app = create_app(
                     server_addr="tcp://127.0.0.1",
-                    dealer_port=self.dealer_port,
+                    dealer_port=self.control_port,
+                    transform_port=self.transform_port,
                     sub_port=self.pub_port,
                     server=self,
                 )
@@ -949,7 +968,9 @@ class NetSyncServer:
         except zmq.error.ZMQError as e:
             if "Address already in use" in str(e) or "Address in use" in str(e):
                 logger.error(
-                    f"Error: Another server instance is already running on port {self.dealer_port}"
+                    "Error: Another server instance is already running on one "
+                    f"of the NetSync ports ({self.control_port}, "
+                    f"{self.transform_port}, {self.pub_port})"
                 )
                 logger.error(
                     "Please stop the existing server before starting a new one."
@@ -958,18 +979,18 @@ class NetSyncServer:
                 # Provide platform-specific instructions
                 if platform.system() == "Windows":
                     logger.error(
-                        f"You can find the process using: netstat -ano | findstr :{self.dealer_port}"
+                        "You can find the process using: "
+                        f"netstat -ano | findstr :{self.control_port}"
                     )
                     logger.error("And stop it using: taskkill /PID <PID> /F")
                 else:
                     logger.error(
-                        f"You can find the process using: lsof -i :{self.dealer_port}"
+                        f"You can find the process using: lsof -i :{self.control_port}"
                     )
                     logger.error("And stop it using: kill <PID>")
 
                 # Clean up sockets if partially created
-                if self.router:
-                    self.router.close()
+                self._close_router_sockets()
                 self.context.term()
                 raise SystemExit(1) from e
             else:
@@ -1033,8 +1054,7 @@ class NetSyncServer:
             else:
                 logger.info("Publisher thread stopped")
 
-        if self.router:
-            self.router.close()
+        self._close_router_sockets()
         if self.context:
             self.context.term()
 
@@ -1043,116 +1063,39 @@ class NetSyncServer:
             f"Broadcasts sent: {self.broadcast_count}, Skipped broadcasts: {self.skipped_broadcasts}, "
             f"Control unicasts sent: {self.ctrl_unicast_sent}, "
             f"Control unicast wouldblock: {self.ctrl_unicast_wouldblock}, "
-            f"Control unicast dropped: {self.ctrl_unicast_dropped}"
+            f"Control unicast dropped: {self.ctrl_unicast_dropped}, "
+            f"Control unicast unreachable: {self.ctrl_unicast_unreachable}, "
+            f"Wrong-lane dropped: {self.wrong_lane_dropped}"
         )
+
+    def _close_router_sockets(self) -> None:
+        """Close ROUTER sockets and clear aliases."""
+        if self.control_router is not None:
+            self.control_router.close()
+            self.control_router = None
+        if self.transform_router is not None:
+            self.transform_router.close()
+            self.transform_router = None
+        self.router = None
 
     def _receive_loop(self) -> None:
         """Receive messages from clients"""
+        poller = zmq.Poller()
+        control_router = self.control_router
+        transform_router = self.transform_router
+        if control_router is not None:
+            poller.register(control_router, zmq.POLLIN)
+        if transform_router is not None:
+            poller.register(transform_router, zmq.POLLIN)
+
         while self.running:
             try:
-                # Check for incoming messages
-                if self.router is not None and self.router.poll(
-                    self.POLL_TIMEOUT, zmq.POLLIN
-                ):
-                    # Receive multipart message [identity, room_id, message]
-                    parts = self.router.recv_multipart()
-                    self._increment_stat("message_count")
+                events = dict(poller.poll(self.POLL_TIMEOUT))
+                if control_router is not None and control_router in events:
+                    self._drain_incoming_router(control_router, "control")
+                if transform_router is not None and transform_router in events:
+                    self._drain_incoming_router(transform_router, "transform")
 
-                    if len(parts) >= 3:
-                        client_identity = parts[0]
-                        room_id_bytes = parts[1]
-                        message_bytes = parts[2]
-                        try:
-                            room_id = room_id_bytes.decode("utf-8")
-                        except UnicodeDecodeError as e:
-                            logger.error(f"Failed to decode room ID: {e}")
-                            continue
-                        # Protocol v5 binary-only handling (no JSON fallback)
-                        try:
-                            msg_type, data, raw_payload = binary_serializer.deserialize(
-                                message_bytes
-                            )
-                            if data is None:
-                                logger.warning("Received message with None data")
-                                continue
-                            if msg_type == binary_serializer.MSG_CLIENT_POSE:
-                                self._handle_client_transform(
-                                    client_identity, room_id, data, raw_payload
-                                )
-                            elif msg_type == binary_serializer.MSG_RPC:
-                                # Get sender's client number from client identity
-                                sender_device_id = self._get_device_id_from_identity(
-                                    client_identity, room_id
-                                )
-                                if sender_device_id:
-                                    sender_client_no = (
-                                        self._get_client_no_for_device_id(
-                                            room_id, sender_device_id
-                                        )
-                                    )
-                                    data["senderClientNo"] = sender_client_no
-                                # Send RPC to room excluding sender
-                                self._send_rpc_to_room(room_id, data)
-                            # MSG_RPC_SERVER and MSG_RPC_CLIENT are reserved for future use
-                            elif msg_type == binary_serializer.MSG_GLOBAL_VAR_SET:
-                                # Buffer global variable set request (no rate limit drops)
-                                self._buffer_global_var_set(room_id, data)
-                                self._monitor_nv_sliding_window(room_id)
-                            elif msg_type == binary_serializer.MSG_CLIENT_VAR_SET:
-                                # Buffer client variable set request (no rate limit drops)
-                                self._buffer_client_var_set(room_id, data)
-                                self._monitor_nv_sliding_window(room_id)
-                            elif msg_type == binary_serializer.MSG_CLIENT_VAR_CLEAR:
-                                self._handle_client_var_clear(
-                                    client_identity, room_id, data
-                                )
-                            elif msg_type == binary_serializer.MSG_OBJECT_POSE:
-                                sender_device_id = self._get_device_id_from_identity(
-                                    client_identity, room_id
-                                )
-                                if sender_device_id:
-                                    sender_client_no = (
-                                        self._get_client_no_for_device_id(
-                                            room_id, sender_device_id
-                                        )
-                                    )
-                                    self._handle_object_pose(
-                                        room_id, sender_client_no, data
-                                    )
-                            elif (
-                                msg_type
-                                == binary_serializer.MSG_OBJECT_OWNERSHIP_REQUEST
-                            ):
-                                sender_device_id = self._get_device_id_from_identity(
-                                    client_identity, room_id
-                                )
-                                if sender_device_id:
-                                    sender_client_no = (
-                                        self._get_client_no_for_device_id(
-                                            room_id, sender_device_id
-                                        )
-                                    )
-                                    self._handle_object_ownership_request(
-                                        client_identity,
-                                        room_id,
-                                        sender_client_no,
-                                        data,
-                                    )
-                            else:
-                                logger.warning(f"Unknown binary msg_type: {msg_type}")
-                        except Exception as e:
-                            logger.warning(
-                                "Failed to decode protocol v5 message from room %s: %s",
-                                room_id,
-                                e,
-                            )
-
-                    else:
-                        logger.warning(
-                            f"Received incomplete message with only {len(parts)} parts"
-                        )
-
-                # Drain control messages via ROUTER after processing incoming
                 self._drain_router_ctrl_queue()
 
             except Exception as e:
@@ -1161,6 +1104,137 @@ class NetSyncServer:
 
         logger.info("Receive loop ended")
 
+    def _drain_incoming_router(
+        self, router: zmq.sugar.socket.Socket[bytes], lane: str
+    ) -> None:
+        """Drain all currently available messages from one ROUTER socket."""
+        while True:
+            try:
+                parts = router.recv_multipart(flags=zmq.DONTWAIT)
+            except zmq.Again:
+                break
+
+            self._increment_stat("message_count")
+            self._handle_incoming_router_message(lane, parts)
+
+    def _handle_incoming_router_message(self, lane: str, parts: list[bytes]) -> None:
+        """Dispatch one incoming ROUTER multipart message for a specific lane."""
+        if len(parts) < 3:
+            logger.warning(
+                "Received incomplete %s message with %s parts", lane, len(parts)
+            )
+            return
+
+        client_identity = parts[0]
+        room_id_bytes = parts[1]
+        message_bytes = parts[2]
+        try:
+            room_id = room_id_bytes.decode("utf-8")
+        except UnicodeDecodeError as exc:
+            logger.error("Failed to decode room ID on %s lane: %s", lane, exc)
+            return
+
+        msg_type, data, raw_payload = binary_serializer.deserialize(message_bytes)
+        if data is None:
+            logger.warning("Received invalid %s-lane message type %s", lane, msg_type)
+            return
+
+        if lane == "control":
+            self._handle_control_message(client_identity, room_id, msg_type, data)
+        else:
+            self._handle_transform_message(
+                client_identity, room_id, msg_type, data, raw_payload
+            )
+
+    def _handle_control_message(
+        self, client_identity: bytes, room_id: str, msg_type: int, data: dict[str, Any]
+    ) -> None:
+        """Handle one message received on the control lane."""
+        if msg_type == binary_serializer.MSG_CLIENT_HELLO:
+            self._handle_client_hello(client_identity, room_id, data)
+        elif msg_type == binary_serializer.MSG_RPC:
+            sender_device_id = self._get_device_id_from_control_identity(
+                client_identity, room_id
+            )
+            if sender_device_id:
+                data["senderClientNo"] = self._get_client_no_for_device_id(
+                    room_id, sender_device_id
+                )
+            self._send_rpc_to_room(room_id, data)
+        elif msg_type == binary_serializer.MSG_GLOBAL_VAR_SET:
+            self._buffer_global_var_set(room_id, data)
+            self._monitor_nv_sliding_window(room_id)
+        elif msg_type == binary_serializer.MSG_CLIENT_VAR_SET:
+            self._buffer_client_var_set(room_id, data)
+            self._monitor_nv_sliding_window(room_id)
+        elif msg_type == binary_serializer.MSG_CLIENT_VAR_CLEAR:
+            self._handle_client_var_clear(client_identity, room_id, data)
+        elif msg_type == binary_serializer.MSG_OBJECT_OWNERSHIP_REQUEST:
+            sender_device_id = self._get_device_id_from_control_identity(
+                client_identity, room_id
+            )
+            if sender_device_id:
+                sender_client_no = self._get_client_no_for_device_id(
+                    room_id, sender_device_id
+                )
+                self._handle_object_ownership_request(
+                    client_identity, room_id, sender_client_no, data
+                )
+        else:
+            self._drop_wrong_lane("control", room_id, msg_type)
+
+    def _handle_transform_message(
+        self,
+        client_identity: bytes,
+        room_id: str,
+        msg_type: int,
+        data: dict[str, Any],
+        raw_payload: bytes,
+    ) -> None:
+        """Handle one message received on the transform lane."""
+        if msg_type == binary_serializer.MSG_CLIENT_POSE:
+            self._handle_client_transform(client_identity, room_id, data, raw_payload)
+        elif msg_type == binary_serializer.MSG_OBJECT_POSE:
+            sender_device_id = self._get_device_id_from_transform_identity(
+                client_identity, room_id
+            )
+            if sender_device_id:
+                sender_client_no = self._get_client_no_for_device_id(
+                    room_id, sender_device_id
+                )
+                self._handle_object_pose(room_id, sender_client_no, data)
+        else:
+            self._drop_wrong_lane("transform", room_id, msg_type)
+
+    def _drop_wrong_lane(self, lane: str, room_id: str, msg_type: int) -> None:
+        """Record and log a message received on the wrong transport lane."""
+        self._increment_stat("wrong_lane_dropped")
+        logger.warning(
+            "Dropped wrong-lane message: lane=%s room=%s msg_type=%s",
+            lane,
+            room_id,
+            msg_type,
+        )
+
+    def _configure_router_socket(
+        self, router: zmq.sugar.socket.Socket[bytes], mandatory: bool
+    ) -> None:
+        """Apply common ROUTER socket options."""
+        router.setsockopt(zmq.LINGER, 0)
+        try:
+            router.setsockopt(zmq.BACKLOG, self.ROUTER_BACKLOG)
+        except Exception:
+            pass
+        try:
+            router.setsockopt(zmq.RCVHWM, 10000)
+        except Exception:
+            pass
+        if mandatory:
+            try:
+                router.setsockopt(zmq.ROUTER_MANDATORY, 1)
+            except Exception:
+                logger.warning("ROUTER_MANDATORY is not supported by this platform")
+
     def _drain_router_ctrl_queue(self) -> None:
         """Drain pending control messages from the router queue.
 
@@ -1168,27 +1242,101 @@ class NetSyncServer:
         via the ROUTER socket to specific clients. It is called from the
         receive loop to ensure timely delivery of control messages.
         """
-        router = self.router
+        router = self.control_router if self.control_router is not None else self.router
         if router is None:
             return
 
         for _ in range(self.ROUTER_CTRL_DRAIN_BATCH):
-            try:
-                ident, room_bytes, msg_bytes = self._router_queue_ctrl.get_nowait()
-            except Empty:
-                break
+            if self._blocked_router_packet is not None:
+                ident, room_bytes, msg_bytes = self._blocked_router_packet
+            else:
+                try:
+                    ident, room_bytes, msg_bytes = self._router_queue_ctrl.get_nowait()
+                except Empty:
+                    break
 
             try:
                 # Send via ROUTER: [identity, room_id, payload]
                 router.send_multipart(
                     [ident, room_bytes, msg_bytes], flags=zmq.DONTWAIT
                 )
+                self._blocked_router_packet = None
                 self._increment_stat("ctrl_unicast_sent")
             except zmq.Again:
-                # Socket would block - drop the message (don't re-enqueue)
+                self._blocked_router_packet = (ident, room_bytes, msg_bytes)
                 self._increment_stat("ctrl_unicast_wouldblock")
+                break
             except Exception as exc:
-                logger.error(f"Router send error: {exc}")
+                self._blocked_router_packet = None
+                if isinstance(exc, zmq.ZMQError) and getattr(
+                    exc, "errno", None
+                ) == getattr(zmq, "EHOSTUNREACH", None):
+                    self._increment_stat("ctrl_unicast_unreachable")
+                    logger.warning("Router control identity unreachable: %s", exc)
+                else:
+                    self._increment_stat("ctrl_unicast_dropped")
+                    logger.error(f"Router send error: {exc}")
+
+    def _handle_client_hello(
+        self, client_identity: bytes, room_id: str, data: dict[str, Any]
+    ) -> None:
+        """Register or refresh a client's control-lane identity."""
+        device_id_raw = data.get("deviceId")
+        if device_id_raw is None or not isinstance(device_id_raw, str):
+            logger.warning("Received client hello with missing or invalid deviceId")
+            return
+
+        device_id = device_id_raw
+        is_stealth = bool(data.get("isStealthMode", False))
+        client_no = self._get_or_assign_client_no(room_id, device_id)
+        now = time.monotonic()
+
+        with self._rooms_lock:
+            self._initialize_room(room_id)
+            is_new_client = device_id not in self.rooms[room_id]
+            is_reconnect = False
+            stealth_changed = False
+
+            if is_new_client:
+                self.rooms[room_id][device_id] = {
+                    "control_identity": client_identity,
+                    "transform_identity": None,
+                    "last_update": now,
+                    "transform_data": None,
+                    "client_no": client_no,
+                    "is_stealth": is_stealth,
+                }
+                self.room_id_mapping_dirty[room_id] = True
+                stealth_text = " (stealth mode)" if is_stealth else ""
+                logger.info(
+                    "New client %s... (client number: %s)%s registered control lane "
+                    "in room %s",
+                    device_id[:8],
+                    client_no,
+                    stealth_text,
+                    room_id,
+                )
+            else:
+                client_data = self.rooms[room_id][device_id]
+                old_identity = client_data.get("control_identity")
+                old_stealth = bool(client_data.get("is_stealth", False))
+                is_reconnect = old_identity != client_identity
+                stealth_changed = old_stealth != is_stealth
+                client_data["control_identity"] = client_identity
+                client_data["last_update"] = now
+                client_data["client_no"] = client_no
+                client_data["is_stealth"] = is_stealth
+                if is_reconnect or stealth_changed:
+                    self.room_id_mapping_dirty[room_id] = True
+
+            if is_stealth:
+                self.room_dirty_flags[room_id] = True
+
+        if is_new_client:
+            self._sync_network_variables_to_new_client(room_id)
+            self._sync_objects_to_new_client(client_identity, room_id)
+        elif is_reconnect:
+            self._sync_network_variables_to_client(room_id, client_identity)
 
     def _handle_client_transform(
         self,
@@ -1225,7 +1373,8 @@ class NetSyncServer:
             is_reconnect = False
             if is_new_client:
                 self.rooms[room_id][device_id] = {
-                    "identity": client_identity,
+                    "control_identity": None,
+                    "transform_identity": client_identity,
                     "last_update": time.monotonic(),
                     "transform_data": data_with_client_no,
                     "client_no": client_no,
@@ -1240,15 +1389,11 @@ class NetSyncServer:
                 )
             else:
                 # Update existing client and mark room as dirty.
-                # Detect reconnection: when a client reconnects (e.g. after
-                # sleep/wake) before the timeout removes it from rooms, the
-                # DEALER socket is recreated with a new ZMQ identity.  Without
-                # updating the identity the server would send ROUTER control
-                # messages (RPC, NV sync) to the stale identity, silently
-                # losing them.
-                old_identity = self.rooms[room_id][device_id].get("identity")
+                # Detect transform-lane reconnection without overwriting the
+                # control identity used for reliable unicasts.
+                old_identity = self.rooms[room_id][device_id].get("transform_identity")
                 is_reconnect = old_identity != client_identity
-                self.rooms[room_id][device_id]["identity"] = client_identity
+                self.rooms[room_id][device_id]["transform_identity"] = client_identity
                 self.rooms[room_id][device_id]["transform_data"] = data_with_client_no
                 self.rooms[room_id][device_id]["last_update"] = time.monotonic()
                 self.rooms[room_id][device_id]["client_no"] = client_no
@@ -1261,8 +1406,8 @@ class NetSyncServer:
                 self.room_dirty_flags[room_id] = True
 
                 if is_reconnect:
-                    # Re-broadcast ID mapping so the reconnected client gets
-                    # the current device-to-clientNo table.
+                    # Re-broadcast ID mapping so peers keep a fresh view of
+                    # this device/client registration.
                     self.room_id_mapping_dirty[room_id] = True
                     logger.info(
                         f"Client {device_id[:8]}... reconnected with new identity in room {room_id}"
@@ -1272,15 +1417,18 @@ class NetSyncServer:
             if is_new_client:
                 self.room_id_mapping_dirty[room_id] = True
 
-        # Sync network variables outside lock to avoid deadlocks.
-        if is_new_client:
-            self._sync_network_variables_to_new_client(room_id)
-            # Sync object ownership state to new client
-            self._sync_objects_to_new_client(client_identity, room_id)
-        elif is_reconnect:
-            # Unicast NV state only to the reconnecting client — no need to
-            # broadcast to the entire room.
-            self._sync_network_variables_to_client(room_id, client_identity)
+        control_identity = None
+        with self._rooms_lock:
+            control_identity = self.rooms[room_id][device_id].get("control_identity")
+
+        # Sync control state only through the control lane. If transform arrived
+        # before hello, the hello handler will sync after control identity exists.
+        if control_identity is not None:
+            if is_new_client:
+                self._sync_network_variables_to_new_client(room_id)
+                self._sync_objects_to_new_client(control_identity, room_id)
+            elif is_reconnect:
+                self._sync_network_variables_to_client(room_id, control_identity)
 
     def _extract_transform_body(self, raw_payload: bytes) -> bytes:
         """Extract the transform body without device ID from raw payload."""
@@ -1463,7 +1611,7 @@ class NetSyncServer:
                 client_no = client_data.get("client_no")
                 if client_no not in target_set:
                     continue
-                identity = client_data.get("identity")
+                identity = client_data.get("control_identity")
                 if identity is None:
                     continue
                 identities_to_send.append(identity)
@@ -1785,7 +1933,9 @@ class NetSyncServer:
     ) -> None:
         """Clear all client variables for the sending client."""
         with self._rooms_lock:
-            device_id = self._get_device_id_from_identity(client_identity, room_id)
+            device_id = self._get_device_id_from_control_identity(
+                client_identity, room_id
+            )
             if device_id is None:
                 logger.warning(
                     "Client variable clear ignored: sender is not mapped in room %s",
@@ -2196,10 +2346,14 @@ class NetSyncServer:
                             continue
                         client_no = client_data.get("client_no", 0)
                         transform_data = client_data.get("transform_data")
+                        if transform_data is None:
+                            continue
                         pose_time = client_data.get("last_update", 0.0)
                         body_bytes = self.client_transform_body_cache.get(
                             client_no, b""
                         )
+                        if not body_bytes:
+                            continue
                         client_snapshot.append(
                             (client_no, pose_time, transform_data, body_bytes)
                         )
@@ -2482,10 +2636,27 @@ class NetSyncServer:
             try:
                 data, addr = probe_sock.recvfrom(1024)
                 response = data.decode("utf-8", errors="replace")
-                # Match the client-side validation (see client.py):
-                # payload must be "STYLY-NETSYNC|<dealerPort>|<pubPort>|<name>"
-                # with at least 4 pipe-separated fields and int-parseable ports.
-                if response.startswith("STYLY-NETSYNC|"):
+                # Accept both current v2 and legacy v1 discovery responses for
+                # conflict detection.
+                if response.startswith("STYLY-NETSYNC2|"):
+                    parts = response.rstrip().split("|")
+                    if len(parts) >= 5:
+                        try:
+                            int(parts[1])
+                            int(parts[2])
+                            int(parts[3])
+                        except ValueError:
+                            return
+                        server_name = parts[4]
+                        logger.opt(colors=True).warning(
+                            f"<red>⚠ DISCOVERY PORT CONFLICT:</red> "
+                            f"Another STYLY-NetSync server "
+                            f"('{server_name}') is already responding "
+                            f"on discovery port {self.server_discovery_port} "
+                            f"(from {addr[0]}:{addr[1]}). Clients on this "
+                            f"LAN may connect to the wrong server."
+                        )
+                elif response.startswith("STYLY-NETSYNC|"):
                     parts = response.rstrip().split("|")
                     if len(parts) >= 4:
                         try:
@@ -2568,9 +2739,12 @@ class NetSyncServer:
 
     def _server_discovery_loop(self) -> None:
         """UDP discovery service loop - responds to client discovery requests"""
-        # Response message format: STYLY-NETSYNC|dealerPort|pubPort|serverName
+        # Response message format:
+        # STYLY-NETSYNC2|controlPort|transformPort|pubPort|serverName
         response = (
-            f"STYLY-NETSYNC|{self.dealer_port}|{self.pub_port}|{self.server_name}"
+            "STYLY-NETSYNC2|"
+            f"{self.control_port}|{self.transform_port}|{self.pub_port}|"
+            f"{self.server_name}"
         )
         response_bytes = response.encode("utf-8")
         udp_socket = self.server_discovery_socket
@@ -2643,9 +2817,12 @@ class NetSyncServer:
 
     def _tcp_server_discovery_loop(self) -> None:
         """TCP discovery service loop - responds to client discovery requests"""
-        # Response message format: STYLY-NETSYNC|dealerPort|pubPort|serverName\n
+        # Response message format:
+        # STYLY-NETSYNC2|controlPort|transformPort|pubPort|serverName\n
         response = (
-            f"STYLY-NETSYNC|{self.dealer_port}|{self.pub_port}|{self.server_name}\n"
+            "STYLY-NETSYNC2|"
+            f"{self.control_port}|{self.transform_port}|{self.pub_port}|"
+            f"{self.server_name}\n"
         )
         response_bytes = response.encode("utf-8")
         tcp_socket = self.tcp_server_discovery_socket
@@ -2723,10 +2900,27 @@ def main() -> None:
     # Port settings group
     port_group = parser.add_argument_group("port settings")
     port_group.add_argument(
+        "--control-port",
+        type=valid_port,
+        metavar="PORT",
+        help=f"TCP port for control DEALER-ROUTER socket (default: {defaults.control_port})",
+    )
+    port_group.add_argument(
         "--dealer-port",
         type=valid_port,
         metavar="PORT",
-        help=f"TCP port for DEALER-ROUTER socket (default: {defaults.dealer_port})",
+        help=(
+            "Deprecated alias for --control-port " f"(default: {defaults.control_port})"
+        ),
+    )
+    port_group.add_argument(
+        "--transform-port",
+        type=valid_port,
+        metavar="PORT",
+        help=(
+            "TCP port for transform uplink DEALER-ROUTER socket "
+            f"(default: {defaults.transform_port})"
+        ),
     )
     port_group.add_argument(
         "--pub-port",
@@ -2842,7 +3036,8 @@ def main() -> None:
     else:
         logger.info("  Server IP addresses: Unable to detect")
 
-    logger.info(f"  DEALER port: {config.dealer_port}")
+    logger.info(f"  Control port: {config.control_port}")
+    logger.info(f"  Transform port: {config.transform_port}")
     logger.info(f"  PUB port: {config.pub_port}")
     if config.enable_server_discovery:
         logger.info(f"  Server discovery port: {config.server_discovery_port}")
@@ -2852,7 +3047,8 @@ def main() -> None:
     logger.info("=" * 80)
 
     server = NetSyncServer(
-        dealer_port=config.dealer_port,
+        control_port=config.control_port,
+        transform_port=config.transform_port,
         pub_port=config.pub_port,
         enable_server_discovery=config.enable_server_discovery,
         server_discovery_port=config.server_discovery_port,

--- a/STYLY-NetSync-Server/tests/integration/test_client.py
+++ b/STYLY-NetSync-Server/tests/integration/test_client.py
@@ -32,7 +32,8 @@ Usage:
   python test_client.py [options]
 
 Options:
-  --dealer-port PORT  Server DEALER port (default: 5555)
+  --control-port PORT  Server control port (default: 5555)
+  --transform-port PORT  Server transform port (default: 5557)
   --sub-port PORT     Server PUB port (default: 5556)
   --server ADDRESS    Server address (default: localhost)
   --room ROOM_ID    Room ID to join (default: test_room)
@@ -85,6 +86,7 @@ class TestClient:
     def __init__(
         self,
         dealer_port=5555,
+        transform_port=5557,
         sub_port=5556,
         server_address="localhost",
         room_id="test_room",
@@ -97,6 +99,7 @@ class TestClient:
         self.room_id = room_id
         self.server_address = server_address
         self.dealer_port = dealer_port
+        self.transform_port = transform_port
         self.sub_port = sub_port
         self.running = False
         self.stop_event = Event()
@@ -364,7 +367,16 @@ def main():
 
     parser = argparse.ArgumentParser(description="STYLY-NetSync Test Client")
     parser.add_argument(
-        "--dealer-port", type=int, default=5555, help="Server DEALER port"
+        "--control-port", type=int, default=None, help="Server control port"
+    )
+    parser.add_argument(
+        "--dealer-port",
+        type=int,
+        default=5555,
+        help="Deprecated alias for --control-port",
+    )
+    parser.add_argument(
+        "--transform-port", type=int, default=5557, help="Server transform port"
     )
     parser.add_argument("--sub-port", type=int, default=5556, help="Server PUB port")
     parser.add_argument(
@@ -373,9 +385,12 @@ def main():
     parser.add_argument("--room", type=str, default="test_room", help="Room ID")
 
     args = parser.parse_args()
+    if args.control_port is not None:
+        args.dealer_port = args.control_port
 
     client = TestClient(
         dealer_port=args.dealer_port,
+        transform_port=args.transform_port,
         sub_port=args.sub_port,
         server_address=args.server,
         room_id=args.room,

--- a/STYLY-NetSync-Server/tests/integration/test_client.py
+++ b/STYLY-NetSync-Server/tests/integration/test_client.py
@@ -65,8 +65,11 @@ from styly_netsync.binary_serializer import (
     MSG_CLIENT_VAR_SYNC,
     MSG_DEVICE_ID_MAPPING,
     MSG_GLOBAL_VAR_SYNC,
+    MSG_ROOM_POSE,
     MSG_ROOM_TRANSFORM,
+    MSG_RPC,
     deserialize,
+    serialize_client_hello,
     serialize_client_transform,
     serialize_client_var_set,
     serialize_global_var_set,
@@ -92,7 +95,8 @@ class TestClient:
         room_id="test_room",
     ):
         self.context = zmq.Context()
-        self.dealer_socket = None
+        self.dealer_socket = None  # Control lane: hello, RPC, Network Variables
+        self.transform_socket = None  # Transform lane: client/object poses
         self.sub_socket = None
         self.device_id = str(uuid.uuid4())
         self.client_no = None
@@ -119,13 +123,22 @@ class TestClient:
     def connect(self):
         """Connect to the server"""
         try:
-            # Connect DEALER socket
+            # Connect control DEALER socket (hello, RPC, Network Variables)
             self.dealer_socket = self.context.socket(zmq.DEALER)
             self.dealer_socket.connect(
                 f"tcp://{self.server_address}:{self.dealer_port}"
             )
             logger.info(
-                f"Connected DEALER socket to tcp://{self.server_address}:{self.dealer_port}"
+                f"Connected control DEALER socket to tcp://{self.server_address}:{self.dealer_port}"
+            )
+
+            # Connect transform DEALER socket (client/object poses)
+            self.transform_socket = self.context.socket(zmq.DEALER)
+            self.transform_socket.connect(
+                f"tcp://{self.server_address}:{self.transform_port}"
+            )
+            logger.info(
+                f"Connected transform DEALER socket to tcp://{self.server_address}:{self.transform_port}"
             )
 
             # Connect SUB socket
@@ -135,6 +148,13 @@ class TestClient:
             logger.info(
                 f"Connected SUB socket to tcp://{self.server_address}:{self.sub_port}"
             )
+
+            # Register the control identity by sending a hello before any poses.
+            # The server binds control_identity from this message and may drop
+            # transform-lane traffic that arrives without a registered client.
+            hello = serialize_client_hello(self.device_id, is_stealth=False)
+            self.dealer_socket.send_multipart([self.room_id.encode("utf-8"), hello])
+            logger.info("Sent client hello on control lane")
 
             return True
         except Exception as e:
@@ -148,6 +168,8 @@ class TestClient:
 
         if self.dealer_socket:
             self.dealer_socket.close()
+        if self.transform_socket:
+            self.transform_socket.close()
         if self.sub_socket:
             self.sub_socket.close()
         self.context.term()
@@ -200,9 +222,9 @@ class TestClient:
             "virtuals": [],  # No virtual objects for this test
         }
 
-        # Serialize and send
+        # Serialize and send on the transform lane
         message = serialize_client_transform(transform_data)
-        self.dealer_socket.send_multipart([self.room_id.encode("utf-8"), message])
+        self.transform_socket.send_multipart([self.room_id.encode("utf-8"), message])
         logger.debug(
             f"Sent transform: pos({self.position_x:.2f}, {self.position_z:.2f}), rot({self.rotation_y:.2f})"
         )
@@ -262,53 +284,62 @@ class TestClient:
         self.dealer_socket.send_multipart([self.room_id.encode("utf-8"), message])
         logger.info(f"Sent RPC: TestRPC({current_time_str})")
 
+    def process_payload(self, data, source):
+        """Process one decoded server payload from either PUB or control lane."""
+        msg_type, msg_data, _ = deserialize(data)
+
+        if msg_type == MSG_DEVICE_ID_MAPPING:
+            # Update our client number
+            for mapping in msg_data["mappings"]:
+                if mapping["deviceId"] == self.device_id:
+                    self.client_no = mapping["clientNo"]
+                    logger.info(f"Received client number: {self.client_no}")
+
+        elif msg_type in (MSG_ROOM_TRANSFORM, MSG_ROOM_POSE):
+            logger.debug(
+                f"Received room transform with {len(msg_data['clients'])} clients"
+            )
+
+        elif msg_type == MSG_GLOBAL_VAR_SYNC:
+            for var in msg_data["variables"]:
+                logger.info(
+                    f"Global variable update: {var['name']} = {var['value']} (by client {var['lastWriterClientNo']})"
+                )
+
+        elif msg_type == MSG_CLIENT_VAR_SYNC:
+            for client_no, variables in msg_data["clientVariables"].items():
+                for var in variables:
+                    logger.info(
+                        f"Client {client_no} variable update: {var['name']} = {var['value']}"
+                    )
+
+        elif msg_type == MSG_RPC:
+            logger.info(
+                f"Received RPC from {source}: {msg_data['functionName']}({msg_data['argumentsJson']}) "
+                f"by client {msg_data['senderClientNo']}"
+            )
+
     def receive_messages(self):
         """Receive and process messages from the server"""
         poller = zmq.Poller()
+        poller.register(self.dealer_socket, zmq.POLLIN)
         poller.register(self.sub_socket, zmq.POLLIN)
 
         while self.running:
             try:
                 socks = dict(poller.poll(100))  # 100ms timeout
 
+                if self.dealer_socket in socks:
+                    message_parts = self.dealer_socket.recv_multipart()
+                    if len(message_parts) >= 2:
+                        self.process_payload(message_parts[-1], "control")
+
                 if self.sub_socket in socks:
                     message_parts = self.sub_socket.recv_multipart()
                     if len(message_parts) >= 2:
                         _room_id = message_parts[0].decode("utf-8")  # noqa: F841
                         data = message_parts[1]
-
-                        msg_type, msg_data, _ = deserialize(data)
-
-                        if msg_type == MSG_DEVICE_ID_MAPPING:
-                            # Update our client number
-                            for mapping in msg_data["mappings"]:
-                                if mapping["deviceId"] == self.device_id:
-                                    self.client_no = mapping["clientNo"]
-                                    logger.info(
-                                        f"Received client number: {self.client_no}"
-                                    )
-
-                        elif msg_type == MSG_ROOM_TRANSFORM:
-                            logger.debug(
-                                f"Received room transform with {len(msg_data['clients'])} clients"
-                            )
-
-                        elif msg_type == MSG_GLOBAL_VAR_SYNC:
-                            for var in msg_data["variables"]:
-                                logger.info(
-                                    f"Global variable update: {var['name']} = {var['value']} (by client {var['lastWriterClientNo']})"
-                                )
-
-                        elif msg_type == MSG_CLIENT_VAR_SYNC:
-                            for client_no, variables in msg_data[
-                                "clientVariables"
-                            ].items():
-                                for var in variables:
-                                    logger.info(
-                                        f"Client {client_no} variable update: {var['name']} = {var['value']}"
-                                    )
-
-                        # RPC messages would be received here
+                        self.process_payload(data, "pub")
 
             except zmq.Again:
                 pass

--- a/STYLY-NetSync-Server/tests/test_binary_serializer.py
+++ b/STYLY-NetSync-Server/tests/test_binary_serializer.py
@@ -289,11 +289,11 @@ def _reconstruct_physical_from_head_and_delta(
 
 
 class TestTransformSerializationV5:
-    """Tests for protocol v6 transform compact serialization."""
+    """Tests for protocol v7 transform compact serialization."""
 
-    def test_protocol_version_is_v6(self) -> None:
-        """Protocol version constant should be at v6."""
-        assert binary_serializer.PROTOCOL_VERSION == 6
+    def test_protocol_version_is_v7(self) -> None:
+        """Protocol version constant should be at v7."""
+        assert binary_serializer.PROTOCOL_VERSION == 7
 
     def test_client_roundtrip_without_flags_infers_valid_bits(self) -> None:
         """Serializer should infer valid bits when flags are omitted."""
@@ -418,7 +418,7 @@ class TestTransformSerializationV5:
 
             assert msg_type == binary_serializer.MSG_CLIENT_POSE
             assert decoded is not None
-            assert decoded["protocolVersion"] == 6
+            assert decoded["protocolVersion"] == 7
             assert len(raw) > 0
 
             o_head = original["head"]
@@ -822,7 +822,7 @@ class TestTransformSerializationV5:
 
         assert msg_type == binary_serializer.MSG_ROOM_POSE
         assert decoded is not None
-        assert decoded["protocolVersion"] == 6
+        assert decoded["protocolVersion"] == 7
         assert decoded["roomId"] == "room-v5"
         assert len(decoded["clients"]) == 2
 
@@ -956,6 +956,32 @@ class TestTransformSerializationV5:
         )
         assert decoded is not None
         assert len(decoded["virtuals"]) == max_vt
+
+
+class TestClientHelloSerialization:
+    """Tests for client hello serialization/deserialization."""
+
+    def test_roundtrip_visible_client(self) -> None:
+        """Visible client hello round-trips correctly."""
+        payload = binary_serializer.serialize_client_hello("device-a", is_stealth=False)
+        msg_type, data, raw = binary_serializer.deserialize(payload)
+
+        assert msg_type == binary_serializer.MSG_CLIENT_HELLO
+        assert raw == b""
+        assert data is not None
+        assert data["deviceId"] == "device-a"
+        assert data["isStealthMode"] is False
+
+    def test_roundtrip_stealth_client(self) -> None:
+        """Stealth client hello carries the stealth flag."""
+        payload = binary_serializer.serialize_client_hello("device-b", is_stealth=True)
+        msg_type, data, _ = binary_serializer.deserialize(payload)
+
+        assert msg_type == binary_serializer.MSG_CLIENT_HELLO
+        assert data is not None
+        assert data["deviceId"] == "device-b"
+        assert data["isStealthMode"] is True
+        assert data["flags"] & binary_serializer.CLIENT_HELLO_FLAG_STEALTH
 
 
 class TestRPCMessageSerialization:

--- a/STYLY-NetSync-Server/tests/test_client_variable_device_store.py
+++ b/STYLY-NetSync-Server/tests/test_client_variable_device_store.py
@@ -34,7 +34,8 @@ def _connect_device(
 ) -> None:
     _map_device(server, room_id, device_id, client_no)
     server.rooms[room_id][device_id] = {
-        "identity": identity,
+        "control_identity": identity,
+        "transform_identity": None,
         "last_update": time.monotonic(),
         "transform_data": {"clientNo": client_no, "deviceId": device_id},
         "client_no": client_no,
@@ -143,7 +144,11 @@ class TestServerClientVariableDeviceStore:
         )
         server._send_ctrl_to_room_via_router.reset_mock()
 
-        server._handle_client_transform(b"ident-a", "room1", {"deviceId": "device-a"})
+        server._handle_client_hello(
+            b"ident-a",
+            "room1",
+            {"deviceId": "device-a", "isStealthMode": False},
+        )
 
         server._send_ctrl_to_room_via_router.assert_called_once()
         room_id, payload = server._send_ctrl_to_room_via_router.call_args.args

--- a/STYLY-NetSync-Server/tests/test_config.py
+++ b/STYLY-NetSync-Server/tests/test_config.py
@@ -561,6 +561,27 @@ class TestMergeCliArgs:
         # Original config unchanged
         assert default_config.dealer_port == 5555
 
+    def test_cli_control_port_wins_over_deprecated_dealer_port(
+        self, default_config: ServerConfig
+    ) -> None:
+        """When both flags are given, the canonical --control-port must win.
+
+        The deprecated --dealer-port alias must never silently override an
+        explicit --control-port.
+        """
+        args = argparse.Namespace(
+            control_port=6000,
+            dealer_port=7000,
+            pub_port=None,
+            server_discovery_port=None,
+            no_server_discovery=False,
+        )
+
+        merged = merge_cli_args(default_config, args)
+        assert merged.control_port == 6000
+        # dealer_port stays mirrored to the resolved control_port.
+        assert merged.dealer_port == 6000
+
     def test_cli_overrides_pub_port(self, default_config: ServerConfig) -> None:
         """Test that CLI pub_port overrides config."""
         args = argparse.Namespace(

--- a/STYLY-NetSync-Server/tests/test_config.py
+++ b/STYLY-NetSync-Server/tests/test_config.py
@@ -37,7 +37,9 @@ class TestLoadDefaultConfig:
         """Test that default config has all expected fields."""
         config = load_default_config()
         # Network
+        assert config.control_port == 5555
         assert config.dealer_port == 5555
+        assert config.transform_port == 5557
         assert config.pub_port == 5556
         assert config.server_discovery_port == 9999
         assert config.rest_api_port == 8800
@@ -85,7 +87,9 @@ class TestServerConfig:
     def test_custom_values(self, default_config: ServerConfig) -> None:
         """Test that custom values can be set."""
         config = ServerConfig(
+            control_port=6666,
             dealer_port=6666,
+            transform_port=6668,
             pub_port=6667,
             server_discovery_port=8888,
             rest_api_port=9900,
@@ -116,7 +120,9 @@ class TestServerConfig:
             log_rotation=default_config.log_rotation,
             log_retention=default_config.log_retention,
         )
+        assert config.control_port == 6666
         assert config.dealer_port == 6666
+        assert config.transform_port == 6668
         assert config.pub_port == 6667
         assert config.server_discovery_port == 8888
         assert config.rest_api_port == 9900
@@ -130,8 +136,10 @@ class TestLoadConfigFromToml:
     def test_load_valid_toml(self, tmp_path: Path) -> None:
         """Test loading a valid TOML file."""
         toml_content = """
-dealer_port = 7777
-pub_port = 7778
+	control_port = 7777
+	dealer_port = 7777
+	transform_port = 7779
+	pub_port = 7778
 server_name = "Test Server"
 enable_server_discovery = false
 """
@@ -139,7 +147,9 @@ enable_server_discovery = false
         config_file.write_text(toml_content)
 
         data = load_config_from_toml(config_file)
+        assert data["control_port"] == 7777
         assert data["dealer_port"] == 7777
+        assert data["transform_port"] == 7779
         assert data["pub_port"] == 7778
         assert data["server_name"] == "Test Server"
         assert data["enable_server_discovery"] is False
@@ -175,6 +185,8 @@ class TestProcessTomlConfig:
         """Test processing network keys."""
         toml_data = {
             "dealer_port": 5555,
+            "control_port": 5555,
+            "transform_port": 5557,
             "pub_port": 5556,
             "server_discovery_port": 9999,
             "server_name": "Test",
@@ -182,7 +194,9 @@ class TestProcessTomlConfig:
         }
 
         result = process_toml_config(toml_data)
+        assert result["control_port"] == 5555
         assert result["dealer_port"] == 5555
+        assert result["transform_port"] == 5557
         assert result["pub_port"] == 5556
         assert result["server_discovery_port"] == 9999
         assert result["server_name"] == "Test"
@@ -192,7 +206,7 @@ class TestProcessTomlConfig:
         """Test processing partial configuration."""
         toml_data = {"dealer_port": 6666}
         result = process_toml_config(toml_data)
-        assert result == {"dealer_port": 6666}
+        assert result == {"control_port": 6666, "dealer_port": 6666}
 
     def test_process_empty_config(self) -> None:
         """Test processing empty configuration."""
@@ -207,7 +221,7 @@ class TestProcessTomlConfig:
         }
         result = process_toml_config(toml_data)
         assert "unknown_key" not in result
-        assert result == {"dealer_port": 5555}
+        assert result == {"control_port": 5555, "dealer_port": 5555}
 
     def test_process_timing_keys(self) -> None:
         """Test processing timing keys."""
@@ -338,6 +352,7 @@ class TestValidateConfig:
 
         config = replace(
             default_config,
+            control_port=1,
             dealer_port=1,
             pub_port=65535,
             server_discovery_port=1024,
@@ -541,6 +556,7 @@ class TestMergeCliArgs:
         )
 
         merged = merge_cli_args(default_config, args)
+        assert merged.control_port == 6000
         assert merged.dealer_port == 6000
         # Original config unchanged
         assert default_config.dealer_port == 5555
@@ -770,7 +786,9 @@ class TestCreateConfigFromArgs:
 
         config, _ = create_config_from_args(args)
         # Should match default config
+        assert config.control_port == 5555
         assert config.dealer_port == 5555
+        assert config.transform_port == 5557
         assert config.pub_port == 5556
 
     def test_config_file_overrides_default(self, tmp_path: Path) -> None:
@@ -795,6 +813,7 @@ server_name = "User Server"
 
         config, _ = create_config_from_args(args)
         # User overrides
+        assert config.control_port == 7777
         assert config.dealer_port == 7777
         assert config.server_name == "User Server"
         # Defaults preserved
@@ -905,10 +924,12 @@ dealer_port = 7777
         )
 
         config, overrides = create_config_from_args(args)
-        assert len(overrides) == 1
-        assert overrides[0].key == "dealer_port"
-        assert overrides[0].default_value == 5555
-        assert overrides[0].new_value == 7777
+        assert len(overrides) == 2
+        override_map = {o.key: o for o in overrides}
+        assert override_map["control_port"].default_value == 5555
+        assert override_map["control_port"].new_value == 7777
+        assert override_map["dealer_port"].default_value == 5555
+        assert override_map["dealer_port"].new_value == 7777
 
     def test_multiple_overrides_tracked(self, tmp_path: Path) -> None:
         """Test that multiple overrides are tracked correctly."""
@@ -933,10 +954,11 @@ client_timeout = 10.0
         )
 
         config, overrides = create_config_from_args(args)
-        assert len(overrides) == 4
+        assert len(overrides) == 5
 
         # Check that all overrides are tracked
         override_keys = {o.key for o in overrides}
+        assert "control_port" in override_keys
         assert "dealer_port" in override_keys
         assert "pub_port" in override_keys
         assert "server_name" in override_keys

--- a/STYLY-NetSync-Server/tests/test_discovery_probe.py
+++ b/STYLY-NetSync-Server/tests/test_discovery_probe.py
@@ -57,7 +57,7 @@ class TestDiscoveryProbe:
                 try:
                     data, addr = sock.recvfrom(1024)
                     if data == b"STYLY-NETSYNC-DISCOVER":
-                        response = b"STYLY-NETSYNC|5555|5556|FakeServer"
+                        response = b"STYLY-NETSYNC2|5555|5557|5556|FakeServer"
                         sock.sendto(response, addr)
                 except TimeoutError:
                     continue

--- a/STYLY-NetSync-Server/tests/test_multi_nic.py
+++ b/STYLY-NetSync-Server/tests/test_multi_nic.py
@@ -125,7 +125,7 @@ class TestDiscoveryAutoConnect:
         mock_sock = MagicMock(spec=socket.socket)
         mock_sock.getsockname.return_value = ("192.168.1.10", 0)
         mock_sock.recvfrom.return_value = (
-            b"STYLY-NETSYNC|6666|7777|TestServer",
+            b"STYLY-NETSYNC2|6666|6668|7777|TestServer",
             ("10.0.0.1", 9999),
         )
         mgr._discovery_sockets = [mock_sock]
@@ -136,6 +136,7 @@ class TestDiscoveryAutoConnect:
 
         assert mgr._server == "tcp://10.0.0.1"
         assert mgr._dealer_port == 6666
+        assert mgr._transform_port == 6668
         assert mgr._sub_port == 7777
         mock_start.assert_called_once()
         assert mgr._discovery_running is False
@@ -145,6 +146,7 @@ class TestDiscoveryAutoConnect:
         mgr = _make_manager()
         original_server = mgr._server
         original_dealer = mgr._dealer_port
+        original_transform = mgr._transform_port
         original_sub = mgr._sub_port
         mgr._running = True
         mgr._discovery_running = True
@@ -152,7 +154,7 @@ class TestDiscoveryAutoConnect:
         mock_sock = MagicMock(spec=socket.socket)
         mock_sock.getsockname.return_value = ("192.168.1.10", 0)
         mock_sock.recvfrom.return_value = (
-            b"STYLY-NETSYNC|6666|7777|TestServer",
+            b"STYLY-NETSYNC2|6666|6668|7777|TestServer",
             ("10.0.0.1", 9999),
         )
         mgr._discovery_sockets = [mock_sock]
@@ -164,10 +166,36 @@ class TestDiscoveryAutoConnect:
         # Address/ports should NOT be updated
         assert mgr._server == original_server
         assert mgr._dealer_port == original_dealer
+        assert mgr._transform_port == original_transform
         assert mgr._sub_port == original_sub
         mock_start.assert_not_called()
         # Discovery should still be stopped
         assert mgr._discovery_running is False
+
+    def test_legacy_discovery_response_is_incompatible(self) -> None:
+        """Legacy v1 discovery responses must not auto-connect."""
+        mgr = _make_manager()
+        mgr._discovery_running = True
+        mgr._discovery_sockets = []
+
+        mock_sock = MagicMock(spec=socket.socket)
+        mock_sock.getsockname.return_value = ("192.168.1.10", 0)
+
+        def recvfrom_side_effect(_size: int) -> tuple[bytes, tuple[str, int]]:
+            if mock_sock.recvfrom.call_count == 1:
+                return (b"STYLY-NETSYNC|6666|7777|LegacyServer", ("10.0.0.1", 9999))
+            mgr._discovery_running = False
+            raise TimeoutError()
+
+        mock_sock.recvfrom.side_effect = recvfrom_side_effect
+        mgr._discovery_sockets = [mock_sock]
+        mgr._broadcast_cache = {"192.168.1.10": "192.168.1.255"}
+
+        with patch.object(mgr, "start") as mock_start, patch("time.sleep"):
+            mgr._discovery_loop(9999)
+
+        mock_start.assert_not_called()
+        assert mgr._server != "tcp://10.0.0.1"
 
     def test_no_self_join_error(self) -> None:
         """_stop_discovery_internal called from discovery thread should not raise."""
@@ -191,7 +219,7 @@ class TestDiscoveryAutoConnect:
         mock_sock.getsockname.return_value = ("192.168.1.10", 0)
         # First recvfrom: return discovery response, second: timeout to exit loop
         mock_sock.recvfrom.side_effect = [
-            (b"STYLY-NETSYNC|6666|7777|TestServer", ("10.0.0.1", 9999)),
+            (b"STYLY-NETSYNC2|6666|6668|7777|TestServer", ("10.0.0.1", 9999)),
             TimeoutError(),
         ]
         mgr._discovery_sockets = [mock_sock]
@@ -214,7 +242,10 @@ class TestDiscoveryAutoConnect:
             # Re-supply socket for second round (after break + retry)
             def reset_socket(*args: object, **kwargs: object) -> None:
                 mock_sock.recvfrom.side_effect = [
-                    (b"STYLY-NETSYNC|6666|7777|TestServer", ("10.0.0.1", 9999)),
+                    (
+                        b"STYLY-NETSYNC2|6666|6668|7777|TestServer",
+                        ("10.0.0.1", 9999),
+                    ),
                 ]
 
             mock_sock.sendto.side_effect = reset_socket

--- a/STYLY-NetSync-Server/tests/test_object_sync.py
+++ b/STYLY-NetSync-Server/tests/test_object_sync.py
@@ -283,12 +283,15 @@ class TestServerObjectOwnership:
         srv.ctrl_unicast_sent = 0
         srv.ctrl_unicast_wouldblock = 0
         srv.ctrl_unicast_dropped = 0
+        srv.ctrl_unicast_unreachable = 0
+        srv.wrong_lane_dropped = 0
 
         # Initialize a room
         srv._initialize_room("test_room")
         # Add a client
         srv.rooms["test_room"]["device_a"] = {
-            "identity": b"ident_a",
+            "control_identity": b"ident_a",
+            "transform_identity": b"transform_a",
             "last_update": time.monotonic(),
             "transform_data": {},
             "client_no": 1,
@@ -298,7 +301,8 @@ class TestServerObjectOwnership:
         srv.room_client_no_to_device_id["test_room"][1] = "device_a"
 
         srv.rooms["test_room"]["device_b"] = {
-            "identity": b"ident_b",
+            "control_identity": b"ident_b",
+            "transform_identity": b"transform_b",
             "last_update": time.monotonic(),
             "transform_data": {},
             "client_no": 2,

--- a/STYLY-NetSync-Server/tests/test_object_sync.py
+++ b/STYLY-NetSync-Server/tests/test_object_sync.py
@@ -33,6 +33,7 @@ class TestObjectPoseSerialization:
 
     def test_basic_round_trip(self) -> None:
         data = {
+            "deviceId": "device-xyz",
             "objectId": _OBJ_ID_1,
             "poseSeq": 42,
             "posX": 1.5,
@@ -49,6 +50,7 @@ class TestObjectPoseSerialization:
         msg_type, result, _ = deserialize(raw)
         assert msg_type == MSG_OBJECT_POSE
         assert result is not None
+        assert result["deviceId"] == "device-xyz"
         assert result["objectId"] == _OBJ_ID_1
         assert result["poseSeq"] == 42
         assert abs(result["posX"] - 1.5) < 0.02

--- a/STYLY-NetSync-Server/tests/test_python_client.py
+++ b/STYLY-NetSync-Server/tests/test_python_client.py
@@ -5,6 +5,7 @@ Test the Python NetSync client implementation meets requirements.
 Validates all acceptance criteria from the implementation brief.
 """
 
+import socket
 import threading
 import time
 
@@ -14,6 +15,21 @@ from styly_netsync import (
     net_sync_manager,
     transform_data,
 )
+
+
+def _find_free_port():
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("", 0))
+        return sock.getsockname()[1]
+
+
+def _wait_until(predicate, timeout=5.0, interval=0.02):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(interval)
+    return False
 
 
 def test_packaging():
@@ -214,6 +230,88 @@ def test_rpc():
         client2.stop()
 
     finally:
+        server.stop()
+
+
+def test_rpc_burst_reaches_ten_targets_during_transform_flood():
+    """Control RPC burst should reach all targets while transforms are flooding."""
+    control_port = _find_free_port()
+    transform_port = _find_free_port()
+    pub_port = _find_free_port()
+    room_id = "rpc_burst_flood"
+
+    server = NetSyncServer(
+        control_port=control_port,
+        transform_port=transform_port,
+        pub_port=pub_port,
+        enable_server_discovery=False,
+    )
+    server_thread = threading.Thread(target=lambda: server.start(), daemon=True)
+    server_thread.start()
+    time.sleep(0.3)
+
+    clients = []
+    try:
+        for _ in range(11):
+            client = net_sync_manager(
+                server="tcp://localhost",
+                dealer_port=control_port,
+                transform_port=transform_port,
+                sub_port=pub_port,
+                room=room_id,
+                auto_dispatch=False,
+            )
+            client.start()
+            clients.append(client)
+
+        assert _wait_until(
+            lambda: all(client.client_no is not None for client in clients),
+            timeout=8.0,
+        )
+
+        sender = clients[0]
+        targets = clients[1:]
+        target_client_nos = [client.client_no for client in targets]
+        assert all(client_no is not None for client_no in target_client_nos)
+        target_ids = [int(client_no) for client_no in target_client_nos]
+
+        received: dict[int, list[tuple[int, str, list[str]]]] = {
+            client_no: [] for client_no in target_ids
+        }
+
+        for target in targets:
+            assert target.client_no is not None
+            target_client_no = target.client_no
+
+            def on_rpc(sender_no, func_name, args, client_no=target_client_no):
+                received[client_no].append((sender_no, func_name, args))
+
+            target.on_rpc_received.add_listener(on_rpc)
+
+        tx = client_transform_data(
+            physical=transform_data(pos_x=1.0, pos_z=2.0, rot_y=45.0),
+            head=transform_data(pos_x=1.0, pos_y=1.6, pos_z=2.0),
+        )
+
+        for _ in range(50):
+            for client in clients:
+                client.send_transform(tx)
+
+        assert sender.rpc("BurstRpc", ["payload"], target_ids)
+
+        def all_targets_received():
+            for client in clients:
+                client.send_transform(tx)
+            for target in targets:
+                target.dispatch_pending_events()
+            return all(received[client_no] for client_no in target_ids)
+
+        assert _wait_until(all_targets_received, timeout=8.0, interval=0.01)
+        assert server.ctrl_unicast_dropped == 0
+
+    finally:
+        for client in clients:
+            client.stop()
         server.stop()
 
 

--- a/STYLY-NetSync-Server/tests/test_reconnect_identity.py
+++ b/STYLY-NetSync-Server/tests/test_reconnect_identity.py
@@ -1,7 +1,7 @@
 """
 Tests for client reconnect identity update and NV resync.
 
-Verifies that when a client reconnects (same device_id, new DEALER socket /
+    Verifies that when a client reconnects (same device_id, new control DEALER socket /
 ZMQ identity) before the server timeout evicts it, the server:
   1. Updates the stored ROUTER identity.
   2. Marks the room ID mapping as dirty.
@@ -61,7 +61,7 @@ def test_reconnect_updates_identity_and_resyncs_nv() -> None:
 
         # Capture the original identity stored by the server
         with server._rooms_lock:
-            original_identity = server.rooms[ROOM][device_id]["identity"]
+            original_identity = server.rooms[ROOM][device_id]["control_identity"]
 
         assert original_identity is not None, "Server should store client identity"
 
@@ -91,7 +91,7 @@ def test_reconnect_updates_identity_and_resyncs_nv() -> None:
 
         # 1. Server should have updated the identity
         with server._rooms_lock:
-            new_identity = server.rooms[ROOM][device_id]["identity"]
+            new_identity = server.rooms[ROOM][device_id]["control_identity"]
         assert (
             new_identity != original_identity
         ), "Server should update identity on reconnect"

--- a/STYLY-NetSync-Server/tests/test_stealth_heartbeat.py
+++ b/STYLY-NetSync-Server/tests/test_stealth_heartbeat.py
@@ -13,6 +13,7 @@ import time
 import unittest
 from unittest.mock import MagicMock, patch
 
+from styly_netsync import binary_serializer
 from styly_netsync.client import (
     STEALTH_HEARTBEAT_INTERVAL,
     net_sync_manager,
@@ -122,6 +123,25 @@ class TestStealthHeartbeatUnit(unittest.TestCase):
         with patch.object(mgr, "_enqueue_control", return_value=False):
             mgr._send_stealth_heartbeat()
         self.assertAlmostEqual(mgr._last_stealth_heartbeat_time, old_time, places=3)
+
+    def test_stealth_heartbeat_uses_client_hello(self) -> None:
+        """Stealth heartbeat should register via MSG_CLIENT_HELLO."""
+        mgr = self._make_running_manager()
+        captured: dict[str, bytes] = {}
+
+        def capture(_room: str, payload: bytes, msg_type: str = "control") -> bool:
+            captured["payload"] = payload
+            captured["msg_type"] = msg_type.encode("utf-8")
+            return True
+
+        with patch.object(mgr, "_enqueue_control", side_effect=capture):
+            mgr._send_stealth_heartbeat()
+
+        msg_type, data, _ = binary_serializer.deserialize(captured["payload"])
+        self.assertEqual(msg_type, binary_serializer.MSG_CLIENT_HELLO)
+        self.assertIsNotNone(data)
+        assert data is not None
+        self.assertTrue(data["isStealthMode"])
 
     # ------------------------------------------------------------------
     # Constant value test

--- a/STYLY-NetSync-Server/tests/test_transport_split.py
+++ b/STYLY-NetSync-Server/tests/test_transport_split.py
@@ -10,33 +10,63 @@ from styly_netsync import binary_serializer
 from styly_netsync.server import NetSyncServer
 
 
-def test_router_control_drain_retries_blocked_packet_fifo() -> None:
-    """A would-block control unicast is retained and retried before later packets."""
+def test_router_control_drain_retries_deferred_packet_next_pass() -> None:
+    """A would-block control unicast is retained and retried on the next drain."""
     srv = NetSyncServer(enable_server_discovery=False)
     router = MagicMock()
     router.send_multipart.side_effect = [zmq.Again(), None]
     srv.control_router = router
-    srv.ROUTER_CTRL_DRAIN_BATCH = 1
 
     first = (b"ident-a", b"room", b"first")
-    second = (b"ident-b", b"room", b"second")
     srv._router_queue_ctrl.put_nowait(first)
-    srv._router_queue_ctrl.put_nowait(second)
 
     srv._drain_router_ctrl_queue()
     assert srv.ctrl_unicast_wouldblock == 1
     assert srv.ctrl_unicast_sent == 0
-    assert srv._blocked_router_packet == first
+    assert srv._router_queue_ctrl.get_nowait() == first
+    srv._router_queue_ctrl.put_nowait(first)
 
     srv._drain_router_ctrl_queue()
     assert srv.ctrl_unicast_sent == 1
-    assert srv._blocked_router_packet is None
     assert router.send_multipart.call_args_list[1].args[0] == [
         first[0],
         first[1],
         first[2],
     ]
-    assert srv._router_queue_ctrl.get_nowait() == second
+
+
+def test_router_control_drain_defers_blocked_identity_without_stalling_others() -> None:
+    """One slow client must not block control unicasts for other identities."""
+    srv = NetSyncServer(enable_server_discovery=False)
+    router = MagicMock()
+
+    def send_multipart(frames: list[bytes], **_kwargs: object) -> None:
+        if frames[0] == b"ident-a":
+            raise zmq.Again()
+
+    router.send_multipart.side_effect = send_multipart
+    srv.control_router = router
+
+    first = (b"ident-a", b"room", b"first")
+    second = (b"ident-b", b"room", b"second")
+    third = (b"ident-a", b"room", b"third")
+    srv._router_queue_ctrl.put_nowait(first)
+    srv._router_queue_ctrl.put_nowait(second)
+    srv._router_queue_ctrl.put_nowait(third)
+
+    srv._drain_router_ctrl_queue()
+
+    assert srv.ctrl_unicast_wouldblock == 1
+    assert srv.ctrl_unicast_sent == 1
+    assert [call.args[0][0] for call in router.send_multipart.call_args_list] == [
+        b"ident-a",
+        b"ident-b",
+    ]
+
+    remaining = []
+    while not srv._router_queue_ctrl.empty():
+        remaining.append(srv._router_queue_ctrl.get_nowait())
+    assert remaining == [first, third]
 
 
 def test_transform_identity_does_not_overwrite_control_identity() -> None:
@@ -197,6 +227,51 @@ def test_object_pose_attributed_by_payload_device_id() -> None:
         obj_state = srv.room_objects[room_id][object_id]
     assert obj_state["owner_client_no"] == client_no
     assert obj_state["pose_seq"] == 3
+
+
+def test_object_pose_before_hello_assigns_payload_device_id() -> None:
+    """A stealth owner's object pose before hello must not be dropped."""
+    srv = NetSyncServer(enable_server_discovery=False)
+    room_id = "obj-before-hello-room"
+    device_id = "stealth-owner-before-hello"
+    object_id = 0xABCDEF02
+
+    pose = binary_serializer.serialize_object_pose(
+        {
+            "deviceId": device_id,
+            "objectId": object_id,
+            "poseSeq": 7,
+            "posX": 1.0,
+            "posY": 2.0,
+            "posZ": 3.0,
+            "rotX": 0.0,
+            "rotY": 0.0,
+            "rotZ": 0.0,
+            "rotW": 1.0,
+        }
+    )
+    msg_type, pose_data, _ = binary_serializer.deserialize(pose)
+    assert msg_type == binary_serializer.MSG_OBJECT_POSE
+    assert pose_data is not None
+
+    srv._handle_transform_message(b"transform-x", room_id, msg_type, pose_data, pose)
+
+    client_no = srv._get_client_no_for_device_id(room_id, device_id)
+    assert client_no != 0
+    with srv._rooms_lock:
+        obj_state = srv.room_objects[room_id][object_id]
+    assert obj_state["owner_client_no"] == client_no
+    assert obj_state["pose_seq"] == 7
+
+    hello = binary_serializer.serialize_client_hello(device_id, is_stealth=True)
+    _, hello_data, _ = binary_serializer.deserialize(hello)
+    assert hello_data is not None
+    srv._handle_client_hello(b"control-1", room_id, hello_data)
+
+    with srv._rooms_lock:
+        client_data = srv.rooms[room_id][device_id]
+    assert client_data["client_no"] == client_no
+    assert client_data["control_identity"] == b"control-1"
 
 
 def test_wrong_lane_message_is_dropped() -> None:

--- a/STYLY-NetSync-Server/tests/test_transport_split.py
+++ b/STYLY-NetSync-Server/tests/test_transport_split.py
@@ -1,0 +1,131 @@
+"""Tests for split control/transform transport behavior."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import zmq
+
+from styly_netsync import binary_serializer
+from styly_netsync.server import NetSyncServer
+
+
+def test_router_control_drain_retries_blocked_packet_fifo() -> None:
+    """A would-block control unicast is retained and retried before later packets."""
+    srv = NetSyncServer(enable_server_discovery=False)
+    router = MagicMock()
+    router.send_multipart.side_effect = [zmq.Again(), None]
+    srv.control_router = router
+    srv.ROUTER_CTRL_DRAIN_BATCH = 1
+
+    first = (b"ident-a", b"room", b"first")
+    second = (b"ident-b", b"room", b"second")
+    srv._router_queue_ctrl.put_nowait(first)
+    srv._router_queue_ctrl.put_nowait(second)
+
+    srv._drain_router_ctrl_queue()
+    assert srv.ctrl_unicast_wouldblock == 1
+    assert srv.ctrl_unicast_sent == 0
+    assert srv._blocked_router_packet == first
+
+    srv._drain_router_ctrl_queue()
+    assert srv.ctrl_unicast_sent == 1
+    assert srv._blocked_router_packet is None
+    assert router.send_multipart.call_args_list[1].args[0] == [
+        first[0],
+        first[1],
+        first[2],
+    ]
+    assert srv._router_queue_ctrl.get_nowait() == second
+
+
+def test_transform_identity_does_not_overwrite_control_identity() -> None:
+    """Transform reconnects must not replace the control identity used for RPC/NV."""
+    srv = NetSyncServer(enable_server_discovery=False)
+    room_id = "split-room"
+    device_id = "device-a"
+
+    hello = binary_serializer.serialize_client_hello(device_id)
+    msg_type, hello_data, _ = binary_serializer.deserialize(hello)
+    assert msg_type == binary_serializer.MSG_CLIENT_HELLO
+    assert hello_data is not None
+    srv._handle_client_hello(b"control-1", room_id, hello_data)
+
+    pose = binary_serializer.serialize_client_transform(
+        {
+            "deviceId": device_id,
+            "flags": 0,
+            "head": {},
+            "right": {},
+            "left": {},
+            "physical": {},
+            "virtuals": [],
+        }
+    )
+    msg_type, pose_data, raw = binary_serializer.deserialize(pose)
+    assert msg_type == binary_serializer.MSG_CLIENT_POSE
+    assert pose_data is not None
+
+    srv._handle_client_transform(b"transform-1", room_id, pose_data, raw)
+    srv._handle_client_transform(b"transform-2", room_id, pose_data, raw)
+
+    with srv._rooms_lock:
+        client_data = srv.rooms[room_id][device_id]
+        assert client_data["control_identity"] == b"control-1"
+        assert client_data["transform_identity"] == b"transform-2"
+
+
+def test_wrong_lane_message_is_dropped() -> None:
+    """Control lane drops transform messages instead of dispatching them."""
+    srv = NetSyncServer(enable_server_discovery=False)
+
+    srv._handle_control_message(
+        b"control-1",
+        "room",
+        binary_serializer.MSG_CLIENT_POSE,
+        {"deviceId": "device-a"},
+    )
+
+    assert srv.wrong_lane_dropped == 1
+    with srv._rooms_lock:
+        assert "room" not in srv.rooms
+
+
+def test_rpc_target_fanout_enqueues_all_ten_targets() -> None:
+    """Targeted RPC fanout should enqueue one control unicast per target."""
+    srv = NetSyncServer(enable_server_discovery=False)
+    room_id = "rpc-room"
+    srv._initialize_room(room_id)
+
+    for client_no in range(1, 12):
+        device_id = f"device-{client_no}"
+        srv.rooms[room_id][device_id] = {
+            "control_identity": f"control-{client_no}".encode(),
+            "transform_identity": f"transform-{client_no}".encode(),
+            "last_update": 0.0,
+            "transform_data": None,
+            "client_no": client_no,
+            "is_stealth": False,
+        }
+        srv.room_device_id_to_client_no[room_id][device_id] = client_no
+        srv.room_client_no_to_device_id[room_id][client_no] = device_id
+
+    srv._send_rpc_to_room(
+        room_id,
+        {
+            "senderClientNo": 11,
+            "targetClientNos": list(range(1, 11)),
+            "functionName": "Burst",
+            "argumentsJson": "[]",
+        },
+    )
+
+    queued = []
+    while not srv._router_queue_ctrl.empty():
+        queued.append(srv._router_queue_ctrl.get_nowait())
+
+    assert len(queued) == 10
+    assert {item[0] for item in queued} == {
+        f"control-{client_no}".encode() for client_no in range(1, 11)
+    }
+    assert srv.ctrl_unicast_dropped == 0

--- a/STYLY-NetSync-Server/tests/test_transport_split.py
+++ b/STYLY-NetSync-Server/tests/test_transport_split.py
@@ -75,6 +75,130 @@ def test_transform_identity_does_not_overwrite_control_identity() -> None:
         assert client_data["transform_identity"] == b"transform-2"
 
 
+def test_hello_after_transform_first_syncs_objects() -> None:
+    """A transform-before-hello join must still receive the object-ownership sync.
+
+    With split sockets a client's first pose can reach the transform lane before
+    its hello reaches the control lane. The transform handler creates the room
+    entry with no control identity and skips object sync; the later hello must
+    detect this first control-lane bind and run the new-client object sync.
+    """
+    srv = NetSyncServer(enable_server_discovery=False)
+    room_id = "order-room"
+    device_id = "device-order"
+
+    # Spy on object sync to observe exactly when/with what identity it runs.
+    srv._sync_objects_to_new_client = MagicMock()  # type: ignore[method-assign]
+
+    # Transform arrives first -> entry created with control_identity=None.
+    pose = binary_serializer.serialize_client_transform(
+        {
+            "deviceId": device_id,
+            "flags": 0,
+            "head": {},
+            "right": {},
+            "left": {},
+            "physical": {},
+            "virtuals": [],
+        }
+    )
+    msg_type, pose_data, raw = binary_serializer.deserialize(pose)
+    assert msg_type == binary_serializer.MSG_CLIENT_POSE
+    assert pose_data is not None
+    srv._handle_client_transform(b"transform-1", room_id, pose_data, raw)
+
+    # No control identity yet, so the transform path must not object-sync.
+    srv._sync_objects_to_new_client.assert_not_called()
+    with srv._rooms_lock:
+        assert srv.rooms[room_id][device_id]["control_identity"] is None
+
+    # Hello arrives afterwards -> control lane binds for the first time.
+    hello = binary_serializer.serialize_client_hello(device_id)
+    msg_type, hello_data, _ = binary_serializer.deserialize(hello)
+    assert msg_type == binary_serializer.MSG_CLIENT_HELLO
+    assert hello_data is not None
+    srv._handle_client_hello(b"control-1", room_id, hello_data)
+
+    # Object ownership sync must run exactly once, on the control identity.
+    srv._sync_objects_to_new_client.assert_called_once_with(b"control-1", room_id)
+    with srv._rooms_lock:
+        assert srv.rooms[room_id][device_id]["control_identity"] == b"control-1"
+
+
+def test_hello_reconnect_after_bind_does_not_resync_objects() -> None:
+    """A genuine control-lane reconnect (already bound) must not re-run object sync."""
+    srv = NetSyncServer(enable_server_discovery=False)
+    room_id = "rebind-room"
+    device_id = "device-rebind"
+
+    hello = binary_serializer.serialize_client_hello(device_id)
+    _, hello_data, _ = binary_serializer.deserialize(hello)
+    assert hello_data is not None
+
+    # First hello: brand-new client, object sync expected once.
+    srv._sync_objects_to_new_client = MagicMock()  # type: ignore[method-assign]
+    srv._handle_client_hello(b"control-1", room_id, hello_data)
+    srv._sync_objects_to_new_client.assert_called_once_with(b"control-1", room_id)
+
+    # Second hello with a new identity: reconnect, but control was already bound,
+    # so object sync must NOT run again.
+    srv._sync_objects_to_new_client.reset_mock()
+    srv._handle_client_hello(b"control-2", room_id, hello_data)
+    srv._sync_objects_to_new_client.assert_not_called()
+
+
+def test_object_pose_attributed_by_payload_device_id() -> None:
+    """A stealth owner's object pose is applied even without a transform_identity.
+
+    Stealth clients register only on the control lane (hello) and never send
+    MSG_CLIENT_POSE, so they never bind a transform_identity. Object poses must
+    be attributed via the deviceId carried in the MSG_OBJECT_POSE payload.
+    """
+    srv = NetSyncServer(enable_server_discovery=False)
+    room_id = "obj-room"
+    device_id = "stealth-owner"
+
+    # Stealth hello on the control lane only — no transform pose is ever sent.
+    hello = binary_serializer.serialize_client_hello(device_id, is_stealth=True)
+    _, hello_data, _ = binary_serializer.deserialize(hello)
+    assert hello_data is not None
+    srv._handle_client_hello(b"control-1", room_id, hello_data)
+    client_no = srv._get_client_no_for_device_id(room_id, device_id)
+    assert client_no != 0
+    with srv._rooms_lock:
+        assert srv.rooms[room_id][device_id]["transform_identity"] is None
+
+    # The stealth client owns and moves an object -> MSG_OBJECT_POSE on transform lane.
+    object_id = 0xABCDEF01
+    pose = binary_serializer.serialize_object_pose(
+        {
+            "deviceId": device_id,
+            "objectId": object_id,
+            "poseSeq": 3,
+            "posX": 1.0,
+            "posY": 2.0,
+            "posZ": 3.0,
+            "rotX": 0.0,
+            "rotY": 0.0,
+            "rotZ": 0.0,
+            "rotW": 1.0,
+        }
+    )
+    msg_type, pose_data, _ = binary_serializer.deserialize(pose)
+    assert msg_type == binary_serializer.MSG_OBJECT_POSE
+    assert pose_data is not None
+    assert pose_data["deviceId"] == device_id
+
+    # The transform-lane socket identity (b"transform-x") was never registered for
+    # this device, yet the pose must still be attributed to the stealth owner.
+    srv._handle_transform_message(b"transform-x", room_id, msg_type, pose_data, pose)
+
+    with srv._rooms_lock:
+        obj_state = srv.room_objects[room_id][object_id]
+    assert obj_state["owner_client_no"] == client_no
+    assert obj_state["pose_seq"] == 3
+
+
 def test_wrong_lane_message_is_dropped() -> None:
     """Control lane drops transform messages instead of dispatching them."""
     srv = NetSyncServer(enable_server_discovery=False)

--- a/STYLY-NetSync-Unity/AGENTS.md
+++ b/STYLY-NetSync-Unity/AGENTS.md
@@ -36,7 +36,7 @@
 - **TransformSyncManager**: Transform sync with SendRate cap, only-on-change filtering, 1Hz idle heartbeat
 - **RPCManager**: Remote procedure calls with priority-based sending and targeted delivery
 - **NetworkVariableManager**: Synchronized key-value storage
-- **BinarySerializer**: Protocol v6 pose serialization/deserialization
+- **BinarySerializer**: Protocol v7 pose serialization/deserialization
 - **MessageProcessor**: Binary protocol message handling
 - **AvatarManager**: Player spawn/despawn management
 

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Editor/StartPythonServer.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Editor/StartPythonServer.cs
@@ -16,7 +16,9 @@ namespace Styly.NetSync.Editor
     internal class ServerLaunchConfig
     {
         // Port settings
+        public int ControlPort = 5555;
         public int DealerPort = 5555;
+        public int TransformPort = 5557;
         public int PubPort = 5556;
         public int ServerDiscoveryPort = StartPythonServer.DefaultServerDiscoveryPort;
         public int RestApiPort = 8800;
@@ -49,8 +51,12 @@ namespace Styly.NetSync.Editor
             if (!string.IsNullOrEmpty(ConfigFile))
                 sb.Append($" --config {quoteValue(ConfigFile)}");
 
-            if (DealerPort != 5555)
-                sb.Append($" --dealer-port {DealerPort}");
+            int resolvedControlPort = ControlPort != 5555 ? ControlPort : DealerPort;
+            if (resolvedControlPort != 5555)
+                sb.Append($" --control-port {resolvedControlPort}");
+
+            if (TransformPort != 5557)
+                sb.Append($" --transform-port {TransformPort}");
 
             if (PubPort != 5556)
                 sb.Append($" --pub-port {PubPort}");

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Editor/StartPythonServerWindow.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Editor/StartPythonServerWindow.cs
@@ -8,7 +8,8 @@ namespace Styly.NetSync.Editor
         private const string PrefsPrefix = "STYLY_NetSync_Server_";
 
         // Port settings
-        private int _dealerPort = 5555;
+        private int _controlPort = 5555;
+        private int _transformPort = 5557;
         private int _pubPort = 5556;
         private int _serverDiscoveryPort = StartPythonServer.DefaultServerDiscoveryPort;
         private int _restApiPort = 8800;
@@ -91,7 +92,8 @@ namespace Styly.NetSync.Editor
 
                 // Port settings
                 EditorGUILayout.LabelField("Ports", EditorStyles.boldLabel);
-                _dealerPort = PortField("Dealer Port", _dealerPort);
+                _controlPort = PortField("Control Port", _controlPort);
+                _transformPort = PortField("Transform Port", _transformPort);
                 _pubPort = PortField("PUB Port", _pubPort);
                 _restApiPort = PortField("REST API Port", _restApiPort);
 
@@ -182,7 +184,9 @@ namespace Styly.NetSync.Editor
         {
             return new ServerLaunchConfig
             {
-                DealerPort = _dealerPort,
+                ControlPort = _controlPort,
+                DealerPort = _controlPort,
+                TransformPort = _transformPort,
                 PubPort = _pubPort,
                 ServerDiscoveryPort = _serverDiscoveryPort,
                 RestApiPort = _restApiPort,
@@ -198,7 +202,11 @@ namespace Styly.NetSync.Editor
 
         private void LoadSettings()
         {
-            _dealerPort = EditorPrefs.GetInt(PrefsPrefix + "DealerPort", 5555);
+            _controlPort = EditorPrefs.GetInt(
+                PrefsPrefix + "ControlPort",
+                EditorPrefs.GetInt(PrefsPrefix + "DealerPort", 5555)
+            );
+            _transformPort = EditorPrefs.GetInt(PrefsPrefix + "TransformPort", 5557);
             _pubPort = EditorPrefs.GetInt(PrefsPrefix + "PubPort", 5556);
             // Prefer the NetSyncManager in an open scene over the saved value,
             // so the dialog reflects the port currently configured in the scene.
@@ -229,7 +237,9 @@ namespace Styly.NetSync.Editor
 
         private void SaveSettings()
         {
-            EditorPrefs.SetInt(PrefsPrefix + "DealerPort", _dealerPort);
+            EditorPrefs.SetInt(PrefsPrefix + "ControlPort", _controlPort);
+            EditorPrefs.SetInt(PrefsPrefix + "DealerPort", _controlPort);
+            EditorPrefs.SetInt(PrefsPrefix + "TransformPort", _transformPort);
             EditorPrefs.SetInt(PrefsPrefix + "PubPort", _pubPort);
             EditorPrefs.SetInt(PrefsPrefix + "ServerDiscoveryPort", _serverDiscoveryPort);
             EditorPrefs.SetInt(PrefsPrefix + "RestApiPort", _restApiPort);
@@ -245,7 +255,8 @@ namespace Styly.NetSync.Editor
 
         private void ResetToDefaults()
         {
-            _dealerPort = 5555;
+            _controlPort = 5555;
+            _transformPort = 5557;
             _pubPort = 5556;
             _serverDiscoveryPort = StartPythonServer.GetDefaultServerDiscoveryPort();
             _restApiPort = 8800;

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/BinarySerializer.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/BinarySerializer.cs
@@ -627,10 +627,17 @@ namespace Styly.NetSync
             writer.Write((byte)0);
         }
 
-        public static void SerializeObjectPoseInto(BinaryWriter writer, uint objectId, ushort poseSeq, Vector3 position, Quaternion rotation)
+        public static void SerializeObjectPoseInto(BinaryWriter writer, string deviceId, uint objectId, ushort poseSeq, Vector3 position, Quaternion rotation)
         {
             writer.Write(MSG_OBJECT_POSE);
             writer.Write(PROTOCOL_VERSION);
+            // Sender device ID (length-prefixed UTF8): lets the server attribute the
+            // pose by payload identity rather than the transform-lane socket identity,
+            // which a stealth owner never binds (it sends no MSG_CLIENT_POSE).
+            var deviceIdBytes = System.Text.Encoding.UTF8.GetBytes(deviceId ?? "");
+            var deviceIdLength = Mathf.Min(deviceIdBytes.Length, byte.MaxValue);
+            writer.Write((byte)deviceIdLength);
+            writer.Write(deviceIdBytes, 0, deviceIdLength);
             writer.Write(objectId);
             writer.Write(poseSeq);
             WriteInt24(writer, QuantizeSignedInt24(position.x, ABS_POS_SCALE));

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/BinarySerializer.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/BinarySerializer.cs
@@ -476,7 +476,7 @@ namespace Styly.NetSync
 
             // Device ID (as UTF8 bytes with length prefix)
             var deviceIdBytes = System.Text.Encoding.UTF8.GetBytes(data != null ? data.deviceId ?? string.Empty : string.Empty);
-            var deviceIdLength = Mathf.Min(deviceIdBytes.Length, byte.MaxValue);
+            var deviceIdLength = System.Math.Min(deviceIdBytes.Length, byte.MaxValue);
             writer.Write((byte)deviceIdLength);
             writer.Write(deviceIdBytes, 0, deviceIdLength);
 
@@ -581,7 +581,7 @@ namespace Styly.NetSync
             writer.Write(isStealth ? CLIENT_HELLO_FLAG_STEALTH : (byte)0);
 
             var deviceIdBytes = System.Text.Encoding.UTF8.GetBytes(deviceId ?? "");
-            var deviceIdLength = Mathf.Min(deviceIdBytes.Length, byte.MaxValue);
+            var deviceIdLength = System.Math.Min(deviceIdBytes.Length, byte.MaxValue);
             writer.Write((byte)deviceIdLength);
             writer.Write(deviceIdBytes, 0, deviceIdLength);
         }
@@ -614,7 +614,7 @@ namespace Styly.NetSync
 
             // Device ID (as UTF8 bytes with length prefix)
             var deviceIdBytes = System.Text.Encoding.UTF8.GetBytes(deviceId ?? "");
-            var deviceIdLength = Mathf.Min(deviceIdBytes.Length, byte.MaxValue);
+            var deviceIdLength = System.Math.Min(deviceIdBytes.Length, byte.MaxValue);
             writer.Write((byte)deviceIdLength);
             writer.Write(deviceIdBytes, 0, deviceIdLength);
 
@@ -635,7 +635,7 @@ namespace Styly.NetSync
             // pose by payload identity rather than the transform-lane socket identity,
             // which a stealth owner never binds (it sends no MSG_CLIENT_POSE).
             var deviceIdBytes = System.Text.Encoding.UTF8.GetBytes(deviceId ?? "");
-            var deviceIdLength = Mathf.Min(deviceIdBytes.Length, byte.MaxValue);
+            var deviceIdLength = System.Math.Min(deviceIdBytes.Length, byte.MaxValue);
             writer.Write((byte)deviceIdLength);
             writer.Write(deviceIdBytes, 0, deviceIdLength);
             writer.Write(objectId);

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/BinarySerializer.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/BinarySerializer.cs
@@ -7,10 +7,11 @@ namespace Styly.NetSync
 {
     internal static class BinarySerializer
     {
-        // v6: Network Variable wire messages dropped the per-write timestamp field.
+        // v7: Control and transform traffic use separate sockets, and clients register
+        // their control identity with MSG_CLIENT_HELLO.
         // Bumped so mixed old/new builds fail the handshake instead of silently
         // misparsing NV traffic (the version byte rides on transform/object messages).
-        public const byte PROTOCOL_VERSION = 6;
+        public const byte PROTOCOL_VERSION = 7;
 
         // Message type identifiers
         public const byte MSG_CLIENT_TRANSFORM = 1;
@@ -31,8 +32,11 @@ namespace Styly.NetSync
         public const byte MSG_OBJECT_OWNERSHIP_CHANGED = 16; // Server → Clients: ownership changed
         public const byte MSG_OBJECT_OWNERSHIP_REJECTED = 17; // Server → Client: request rejected
         public const byte MSG_CLIENT_VAR_CLEAR = 18; // Clear all client variables for the sender
+        public const byte MSG_CLIENT_HELLO = 19; // Client → Server: bind control identity to device ID
 
-        // Protocol v5 pose encoding constants
+        public const byte CLIENT_HELLO_FLAG_STEALTH = 0x01;
+
+        // Protocol v7 pose encoding constants
         private const float ABS_POS_SCALE = 0.01f;
         private const float LOCO_POS_SCALE = 0.01f;
         private const float REL_POS_SCALE = 0.005f;
@@ -568,6 +572,21 @@ namespace Styly.NetSync
         }
 
         /// <summary>
+        /// Serialize a client hello control message into an existing BinaryWriter.
+        /// </summary>
+        public static void SerializeClientHelloInto(BinaryWriter writer, string deviceId, bool isStealth)
+        {
+            writer.Write(MSG_CLIENT_HELLO);
+            writer.Write(PROTOCOL_VERSION);
+            writer.Write(isStealth ? CLIENT_HELLO_FLAG_STEALTH : (byte)0);
+
+            var deviceIdBytes = System.Text.Encoding.UTF8.GetBytes(deviceId ?? "");
+            var deviceIdLength = Mathf.Min(deviceIdBytes.Length, byte.MaxValue);
+            writer.Write((byte)deviceIdLength);
+            writer.Write(deviceIdBytes, 0, deviceIdLength);
+        }
+
+        /// <summary>
         /// Serialize a stealth handshake into a new byte array (legacy API).
         /// Prefer SerializeStealthHandshakeInto to reuse an existing stream/writer.
         /// </summary>
@@ -642,7 +661,7 @@ namespace Styly.NetSync
                 var messageType = reader.ReadByte();
 
                 // Validate message type is within valid range
-                if (messageType < MSG_CLIENT_TRANSFORM || messageType > MSG_CLIENT_VAR_CLEAR)
+                if (messageType < MSG_CLIENT_TRANSFORM || messageType > MSG_CLIENT_HELLO)
                 {
                     // Don't throw exception, just return invalid type with null data
                     // This allows the caller to handle it gracefully

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/ConnectionManager.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/ConnectionManager.cs
@@ -320,9 +320,10 @@ namespace Styly.NetSync
 
                 var roomIdBytes = Encoding.UTF8.GetBytes(roomId);
 
-                // Queue connection callback for main thread instead of invoking directly
-                _pendingMainThreadActions.Enqueue(() => OnConnectionEstablished?.Invoke());
+                // Ensure hello is the first queued control message for this connection.
                 EnqueueClientHello(roomId, isStealth: false);
+                // Queue connection callback for main thread instead of invoking directly.
+                _pendingMainThreadActions.Enqueue(() => OnConnectionEstablished?.Invoke());
 
                 while (!_shouldStop)
                 {

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/ConnectionManager.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/ConnectionManager.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Text;
@@ -15,6 +16,7 @@ namespace Styly.NetSync
     internal class ConnectionManager : IConnectionManager
     {
         private DealerSocket _dealerSocket;
+        private DealerSocket _transformDealerSocket;
         private SubscriberSocket _subSocket;
         private Thread _receiveThread;
         private volatile bool _shouldStop;
@@ -36,7 +38,7 @@ namespace Styly.NetSync
         private enum LogLevel { Info, Warning, Error }
 
         public SubscriberSocket SubSocket => _subSocket;
-        public bool IsConnected => _dealerSocket != null && _subSocket != null && !_connectionError;
+        public bool IsConnected => _dealerSocket != null && _transformDealerSocket != null && _subSocket != null && !_connectionError;
         public bool IsConnectionError => _connectionError;
 
         // Thread-safe accessors for exception state
@@ -52,10 +54,13 @@ namespace Styly.NetSync
         public event Action<string> OnConnectionError;
         public event Action OnConnectionEstablished;
 
-        private readonly NetSyncManager _netSyncManager;
         private readonly MessageProcessor _messageProcessor;
+        private readonly string _deviceId;
 
         private const int TransformRcvHwm = 2;
+        private const int ControlSendHwm = 1024;
+        private const int ControlReceiveHwm = 1024;
+        private const int TransformSendHwm = 2;
         private const long QueueFullWarnIntervalMs = 5000; // Rate limit warning logs to once per 5 seconds
         private long _lastQueueFullWarnMs;
 
@@ -80,12 +85,13 @@ namespace Styly.NetSync
         /// </summary>
         private readonly ConcurrentQueue<OutboundPacket> _ctrlOutbox = new();
         private int _ctrlOutboxCount;
+        private OutboundPacket _pendingControl;
 
         /// <summary>
         /// Latest transform packet to send (latest-wins semantics).
         /// Only the most recent transform is sent; older ones are overwritten.
         /// </summary>
-        private volatile OutboundPacket _latestTransform;
+        private OutboundPacket _latestTransform;
 
         /// <summary>
         /// Per-objectId latest-wins slots for NetSyncObject transform sends.
@@ -112,13 +118,13 @@ namespace Styly.NetSync
 
         public ConnectionManager(NetSyncManager netSyncManager, MessageProcessor messageProcessor, bool enableDebugLogs, bool logNetworkTraffic)
         {
-            _netSyncManager = netSyncManager;
             _messageProcessor = messageProcessor;
+            _deviceId = netSyncManager != null ? netSyncManager.DeviceId : string.Empty;
             _enableDebugLogs = enableDebugLogs;
             _logNetworkTraffic = logNetworkTraffic;
         }
 
-        public void Connect(string serverAddress, int dealerPort, int subPort, string roomId)
+        public void Connect(string serverAddress, int controlPort, int transformPort, int subPort, string roomId)
         {
             if (_receiveThread != null)
             {
@@ -128,7 +134,7 @@ namespace Styly.NetSync
             _currentRoomId = roomId;
             _connectionError = false;
             _shouldStop = false;
-            _receiveThread = new Thread(() => NetworkLoop(serverAddress, dealerPort, subPort, roomId))
+            _receiveThread = new Thread(() => NetworkLoop(serverAddress, controlPort, transformPort, subPort, roomId))
             {
                 IsBackground = true,
                 Name = "STYLY_NetworkThread"
@@ -154,6 +160,7 @@ namespace Styly.NetSync
 
             _subSocket = null;
             _dealerSocket = null;
+            _transformDealerSocket = null;
             _receiveThread = null;
 
             // OS-specific cleanup
@@ -200,6 +207,15 @@ namespace Styly.NetSync
             return true;
         }
 
+        private bool EnqueueClientHello(string roomId, bool isStealth)
+        {
+            using var ms = new MemoryStream();
+            using var writer = new BinaryWriter(ms);
+            BinarySerializer.SerializeClientHelloInto(writer, _deviceId, isStealth);
+            writer.Flush();
+            return TryEnqueueControl(roomId, ms.ToArray());
+        }
+
         /// <summary>
         /// Set the latest transform packet to send (latest-wins semantics).
         /// Only the most recent transform is retained; calling this again overwrites the previous.
@@ -209,7 +225,7 @@ namespace Styly.NetSync
         public void SetLatestTransform(string roomId, byte[] payload)
         {
             if (_receiveThread == null || _shouldStop || _connectionError) { return; }
-            if (_dealerSocket == null) { return; }
+            if (_transformDealerSocket == null) { return; }
 
             var packet = new OutboundPacket
             {
@@ -232,7 +248,7 @@ namespace Styly.NetSync
         public void SetLatestObjectTransform(string roomId, uint objectId, byte[] payload)
         {
             if (_receiveThread == null || _shouldStop || _connectionError) { return; }
-            if (_dealerSocket == null) { return; }
+            if (_transformDealerSocket == null) { return; }
             if (objectId == 0u) { return; }
 
             var packet = new OutboundPacket
@@ -264,19 +280,30 @@ namespace Styly.NetSync
             return $"tcp://{host}:{port}";
         }
 
-        private void NetworkLoop(string serverAddress, int dealerPort, int subPort, string roomId)
+        private void NetworkLoop(string serverAddress, int controlPort, int transformPort, int subPort, string roomId)
         {
             try
             {
-                // Dealer (for sending)
-                using var dealer = new DealerSocket();
-                dealer.Options.Linger = TimeSpan.Zero;
-                dealer.Options.SendHighWatermark = 10;
-                var dealerAddr = BuildConnectAddress(serverAddress, dealerPort);
-                dealer.Connect(dealerAddr);
-                _dealerSocket = dealer;
+                // Control dealer (RPC, Network Variables, ownership, hello).
+                using var controlDealer = new DealerSocket();
+                controlDealer.Options.Linger = TimeSpan.Zero;
+                controlDealer.Options.SendHighWatermark = ControlSendHwm;
+                controlDealer.Options.ReceiveHighWatermark = ControlReceiveHwm;
+                var controlAddr = BuildConnectAddress(serverAddress, controlPort);
+                controlDealer.Connect(controlAddr);
+                _dealerSocket = controlDealer;
 
-                if (_enableDebugLogs) _pendingLogs.Enqueue((LogLevel.Info, $"[ConnectionManager] [Thread] DEALER connected → {dealerAddr}"));
+                if (_enableDebugLogs) _pendingLogs.Enqueue((LogLevel.Info, $"[ConnectionManager] [Thread] CONTROL DEALER connected → {controlAddr}"));
+
+                // Transform dealer (client and object poses only).
+                using var transformDealer = new DealerSocket();
+                transformDealer.Options.Linger = TimeSpan.Zero;
+                transformDealer.Options.SendHighWatermark = TransformSendHwm;
+                var transformAddr = BuildConnectAddress(serverAddress, transformPort);
+                transformDealer.Connect(transformAddr);
+                _transformDealerSocket = transformDealer;
+
+                if (_enableDebugLogs) _pendingLogs.Enqueue((LogLevel.Info, $"[ConnectionManager] [Thread] TRANSFORM DEALER connected → {transformAddr}"));
 
                 // Subscriber (for receiving)
                 using var sub = new SubscriberSocket();
@@ -295,10 +322,11 @@ namespace Styly.NetSync
 
                 // Queue connection callback for main thread instead of invoking directly
                 _pendingMainThreadActions.Enqueue(() => OnConnectionEstablished?.Invoke());
+                EnqueueClientHello(roomId, isStealth: false);
 
                 while (!_shouldStop)
                 {
-                    var sentAny = FlushOutgoing(dealer);
+                    var sentAny = FlushOutgoing(controlDealer, transformDealer);
                     bool receivedAny = false;
 
                     byte[] lastAvatarPayload = null;
@@ -360,9 +388,9 @@ namespace Styly.NetSync
                     // DEALER receive: control messages (RPC, NV, ID mapping) from ROUTER
                     // Server sends control messages via ROUTER->DEALER instead of PUB/SUB
                     // Message format: [roomId, payload] (2 frames)
-                    while (dealer.TryReceiveFrameString(TimeSpan.Zero, out var dealerRoomId))
+                    while (controlDealer.TryReceiveFrameString(TimeSpan.Zero, out var dealerRoomId))
                     {
-                        if (!dealer.TryReceiveFrameBytes(TimeSpan.Zero, out var dealerPayload))
+                        if (!controlDealer.TryReceiveFrameBytes(TimeSpan.Zero, out var dealerPayload))
                         {
                             // Incomplete message - should not happen with proper framing
                             break;
@@ -403,7 +431,7 @@ namespace Styly.NetSync
                     
                     // Queue log for main thread (Debug.Log* is not safe from background threads)
                     var threadId = Thread.CurrentThread.ManagedThreadId;
-                    var endpoint = $"{serverAddress}:{dealerPort}/{subPort}";
+                    var endpoint = $"{serverAddress}:{controlPort}/{transformPort}/{subPort}";
                     _pendingLogs.Enqueue((LogLevel.Error,
                         $"[ConnectionManager] Network thread error. " +
                         $"Type={ex_local.GetType().Name} Message={ex_local.Message} " +
@@ -423,7 +451,7 @@ namespace Styly.NetSync
             }
         }
 
-        private bool FlushOutgoing(DealerSocket dealer)
+        private bool FlushOutgoing(DealerSocket controlDealer, DealerSocket transformDealer)
         {
             bool didWork = false;
 
@@ -431,9 +459,9 @@ namespace Styly.NetSync
             // 1. Drain control messages first (higher priority)
             // 2. Then try to send latest transform (lower priority)
 
-            didWork |= DrainControlSends(dealer, maxBatch: 64);
-            didWork |= TrySendLatestTransform(dealer);
-            didWork |= TrySendLatestObjectTransforms(dealer);
+            didWork |= DrainControlSends(controlDealer, maxBatch: 64);
+            didWork |= TrySendLatestTransform(transformDealer);
+            didWork |= TrySendLatestObjectTransforms(transformDealer);
 
             return didWork;
         }
@@ -488,20 +516,31 @@ namespace Styly.NetSync
             int sent = 0;
             double now = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() / 1000.0;
 
-            while (sent < maxBatch && _ctrlOutbox.TryDequeue(out var packet))
+            while (sent < maxBatch)
             {
-                Interlocked.Decrement(ref _ctrlOutboxCount);
+                if (_pendingControl == null)
+                {
+                    if (!_ctrlOutbox.TryDequeue(out _pendingControl))
+                    {
+                        break;
+                    }
+                    Interlocked.Decrement(ref _ctrlOutboxCount);
+                }
+
+                var packet = _pendingControl;
 
                 // TTL check - skip expired packets
                 if (now - packet.EnqueuedAt > CTRL_TTL_SECONDS)
                 {
                     _pendingLogs.Enqueue((LogLevel.Warning, $"[ConnectionManager] Control packet expired (TTL {CTRL_TTL_SECONDS}s exceeded)"));
+                    _pendingControl = null;
                     continue;
                 }
 
                 // Try to send
                 if (TrySendDealer(dealer, packet.RoomId, packet.Payload))
                 {
+                    _pendingControl = null;
                     didWork = true;
                     sent++;
                 }
@@ -510,13 +549,6 @@ namespace Styly.NetSync
                     // Backpressure - increment counter and stop draining
                     Interlocked.Increment(ref _wouldBlockCount);
                     packet.Attempts++;
-
-                    // The packet is DROPPED on backpressure (not retried) for the following reasons:
-                    // 1. Re-enqueue at the front is not possible with ConcurrentQueue
-                    // 2. Re-enqueuing at the back would cause out-of-order delivery
-                    // 3. Retrying could cause infinite loops if backpressure persists
-                    // This is acceptable for control messages as they are idempotent or timestamped.
-                    // In practice, the HWM should rarely be hit with proper flow control.
                     break;
                 }
             }
@@ -616,6 +648,7 @@ namespace Styly.NetSync
             // Clear control outbox
             while (_ctrlOutbox.TryDequeue(out _)) { }
             Interlocked.Exchange(ref _ctrlOutboxCount, 0);
+            _pendingControl = null;
 
             // Clear latest transform
             Volatile.Write(ref _latestTransform, null);
@@ -675,13 +708,13 @@ namespace Styly.NetSync
             }
         }
 
-        public void ProcessDiscoveredServer(string serverAddress, int dealerPort, int subPort)
+        public void ProcessDiscoveredServer(string serverAddress, int controlPort, int transformPort, int subPort)
         {
             if (_discoveryManager != null)
             {
                 _discoveryManager.StopDiscovery();
             }
-            Connect(serverAddress, dealerPort, subPort, _currentRoomId);
+            Connect(serverAddress, controlPort, transformPort, subPort, _currentRoomId);
         }
 
         public void DebugLog(string msg)

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/IConnectionManager.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/IConnectionManager.cs
@@ -6,7 +6,7 @@ namespace Styly.NetSync
     internal interface IConnectionManager
     {
         // Connection lifecycle
-        void Connect(string serverAddress, int dealerPort, int subPort, string roomId);
+        void Connect(string serverAddress, int controlPort, int transformPort, int subPort, string roomId);
         void Disconnect();
 
         // Connection state
@@ -28,7 +28,7 @@ namespace Styly.NetSync
 
         // Discovery
         void StartDiscovery(ServerDiscoveryManager discoveryManager, string roomId);
-        void ProcessDiscoveredServer(string serverAddress, int dealerPort, int subPort);
+        void ProcessDiscoveredServer(string serverAddress, int controlPort, int transformPort, int subPort);
 
         // Events
         event Action<string> OnConnectionError;

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/ObjectSyncManager.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/ObjectSyncManager.cs
@@ -80,7 +80,7 @@ namespace Styly.NetSync
             _connectionManager.TryEnqueueControl(roomId, payload);
         }
 
-        public void Tick(string roomId, float currentTime, int localClientNo, float transformSendRate)
+        public void Tick(string roomId, float currentTime, int localClientNo, string localDeviceId, float transformSendRate)
         {
             float sendInterval = 1f / Mathf.Max(0.5f, transformSendRate);
 
@@ -123,7 +123,7 @@ namespace Styly.NetSync
                 // Serialize and send
                 _buf.EnsureCapacity(128);
                 _buf.Stream.Position = 0;
-                BinarySerializer.SerializeObjectPoseInto(_buf.Writer, objectId, state.PoseSeq, pos, rot);
+                BinarySerializer.SerializeObjectPoseInto(_buf.Writer, localDeviceId, objectId, state.PoseSeq, pos, rot);
                 _buf.Writer.Flush();
 
                 var length = (int)_buf.Stream.Position;

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/OfflineConnectionManager.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/OfflineConnectionManager.cs
@@ -17,7 +17,7 @@ namespace Styly.NetSync
         public event Action<string> OnConnectionError;
         public event Action OnConnectionEstablished;
 
-        public void Connect(string serverAddress, int dealerPort, int subPort, string roomId)
+        public void Connect(string serverAddress, int controlPort, int transformPort, int subPort, string roomId)
         {
             if (_isConnected) return;
             _isConnected = true;
@@ -35,6 +35,6 @@ namespace Styly.NetSync
         public void SetLatestTransform(string roomId, byte[] payload) { }
         public void SetLatestObjectTransform(string roomId, uint objectId, byte[] payload) { }
         public void StartDiscovery(ServerDiscoveryManager discoveryManager, string roomId) { }
-        public void ProcessDiscoveredServer(string serverAddress, int dealerPort, int subPort) { }
+        public void ProcessDiscoveredServer(string serverAddress, int controlPort, int transformPort, int subPort) { }
     }
 }

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/ServerDiscoveryManager.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/ServerDiscoveryManager.cs
@@ -40,7 +40,7 @@ namespace Styly.NetSync
         public int MaxParallelConnections { get; set; } = 20; // Scan up to 20 IPs concurrently
         public int TcpConnectionTimeoutMs { get; set; } = 300; // Reduced timeout for faster scanning
 
-        public event Action<string, int, int> OnServerDiscovered;
+        public event Action<string, int, int, int> OnServerDiscovered;
 
         public ServerDiscoveryManager(bool enableDebugLogs)
         {
@@ -562,22 +562,23 @@ namespace Styly.NetSync
                 var message = Encoding.UTF8.GetString(data);
                 var parts = message.Split('|');
 
-                if (parts.Length >= 3 && parts[0] == "STYLY-NETSYNC")
+                if (parts.Length >= 5 && parts[0] == "STYLY-NETSYNC2")
                 {
-                    var dealerPort = int.Parse(parts[1]);
-                    var subPort = int.Parse(parts[2]);
-                    var serverName = parts.Length >= 4 ? parts[3] : "Unknown Server";
+                    var controlPort = int.Parse(parts[1]);
+                    var transformPort = int.Parse(parts[2]);
+                    var subPort = int.Parse(parts[3]);
+                    var serverName = parts[4];
 
                     var serverAddress = $"tcp://{sender.Address}";
 
                     // Cache the discovered server IP for future connections
                     QueueCacheServerIp(sender.Address.ToString());
 
-                    DebugLog($"Discovered server '{serverName}' at {serverAddress} (dealer:{dealerPort}, sub:{subPort})");
+                    DebugLog($"Discovered server '{serverName}' at {serverAddress} (control:{controlPort}, transform:{transformPort}, sub:{subPort})");
 
                     if (OnServerDiscovered != null)
                     {
-                        OnServerDiscovered.Invoke(serverAddress, dealerPort, subPort);
+                        OnServerDiscovered.Invoke(serverAddress, controlPort, transformPort, subPort);
                     }
 
                     // Stop sending more discovery requests once we found a server
@@ -585,6 +586,10 @@ namespace Styly.NetSync
                     {
                         _isDiscovering = false;
                     }
+                }
+                else if (parts.Length >= 1 && parts[0] == "STYLY-NETSYNC")
+                {
+                    Debug.LogWarning("[ServerDiscovery] Ignoring incompatible legacy STYLY-NETSYNC discovery response.");
                 }
             }
             catch (Exception ex)

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/ServerDiscoveryManager.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/ServerDiscoveryManager.cs
@@ -372,12 +372,12 @@ namespace Styly.NetSync
 
                 if (bytesRead > 0)
                 {
-                    // Process response
+                    // Only report success when the reply is a compatible server;
+                    // otherwise return false so discovery keeps probing.
                     var remoteEP = new IPEndPoint(IPAddress.Parse(ipAddress), ServerDiscoveryPort);
                     byte[] responseData = new byte[bytesRead];
                     Array.Copy(buffer, responseData, bytesRead);
-                    ProcessDiscoveryResponse(responseData, remoteEP);
-                    return true;
+                    return ProcessDiscoveryResponse(responseData, remoteEP);
                 }
             }
             catch (Exception)
@@ -555,46 +555,53 @@ namespace Styly.NetSync
             DebugLog("Stopped discovery");
         }
 
-        private void ProcessDiscoveryResponse(byte[] data, IPEndPoint sender)
+        // Returns true only when a compatible server was discovered, so callers
+        // (e.g. TCP probes) can keep scanning on a non-matching response.
+        private bool ProcessDiscoveryResponse(byte[] data, IPEndPoint sender)
         {
             try
             {
                 var message = Encoding.UTF8.GetString(data);
                 var parts = message.Split('|');
 
-                if (parts.Length >= 5 && parts[0] == "STYLY-NETSYNC2")
+                // Clients and servers always run the same version, so any reply
+                // that is not a current STYLY-NETSYNC2 response is not a
+                // compatible server. Treat it as "not found" and keep scanning.
+                if (parts.Length < 5 || parts[0] != "STYLY-NETSYNC2")
                 {
-                    var controlPort = int.Parse(parts[1]);
-                    var transformPort = int.Parse(parts[2]);
-                    var subPort = int.Parse(parts[3]);
-                    var serverName = parts[4];
-
-                    var serverAddress = $"tcp://{sender.Address}";
-
-                    // Cache the discovered server IP for future connections
-                    QueueCacheServerIp(sender.Address.ToString());
-
-                    DebugLog($"Discovered server '{serverName}' at {serverAddress} (control:{controlPort}, transform:{transformPort}, sub:{subPort})");
-
-                    if (OnServerDiscovered != null)
-                    {
-                        OnServerDiscovered.Invoke(serverAddress, controlPort, transformPort, subPort);
-                    }
-
-                    // Stop sending more discovery requests once we found a server
-                    lock (_lockObject)
-                    {
-                        _isDiscovering = false;
-                    }
+                    DebugLog($"Ignoring non-matching discovery response from {sender.Address}");
+                    return false;
                 }
-                else if (parts.Length >= 1 && parts[0] == "STYLY-NETSYNC")
+
+                var controlPort = int.Parse(parts[1]);
+                var transformPort = int.Parse(parts[2]);
+                var subPort = int.Parse(parts[3]);
+                var serverName = parts[4];
+
+                var serverAddress = $"tcp://{sender.Address}";
+
+                // Cache the discovered server IP for future connections
+                QueueCacheServerIp(sender.Address.ToString());
+
+                DebugLog($"Discovered server '{serverName}' at {serverAddress} (control:{controlPort}, transform:{transformPort}, sub:{subPort})");
+
+                if (OnServerDiscovered != null)
                 {
-                    Debug.LogWarning("[ServerDiscovery] Ignoring incompatible legacy STYLY-NETSYNC discovery response.");
+                    OnServerDiscovered.Invoke(serverAddress, controlPort, transformPort, subPort);
                 }
+
+                // Stop sending more discovery requests once we found a server
+                lock (_lockObject)
+                {
+                    _isDiscovering = false;
+                }
+
+                return true;
             }
             catch (Exception ex)
             {
                 Debug.LogWarning($"Failed to process discovery response: {ex.Message}");
+                return false;
             }
         }
 

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/TransformSyncManager.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/TransformSyncManager.cs
@@ -100,12 +100,12 @@ namespace Styly.NetSync
         {
             try
             {
-                // Estimate size for handshake and ensure capacity
-                var required = EstimateStealthHandshakeSize(_deviceId);
+                // Estimate size for client hello and ensure capacity
+                var required = EstimateClientHelloSize(_deviceId);
                 _buf.EnsureCapacity(required);
 
                 _buf.Stream.Position = 0;
-                BinarySerializer.SerializeStealthHandshakeInto(_buf.Writer, _deviceId);
+                BinarySerializer.SerializeClientHelloInto(_buf.Writer, _deviceId, isStealth: true);
                 _buf.Writer.Flush();
 
                 var length = (int)_buf.Stream.Position;
@@ -190,14 +190,14 @@ namespace Styly.NetSync
         }
 
         /// <summary>
-        /// Estimate byte size for stealth handshake payload to pre-size buffers.
+        /// Estimate byte size for client hello payload to pre-size buffers.
         /// </summary>
-        private static int EstimateStealthHandshakeSize(string deviceId)
+        private static int EstimateClientHelloSize(string deviceId)
         {
             var deviceIdBytes = deviceId != null ? Encoding.UTF8.GetByteCount(deviceId) : 0;
             if (deviceIdBytes > 255) deviceIdBytes = 255; // Length prefix is 1 byte
-            // 1(type) + 1(protocol) + 1(deviceIdLen) + deviceId + 2(poseSeq) + 1(flags) + 1(encodingFlags) + 1(virtualCount)
-            return 1 + 1 + 1 + deviceIdBytes + 2 + 1 + 1 + 1;
+            // 1(type) + 1(protocol) + 1(flags) + 1(deviceIdLen) + deviceId
+            return 1 + 1 + 1 + 1 + deviceIdBytes;
         }
 
         /// <summary>

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/NetSyncManager.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/NetSyncManager.cs
@@ -825,7 +825,7 @@ namespace Styly.NetSync
                 // Object sync: send owned object transforms and apply received transforms
                 if (_objectSyncManager != null)
                 {
-                    _objectSyncManager.Tick(_roomId, Time.time, _clientNo, _transformSendRate);
+                    _objectSyncManager.Tick(_roomId, Time.time, _clientNo, DeviceId, _transformSendRate);
                     _objectSyncManager.TickTransformAppliers(Time.deltaTime, NetSyncClock.NowSeconds());
                 }
             }

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/NetSyncManager.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/NetSyncManager.cs
@@ -19,6 +19,7 @@ namespace Styly.NetSync
         [Header("Connection Settings")]
         [SerializeField, Tooltip("Server IP address or hostname (e.g. 192.168.1.100, localhost). Leave empty to auto-discover server on local network")] private string _serverAddress = "";
         private int _dealerPort = 5555;
+        private int _transformPort = 5557;
         private int _subPort = 5556;
         [SerializeField] private string _roomId = "default_room";
 
@@ -507,6 +508,7 @@ namespace Styly.NetSync
         private bool _roomSwitching; // Flag to prevent operations during room switching
         private string _discoveredServer;
         private int _discoveredDealerPort;
+        private int _discoveredTransformPort;
         private int _discoveredSubPort;
         private float _discoveryStartTime;
         private const float ReconnectDelay = 10f;
@@ -1148,19 +1150,21 @@ namespace Styly.NetSync
             _shouldCheckReady = true;
         }
 
-        private void OnServerDiscovered(string serverAddress, int dealerPort, int subPort)
+        private void OnServerDiscovered(string serverAddress, int controlPort, int transformPort, int subPort)
         {
             _discoveredServer = serverAddress;
-            _discoveredDealerPort = dealerPort;
+            _discoveredDealerPort = controlPort;
+            _discoveredTransformPort = transformPort;
             _discoveredSubPort = subPort;
 
             // Update the server address for future connections
             // Remove tcp:// prefix (discovery always returns with tcp://)
             _serverAddress = serverAddress.Substring(6);
-            _dealerPort = dealerPort;
+            _dealerPort = controlPort;
+            _transformPort = transformPort;
             _subPort = subPort;
 
-            DebugLog($"Server discovered: {serverAddress} (dealer:{dealerPort}, sub:{subPort})");
+            DebugLog($"Server discovered: {serverAddress} (control:{controlPort}, transform:{transformPort}, sub:{subPort})");
         }
         #endregion ------------------------------------------------------------------------
 
@@ -1169,7 +1173,7 @@ namespace Styly.NetSync
         {
             if (_offlineMode)
             {
-                _connectionManager.Connect("", 0, 0, _roomId);
+                _connectionManager.Connect("", 0, 0, 0, _roomId);
                 return;
             }
 
@@ -1182,7 +1186,7 @@ namespace Styly.NetSync
 
             // Add tcp:// prefix
             string fullAddress = $"tcp://{_serverAddress}";
-            _connectionManager.Connect(fullAddress, _dealerPort, _subPort, _roomId);
+            _connectionManager.Connect(fullAddress, _dealerPort, _transformPort, _subPort, _roomId);
         }
 
         private void StopNetworking()
@@ -1219,7 +1223,7 @@ namespace Styly.NetSync
             {
                 _isDiscovering = false;
                 StopDiscovery();
-                _connectionManager.ProcessDiscoveredServer(_discoveredServer, _discoveredDealerPort, _discoveredSubPort);
+                _connectionManager.ProcessDiscoveredServer(_discoveredServer, _discoveredDealerPort, _discoveredTransformPort, _discoveredSubPort);
                 _discoveredServer = null;
                 return; // Exit early - no need to check timeout or retry
             }


### PR DESCRIPTION
## Summary
- Split the ZeroMQ transport into control, transform uplink, and PUB/SUB downlink ports.
- Add protocol v7 client hello so the server can bind control identities independently from transform identities.
- Route RPC, Network Variables, ownership, ID mapping, and hello over the control lane with FIFO retry under ROUTER backpressure.
- Route avatar/object poses over the transform lane with latest-wins semantics.
- Update Unity, Python client, simulator, REST bridge, discovery v2, docs, and regression tests.

## Root Cause
RPC delivery could be lost because control messages shared backpressure-sensitive transform paths and the server ROUTER drain dropped packets when sends would block.

## Breaking Change
This is a network protocol break. Server, Unity clients, and Python clients must be deployed together. Legacy discovery responses are treated as incompatible. `dealer_port` / `--dealer-port` remain as a one-release alias for `control_port` / `--control-port`.

## Validation
- `black --check src/ tests/`
- `ruff check src/ tests/`
- `mypy src/`
- `pytest -q`
- `dotnet build com.styly.styly-netsync.csproj --no-restore`
- `dotnet build com.styly.styly-netsync.Editor.csproj --no-restore`
- `uloop compile --wait-for-domain-reload true`
- `uloop get-logs --log-type Error --max-count 20 --include-stack-trace false`
- `uloop run-tests --test-mode EditMode --filter-type all` returned no matching tests

Fixes #454
