### PR TITLE
fix: source synced hand pose from XRHandSubsystem wrist joint (#461)

### DIFF
--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/HandPoseNormalizer.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/HandPoseNormalizer.cs
@@ -1,4 +1,4 @@
-// HandPoseNormalizer.cs - Follows HandVisualizer's wrist transform for cross-platform hand tracking
+// HandPoseNormalizer.cs - Drives the synced hand from the XRHandSubsystem wrist joint for cross-platform hand tracking
 using System;
 using System.Collections.Generic;
 using Unity.XR.CoreUtils;
@@ -9,12 +9,15 @@ using UnityEngine.XR.Hands;
 namespace Styly.NetSync.Internal
 {
     /// <summary>
-    /// Component that synchronizes hand pose with the HandVisualizer's wrist transform (L_Wrist/R_Wrist).
-    /// This approach ensures consistent hand positioning across different VR platforms (Quest, Pico, etc.)
-    /// by using the XR Hands subsystem's normalized joint data instead of platform-specific InputAction bindings.
+    /// Component that synchronizes the hand pose using the XR Hands subsystem's normalized wrist joint
+    /// (XRHandJointID.Wrist). Sourcing the pose from the subsystem keeps hand positioning consistent across
+    /// VR platforms (Quest, Pico, etc.) and is rig-agnostic: it works whether the rig uses a HandVisualizer
+    /// or skeleton-driven glove meshes (XRHandSkeletonDriver), and does not depend on a particular scene
+    /// Transform exposing a rig-relative localPosition.
     ///
-    /// Monitors the hand tracking state via activeInHierarchy:
-    /// - Hand tracking active: Disables TrackedPoseDriver and copies pose from HandVisualizer
+    /// A scene Transform named L_Wrist/R_Wrist (when present) is still used only as a hand-tracking
+    /// active-state probe via activeInHierarchy; the synced position/rotation comes from the subsystem:
+    /// - Hand tracking active: Disables TrackedPoseDriver and applies the subsystem wrist pose
     /// - Controller mode: Re-enables TrackedPoseDriver for controller-based tracking
     /// </summary>
     internal class HandPoseNormalizer : MonoBehaviour
@@ -160,18 +163,25 @@ namespace Styly.NetSync.Internal
                 return;
             }
 
-            // Check if hand tracking is active (HandVisualizer activates the hand object when tracking)
+            // Check if hand tracking is active. The matched wrist GameObject (HandVisualizer wrist or a
+            // skeleton-driven glove bone) is active while hand tracking is on; used only as a state probe.
             bool isHandTrackingActive = _handTransform.gameObject.activeInHierarchy;
 
             if (isHandTrackingActive)
             {
-                // Hand tracking mode: disable TrackedPoseDriver and copy from HandVisualizer
+                // Hand tracking mode: disable TrackedPoseDriver and apply the subsystem wrist pose.
                 DisableTrackedPoseDriver();
 
-                // Copy the hand transform's local position and rotation
-                _selfTransform.localPosition = _handTransform.localPosition;
-                _selfTransform.localRotation = _handTransform.localRotation;
-
+                // Source the pose from the XRHandSubsystem (rig-agnostic) instead of copying the
+                // matched scene Transform's localPosition. The matched Transform is used only as an
+                // active-state probe above; its localPosition is a valid rig-relative hand pose for a
+                // HandVisualizer wrist but a near-constant bone offset for skeleton-driven gloves.
+                if (TryGetWristPose(out var wristPose))
+                {
+                    _selfTransform.localPosition = wristPose.position;
+                    _selfTransform.localRotation = wristPose.rotation;
+                }
+                // If the wrist pose is momentarily unavailable, hold the last good pose.
             }
             else
             {
@@ -187,12 +197,11 @@ namespace Styly.NetSync.Internal
         }
 
         /// <summary>
-        /// Updates hand tracking state from XRHandSubsystem using state machine.
-        /// Uses delayed check for lost detection to distinguish controller switch from true lost.
+        /// Ensures a running XRHandSubsystem reference is cached.
+        /// Returns true when a running subsystem is available.
         /// </summary>
-        private void UpdateHandTrackingState()
+        private bool EnsureHandSubsystem()
         {
-            // Try to get XRHandSubsystem if not available or not running
             if (_handSubsystem == null || !_handSubsystem.running)
             {
                 var subsystems = new List<XRHandSubsystem>();
@@ -208,8 +217,47 @@ namespace Styly.NetSync.Internal
                 }
             }
 
+            return _handSubsystem != null && _handSubsystem.running;
+        }
+
+        /// <summary>
+        /// Gets the wrist joint pose directly from the XRHandSubsystem.
+        /// The pose is XROrigin-relative, which matches this transform's parent space (the avatar
+        /// root tracks the XROrigin), so it is applied as localPosition/localRotation.
+        ///
+        /// This is rig-agnostic: it works whether the rig uses a HandVisualizer-style shallow wrist
+        /// or skeleton-driven glove meshes (XRHandSkeletonDriver). It deliberately does NOT read the
+        /// matched scene Transform's localPosition, which only represents a rig-relative hand pose for
+        /// a HandVisualizer wrist and collapses to a near-constant bone offset for skeleton bones.
+        /// </summary>
+        private bool TryGetWristPose(out Pose pose)
+        {
+            pose = Pose.identity;
+
+            if (!EnsureHandSubsystem())
+            {
+                return false;
+            }
+
+            var hand = _handedness == Handedness.Left
+                ? _handSubsystem.leftHand
+                : _handSubsystem.rightHand;
+            if (!hand.isTracked)
+            {
+                return false;
+            }
+
+            return hand.GetJoint(XRHandJointID.Wrist).TryGetPose(out pose);
+        }
+
+        /// <summary>
+        /// Updates hand tracking state from XRHandSubsystem using state machine.
+        /// Uses delayed check for lost detection to distinguish controller switch from true lost.
+        /// </summary>
+        private void UpdateHandTrackingState()
+        {
             // If no running XRHandSubsystem, reset to Unknown state
-            if (_handSubsystem == null || !_handSubsystem.running)
+            if (!EnsureHandSubsystem())
             {
                 if (_trackingState != TrackingState.Unknown && _trackingState != TrackingState.ControllerMode)
                 {


### PR DESCRIPTION
## Summary

Fixes #461 — in hand-tracking mode, remote peers rendered the local user's hands pinned near the avatar origin on rigs that use skeleton-driven glove meshes (`XRHandSkeletonDriver`) instead of a Unity XR Hands `HandVisualizer`.

`HandPoseNormalizer` positioned the synced hand by copying the `localPosition` of a scene `Transform` it located by exact name (`R_Wrist`/`L_Wrist`). That only yields a rig-relative hand pose for a HandVisualizer-style **shallow wrist**. For a skeleton-driven glove FBX, the same-named `R_Wrist`/`L_Wrist` is a **skeleton bone** whose `localPosition` is a near-constant offset relative to its parent bone — collapsing the synced hand to a point at the avatar root. Controller mode and head were always correct because they use different paths; tracking lost/found was correct because it already reads `XRHandSubsystem.hand.isTracked`.

## Change

Source the **position** directly from the XR Hands subsystem wrist joint instead of a scene Transform:

- `GetJoint(XRHandJointID.Wrist).TryGetPose(out var pose)` → applied as `localPosition`/`localRotation`. The wrist pose is XROrigin-relative and the avatar root tracks the XROrigin, so it maps directly to local space. This is rig-agnostic (HandVisualizer **and** skeleton-driven gloves).
- The matched `R_Wrist`/`L_Wrist` Transform is kept **only** as a hand-tracking active-state probe (`activeInHierarchy`). The `TrackedPoseDriver` enable/disable logic, the 3-frame lost-check state machine, and the `OnTrackingStateChanged` events are **unchanged**.
- Subsystem acquisition factored into a shared `EnsureHandSubsystem()` helper (behavior-preserving), used by both the new `TryGetWristPose()` and the existing `UpdateHandTrackingState()`.
- When the wrist pose is momentarily unavailable, the **last good pose is held** rather than snapping to the broken bone offset.

Scope is intentionally minimal — matching the issue's "Suggested fix" and the reporter's on-device-validated workaround — so the working controller/lost-found paths are untouched.

## Why no regression on HandVisualizer rigs

The old path was correct only where `R_Wrist.localPosition` already equaled the XROrigin-relative wrist position (i.e. it implicitly assumed XROrigin-relative). The subsystem wrist pose **is** XROrigin-relative (it is also the upstream source that drives HandVisualizer). So the new code is correct wherever the old code was correct, **and additionally** correct where the old code was broken — a strict superset.

## Test evidence

- `uloop compile --force-recompile`: **0 errors**; zero IDE diagnostics on `HandPoseNormalizer.cs`.
- On-device verified on the reporter's rig: PICO 4 Ultra Enterprise (OpenXR), hand tracking + `XRHandSkeletonDriver` glove meshes, no HandVisualizer sample → remote hands now follow the real hand.
- HandVisualizer/Quest path is reasoned-equivalent (subsystem is its upstream source) but not personally device-tested.

## Parity

No Python-side change needed — this is `XRHandSubsystem`/device-specific; `client.py` has no hand-pose equivalent.