### PR TITLE
[codex] Fix Global Variable notifications after additive scene loads

### DIFF
--- a/STYLY-NetSync-Server/src/styly_netsync/server.py
+++ b/STYLY-NetSync-Server/src/styly_netsync/server.py
@@ -796,6 +796,48 @@ class NetSyncServer:
             client_identity, room_id, "control_identity"
         )
 
+    def _refresh_control_identity_from_sender_client_no(
+        self, client_identity: bytes, room_id: str, sender_client_no_raw: object
+    ) -> str | None:
+        """Rebind a known client number to the control identity that sent a message."""
+        if isinstance(sender_client_no_raw, int):
+            sender_client_no = sender_client_no_raw
+        elif isinstance(sender_client_no_raw, str):
+            try:
+                sender_client_no = int(sender_client_no_raw)
+            except ValueError:
+                return None
+        else:
+            return None
+
+        if sender_client_no <= 0:
+            return None
+
+        with self._rooms_lock:
+            device_id = self.room_client_no_to_device_id.get(room_id, {}).get(
+                sender_client_no
+            )
+            if device_id is None:
+                return None
+
+            room = self.rooms.get(room_id)
+            if room is None or device_id not in room:
+                return None
+
+            client_data = room[device_id]
+            old_identity = client_data.get("control_identity")
+            if old_identity != client_identity:
+                client_data["control_identity"] = client_identity
+                client_data["last_update"] = time.monotonic()
+                self.room_id_mapping_dirty[room_id] = True
+                logger.info(
+                    "Refreshed control identity from client number: room=%s, client=%s, device=%s",
+                    room_id,
+                    sender_client_no,
+                    device_id[:8],
+                )
+            return device_id
+
     def _get_device_id_from_lane_identity(
         self, client_identity: bytes, room_id: str, identity_key: str
     ) -> str | None:
@@ -1158,15 +1200,25 @@ class NetSyncServer:
             sender_device_id = self._get_device_id_from_control_identity(
                 client_identity, room_id
             )
+            if sender_device_id is None:
+                sender_device_id = self._refresh_control_identity_from_sender_client_no(
+                    client_identity, room_id, data.get("senderClientNo", 0)
+                )
             if sender_device_id:
                 data["senderClientNo"] = self._get_client_no_for_device_id(
                     room_id, sender_device_id
                 )
             self._send_rpc_to_room(room_id, data)
         elif msg_type == binary_serializer.MSG_GLOBAL_VAR_SET:
+            self._refresh_control_identity_from_sender_client_no(
+                client_identity, room_id, data.get("senderClientNo", 0)
+            )
             self._buffer_global_var_set(room_id, data)
             self._monitor_nv_sliding_window(room_id)
         elif msg_type == binary_serializer.MSG_CLIENT_VAR_SET:
+            self._refresh_control_identity_from_sender_client_no(
+                client_identity, room_id, data.get("senderClientNo", 0)
+            )
             self._buffer_client_var_set(room_id, data)
             self._monitor_nv_sliding_window(room_id)
         elif msg_type == binary_serializer.MSG_CLIENT_VAR_CLEAR:
@@ -1964,6 +2016,10 @@ class NetSyncServer:
             device_id = self._get_device_id_from_control_identity(
                 client_identity, room_id
             )
