### PR TITLE
[codex] Ignore cache directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,4 +36,5 @@ gha-creds-*.json
 *_clone_*/
 
 # Misc
+/cache/
 nanobanana-output/*


### PR DESCRIPTION
## What changed

- Added the root `cache/` directory to `.gitignore`.

## Why

`cache/` contains local cache artifacts such as `cache/projects.json`, which should not be tracked in Git.

## Validation

- Confirmed no files under `cache/` are currently tracked by Git.
- Ran `git check-ignore -v cache/projects.json` and confirmed it matches the `/cache/` rule.