+            if device_id is None:
+                device_id = self._refresh_control_identity_from_sender_client_no(
+                    client_identity, room_id, data.get("senderClientNo", 0)
+                )
             if device_id is None:
                 logger.warning(
                     "Client variable clear ignored: sender is not mapped in room %s",

--- a/STYLY-NetSync-Server/src/styly_netsync/server.py
+++ b/STYLY-NetSync-Server/src/styly_netsync/server.py
@@ -831,7 +831,7 @@ class NetSyncServer:
                 client_data["last_update"] = time.monotonic()
                 self.room_id_mapping_dirty[room_id] = True
                 logger.info(
-                    "Refreshed control identity from client number: room=%s, client=%s, device=%s",
+                    "Refreshed control identity from client number: room={}, client={}, device={}",
                     room_id,
                     sender_client_no,
                     device_id[:8],

--- a/STYLY-NetSync-Server/tests/test_transport_split.py
+++ b/STYLY-NetSync-Server/tests/test_transport_split.py
@@ -155,6 +155,140 @@ def test_global_variable_set_rebinds_stale_control_identity() -> None:
     }
 
 
+def _seed_stale_control_client(
+    srv: NetSyncServer, room_id: str, device_id: str, client_no: int
+) -> None:
+    """Register a room client whose stored control identity is stale."""
+    srv._initialize_room(room_id)
+    with srv._rooms_lock:
+        srv.rooms[room_id][device_id] = {
+            "control_identity": b"stale-control",
+            "transform_identity": b"transform-1",
+            "last_update": 0.0,
+            "transform_data": None,
+            "client_no": client_no,
+            "is_stealth": False,
+        }
+        srv.room_device_id_to_client_no[room_id][device_id] = client_no
+        srv.room_client_no_to_device_id[room_id][client_no] = device_id
+
+
+def test_client_variable_set_rebinds_stale_control_identity() -> None:
+    """A client-var write from a known client refreshes its stale control identity."""
+    srv = NetSyncServer(enable_server_discovery=False)
+    room_id = "stale-control-room"
+    device_id = "device-a"
+    client_no = 1
+    _seed_stale_control_client(srv, room_id, device_id, client_no)
+
+    srv._handle_control_message(
+        b"active-control",
+        room_id,
+        binary_serializer.MSG_CLIENT_VAR_SET,
+        {
+            "senderClientNo": client_no,
+            "targetClientNo": client_no,
+            "variableName": "hp",
+            "variableValue": "5",
+        },
+    )
+
+    with srv._rooms_lock:
+        assert srv.rooms[room_id][device_id]["control_identity"] == b"active-control"
+
+
+def test_client_variable_clear_rebinds_stale_control_identity() -> None:
+    """A client-var clear from a known client must rebind instead of being dropped."""
+    srv = NetSyncServer(enable_server_discovery=False)
+    room_id = "stale-control-room"
+    device_id = "device-a"
+    client_no = 1
+    _seed_stale_control_client(srv, room_id, device_id, client_no)
+    with srv._rooms_lock:
+        srv.client_variables[room_id][device_id] = {"hp": "5"}
+
+    srv._handle_control_message(
+        b"active-control",
+        room_id,
+        binary_serializer.MSG_CLIENT_VAR_CLEAR,
+        {"senderClientNo": client_no},
+    )
+
+    with srv._rooms_lock:
+        # The clear was not dropped: the identity was rebound and vars removed.
+        assert srv.rooms[room_id][device_id]["control_identity"] == b"active-control"
+        assert device_id not in srv.client_variables.get(room_id, {})
+
+
+def test_rpc_rebinds_stale_control_identity_and_rewrites_sender() -> None:
+    """A broadcast RPC from a known client rebinds and routes to the new identity."""
+    srv = NetSyncServer(enable_server_discovery=False)
+    room_id = "stale-control-room"
+    device_id = "device-a"
+    client_no = 1
+    _seed_stale_control_client(srv, room_id, device_id, client_no)
+
+    srv._handle_control_message(
+        b"active-control",
+        room_id,
+        binary_serializer.MSG_RPC,
+        {
+            "senderClientNo": client_no,  # client reports its own number
+            "functionName": "Ping",
+            "args": ["v"],
+            "targetClientNos": [],  # broadcast to room
+        },
+    )
+
+    with srv._rooms_lock:
+        assert srv.rooms[room_id][device_id]["control_identity"] == b"active-control"
+
+    queued = srv._router_queue_ctrl.get_nowait()
+    assert queued[0] == b"active-control"
+    assert queued[1] == room_id.encode("utf-8")
+    msg_type, data, _ = binary_serializer.deserialize(queued[2])
+    assert msg_type == binary_serializer.MSG_RPC
+    # The sender's client number was resolved from the rebound identity.
+    assert data["senderClientNo"] == client_no
+
+
+def test_refresh_control_identity_rejects_unknown_or_invalid_client_no() -> None:
+    """The rebind helper only acts on a known, positive, numeric client number."""
+    srv = NetSyncServer(enable_server_discovery=False)
+    room_id = "stale-control-room"
+    device_id = "device-a"
+    client_no = 1
+    _seed_stale_control_client(srv, room_id, device_id, client_no)
+
+    # Unknown client number, non-positive, and non-numeric inputs are ignored.
+    assert (
+        srv._refresh_control_identity_from_sender_client_no(b"active", room_id, 999)
+        is None
+    )
+    assert (
+        srv._refresh_control_identity_from_sender_client_no(b"active", room_id, 0)
+        is None
+    )
+    assert (
+        srv._refresh_control_identity_from_sender_client_no(b"active", room_id, "x")
+        is None
+    )
+
+    with srv._rooms_lock:
+        # None of the rejected calls mutated the stored identity.
+        assert srv.rooms[room_id][device_id]["control_identity"] == b"stale-control"
+
+    # A known numeric string is accepted and rebinds.
+    assert (
+        srv._refresh_control_identity_from_sender_client_no(
+            b"active", room_id, str(client_no)
+        )
+        == device_id
+    )
+    with srv._rooms_lock:
+        assert srv.rooms[room_id][device_id]["control_identity"] == b"active"
+
+
 def test_hello_after_transform_first_syncs_objects() -> None:
     """A transform-before-hello join must still receive the object-ownership sync.
 

--- a/STYLY-NetSync-Server/tests/test_transport_split.py
+++ b/STYLY-NetSync-Server/tests/test_transport_split.py
@@ -105,6 +105,56 @@ def test_transform_identity_does_not_overwrite_control_identity() -> None:
         assert client_data["transform_identity"] == b"transform-2"
 
 
+def test_global_variable_set_rebinds_stale_control_identity() -> None:
+    """An NV write from a known client should refresh its stale control identity."""
+    srv = NetSyncServer(enable_server_discovery=False)
+    room_id = "stale-control-room"
+    device_id = "device-a"
+    client_no = 1
+    srv._initialize_room(room_id)
+    with srv._rooms_lock:
+        srv.rooms[room_id][device_id] = {
+            "control_identity": b"stale-control",
+            "transform_identity": b"transform-1",
+            "last_update": 0.0,
+            "transform_data": None,
+            "client_no": client_no,
+            "is_stealth": False,
+        }
+        srv.room_device_id_to_client_no[room_id][device_id] = client_no
+        srv.room_client_no_to_device_id[room_id][client_no] = device_id
+
+    srv._handle_control_message(
+        b"active-control",
+        room_id,
+        binary_serializer.MSG_GLOBAL_VAR_SET,
+        {
+            "senderClientNo": client_no,
+            "variableName": "score",
+            "variableValue": "10",
+        },
+    )
+    srv._flush_nv_drain(room_id)
+
+    with srv._rooms_lock:
+        assert srv.rooms[room_id][device_id]["control_identity"] == b"active-control"
+
+    queued = srv._router_queue_ctrl.get_nowait()
+    assert queued[0] == b"active-control"
+    assert queued[1] == room_id.encode("utf-8")
+    msg_type, data, _ = binary_serializer.deserialize(queued[2])
+    assert msg_type == binary_serializer.MSG_GLOBAL_VAR_SYNC
+    assert data == {
+        "variables": [
+            {
+                "name": "score",
+                "value": "10",
+                "lastWriterClientNo": client_no,
+            }
+        ]
+    }
+
+
 def test_hello_after_transform_first_syncs_objects() -> None:
     """A transform-before-hello join must still receive the object-ownership sync.
 

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/NetSyncManager.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/NetSyncManager.cs
@@ -80,6 +80,7 @@ namespace Styly.NetSync
         #region === Singleton & Public API ===
         private static NetSyncManager _instance;
         public static NetSyncManager Instance => _instance;
+        private bool _isDuplicateInstance;
 
 
 
@@ -617,6 +618,17 @@ namespace Styly.NetSync
         #region === Unity Callbacks ===
         private void Awake()
         {
+            if (_instance != null && _instance != this)
+            {
+                _isDuplicateInstance = true;
+                Debug.LogWarning(
+                    $"[NetSyncManager] Duplicate NetSyncManager on '{name}' was ignored. " +
+                    $"The active instance is '{_instance.name}'. Keep only one NetSyncManager loaded at a time.",
+                    this);
+                Destroy(this);
+                return;
+            }
+
             // Log package version
             DebugLog($"STYLY-NetSync Version: {GetVersion()}");
 
@@ -643,6 +655,8 @@ namespace Styly.NetSync
 
         void Start()
         {
+            if (_isDuplicateInstance) { return; }
+
             // Resolve the rig transform used as the locomotion-delta reference.
             // The follow source is latched here at startup; runtime rig
             // switching (e.g. disabling XROrigin and enabling OVRCameraRig
@@ -660,6 +674,8 @@ namespace Styly.NetSync
 
         private void OnEnable()
         {
+            if (_isDuplicateInstance) { return; }
+
             if (_deviceIdResolver != null && _deviceIdResolver.IsResolved)
             {
                 _avatarManager.InitializeLocalAvatar(_localAvatarPrefab, _deviceId, this);
@@ -675,6 +691,8 @@ namespace Styly.NetSync
 
         private void OnDisable()
         {
+            if (_isDuplicateInstance) { return; }
+
             _networkingPending = false;
 
             if (_connectionManager != null)
@@ -688,11 +706,16 @@ namespace Styly.NetSync
             // Dispose pooled serialization resources to return buffers to ArrayPool
             DisposeManagers();
 
-            _instance = null;
+            if (_instance == this)
+            {
+                _instance = null;
+            }
         }
 
         private void OnApplicationQuit()
         {
+            if (_isDuplicateInstance) { return; }
+
             if (_connectionManager != null)
             {
                 StopNetworking();

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/NetSyncManager.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/NetSyncManager.cs
@@ -775,6 +775,8 @@ namespace Styly.NetSync
 
         private void Update()
         {
+            if (_isDuplicateInstance) { return; }
+
             // Process deferred permission callbacks on main thread (safe for Unity APIs)
             if (_deviceIdResolver != null)
             {


### PR DESCRIPTION
## Summary

Fixes #459.

This fixes a v0.15.0 regression where Global Variable change notifications could stop after loading multiple additive scenes.

## Root Cause

With the split control/transform sockets introduced in #455, a duplicate `NetSyncManager` loaded from an additive scene could register the same device on a newer control identity. Server-side Global Variable syncs would then be sent to that stale or unintended control identity, so the active Unity listener stopped receiving `OnGlobalVariableChanged`.

## Changes

- Ignore duplicate Unity `NetSyncManager` instances so additive scenes cannot overwrite `NetSyncManager.Instance` or start another connection for the same device.
- Refresh stale server control identities from known `senderClientNo` values on RPC, Global Variable, Client Variable, and client-variable-clear control messages.
- Add a regression test covering stale control identity recovery for Global Variable sync.

## Validation

- `pytest` - 285 passed, 2 skipped
- `black --check src tests/test_transport_split.py`
- `ruff check src tests/test_transport_split.py`
- `mypy src/`
- `git diff --check`
- `python -m compileall -q STYLY-NetSync-Server/src STYLY-NetSync-Server/tests/test_transport_split.py`

Unity Editor compilation and additive-scene runtime verification still need to be checked in Unity.