### PR TITLE
fix: preserve control identity with stable device IDs (protocol v8)

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"9b3e3f61-c3e5-4de7-ada1-3bb83d939961","pid":20695,"procStart":"Mon Jun  8 05:22:56 2026","acquiredAt":1780896359944}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,12 +57,13 @@ black src/ tests/ && ruff check src/ tests/ && mypy src/ && pytest --cov=src
 
 - **Server**: Multi-threaded Python (receive, periodic, discovery threads) with ZeroMQ control/transform DEALER-ROUTER sockets + PUB-SUB and group-based room management
 - **Unity Client**: Manager pattern with internal components (connection, transform sync, RPC, network variables, avatars)
-- **Protocol**: Binary v7 with quantized positions and smallest-three quaternion compression
+- **Protocol**: Binary v8 with quantized positions and smallest-three quaternion compression
 - **Technology**: Python 3.11+ / pyzmq / FastAPI / msgpack (server), Unity 6 / NetMQ / Newtonsoft.Json (client)
 
 ## Protocol Rules
 
-- Binary protocol is `protocolVersion=7` only (earlier versions removed); the version byte rides on transform/object/hello messages and bumps on any breaking wire change, including Network Variable message changes
+- Binary protocol is `protocolVersion=8` only (earlier versions removed); the version byte rides on transform/object/hello messages and bumps on any breaking wire change, including Network Variable message changes
+- Client-originated control messages (RPC, Global/Client Var Set, Client Var Clear, Object Ownership Request) carry a sender `deviceId` so the server can rebind stale control-lane identities by stable device ID instead of volatile client numbers
 - Message IDs: `MSG_CLIENT_POSE=11`, `MSG_ROOM_POSE=12`, `MSG_CLIENT_VAR_CLEAR=18`, `MSG_CLIENT_HELLO=19`
 - Unbound `Head` is absolute; `Right/Left/Virtual` are head-relative
 - Moving-floor-local poses set `PoseFlags.MovingFloorLocal`; `Head` is moving-floor local while `Right/Left/Virtual` remain head-relative within that floor

--- a/README.md
+++ b/README.md
@@ -85,10 +85,10 @@ The uvx command automatically downloads the package, creates an isolated virtual
 ### Version compatibility note
 
 - Keep Unity package and server versions aligned.
-- The current wire protocol is `protocolVersion = 7`; it is not backward compatible with older clients or servers.
+- The current wire protocol is `protocolVersion = 8`; it is not backward compatible with older clients or servers.
 - Transport uses separate ports for control (`5555`), transform uplink (`5557`), and PUB/SUB downlink (`5556`). Legacy discovery responses are treated as incompatible.
 - `xrOriginDelta` carries a Y component (4×`int16`: `dx, dy, dz, dyaw`) so receivers can reconstruct vertical rig motion (e.g. elevators).
-- Protocol v7 position quantization uses:
+- Protocol v8 position quantization uses:
   - Absolute scale (`Head`): signed `int24` at `0.01 m` per unit, per-axis range `[-83,886.08 m, 83,886.07 m]`.
   - Head-relative scale (`Right`/`Left`/`Virtual`): `0.005 m` per unit, per-axis range `[-163.84 m, 163.835 m]`.
 - This is an encoding range, not a hard world-size limit. Large virtual worlds are supported as long as each encoded value stays in range (out-of-range values are clamped).

--- a/STYLY-NetSync-Server/AGENTS.md
+++ b/STYLY-NetSync-Server/AGENTS.md
@@ -32,7 +32,7 @@ styly-netsync-simulator --clients 100 --server localhost --room default_room
 ## Architecture
 
 - **NetSyncServer** (`server.py`): Multi-threaded (receive, periodic, discovery threads)
-- **BinarySerializer** (`binary_serializer.py`): Protocol v7 binary serializer
+- **BinarySerializer** (`binary_serializer.py`): Protocol v8 binary serializer
 - **Python Client API** (`client.py`): `net_sync_manager` class for Python clients
 - **REST Bridge** (`rest_bridge.py`): FastAPI REST API for external integrations
 

--- a/STYLY-NetSync-Server/README.md
+++ b/STYLY-NetSync-Server/README.md
@@ -42,7 +42,7 @@ styly-netsync-simulator --server tcp://localhost --room my_room --clients 50
 
 ## Wire protocol compatibility
 
-- Current wire protocol is `protocolVersion = 7`.
+- Current wire protocol is `protocolVersion = 8`.
 - Transport uses three sockets: control (`control_port`, default `5555`) for RPC, Network Variables, ownership, ID mapping, and client hello; transform uplink (`transform_port`, default `5557`) for client/object poses; PUB/SUB (`pub_port`, default `5556`) for room pose and room object downlink.
 - Discovery responses use `STYLY-NETSYNC2|controlPort|transformPort|pubPort|serverName`; legacy `STYLY-NETSYNC|...` responses are explicitly incompatible.
 - `dealer_port` / `--dealer-port` remain a one-release compatibility alias for `control_port` / `--control-port`.
@@ -51,7 +51,7 @@ styly-netsync-simulator --server tcp://localhost --room my_room --clients 50
 - Unbound poses keep the `xrOriginDelta` semantics: `xrOriginDelta` carries a Y component as a 4th `int16` (`dx, dy, dz, dyaw` = 8 bytes), so receivers can reconstruct the sender's rig-Y motion.
 - Legacy transform protocols (v2/v3) and JSON transform fallback are not supported.
 - Deploy Unity and Python updates together when changing transform protocol behavior.
-- Protocol v7 position quantization ranges:
+- Protocol v8 position quantization ranges:
   - Absolute (`headPosAbs` only): signed `int24` at `0.01 m` per unit, per-axis range `[-83,886.08 m, 83,886.07 m]`.
   - XROrigin locomotion delta for unbound poses (`xrOriginDelta`, 4×`int16`: `dx, dy, dz, dyaw`): `0.01 m` per unit for translation, `0.1°` for yaw. Receivers reconstruct `physicalPos = invDeltaRot * (headPos − deltaPos)`; it is not on the wire as a separate absolute field.
   - Direct physical payload for moving-floor-local poses (`physical`, 4×`int16`: `x, y, z, yaw`): `0.01 m` per unit for translation, `0.1°` for yaw.
@@ -62,7 +62,7 @@ styly-netsync-simulator --server tcp://localhost --room my_room --clients 50
 
 The following options summarize trade-offs when expanding absolute-position range.
 
-Assumed unbound baseline (`protocolVersion=7`, `MovingFloorLocal` off):
+Assumed unbound baseline (`protocolVersion=8`, `MovingFloorLocal` off):
 - Client pose body with `Physical+Head+Right+Left` valid and `virtualCount=0`: `46 bytes` (matches `test_client_body_size_with_full_pose_no_virtuals`).
 - Room per-client entry (`clientNo + poseTime + clientBody`): `56 bytes`.
 

--- a/STYLY-NetSync-Server/src/styly_netsync/binary_serializer.py
+++ b/STYLY-NetSync-Server/src/styly_netsync/binary_serializer.py
@@ -6,11 +6,13 @@ from typing import Any
 logger = logging.getLogger(__name__)
 
 # Message type identifiers
+# v8: Client-originated control messages carry deviceId so the server can
+# refresh stale control-lane identities independently of volatile client numbers.
 # v7: Control and transform traffic use separate sockets, and clients register
 # their control identity with MSG_CLIENT_HELLO.
 # Bumped so mixed old/new builds fail the handshake instead of silently
 # misparsing NV traffic (the version byte rides on transform/object messages).
-PROTOCOL_VERSION = 7
+PROTOCOL_VERSION = 8
 MSG_CLIENT_TRANSFORM = 1
 MSG_ROOM_TRANSFORM = 2  # Legacy room transform with short IDs only
 MSG_RPC = 3  # Remote procedure call
@@ -40,7 +42,7 @@ CLIENT_HELLO_FLAG_STEALTH = 0x01
 _max_virtual_transforms = 50
 MAX_VIRTUAL_TRANSFORMS = _max_virtual_transforms  # Legacy alias for backward compat
 
-# Protocol v7 pose encoding constants
+# Protocol v8 pose encoding constants
 ABS_POS_SCALE = 0.01
 LOCO_POS_SCALE = 0.01
 REL_POS_SCALE = 0.005
@@ -617,6 +619,9 @@ def _serialize_rpc_base(buffer: bytearray, data: dict[str, Any], msg_type: int) 
     sender_client_no = data.get("senderClientNo", 0)
     buffer.extend(struct.pack("<H", sender_client_no))
 
+    # Sender device ID for control identity binding.
+    _pack_string(buffer, data.get("deviceId", ""))
+
     # Target client numbers (count + each clientNo as ushort). 0 count means broadcast.
     target_client_nos = data.get("targetClientNos") or []
     if len(target_client_nos) > 255:
@@ -704,7 +709,7 @@ def serialize_global_var_set(data: dict[str, Any]) -> bytes:
     """Serialize global variable set message
 
     Args:
-        data: Dictionary with senderClientNo, variableName, variableValue
+        data: Dictionary with senderClientNo, deviceId, variableName, variableValue
     """
     buffer = bytearray()
 
@@ -713,6 +718,9 @@ def serialize_global_var_set(data: dict[str, Any]) -> bytes:
 
     # Sender client number (2 bytes)
     buffer.extend(struct.pack("<H", data.get("senderClientNo", 0)))
+
+    # Sender device ID for control identity binding.
+    _pack_string(buffer, data.get("deviceId", ""))
 
     # Variable name (max 64 bytes)
     name = data.get("variableName", "")[:64]
@@ -753,7 +761,7 @@ def serialize_client_var_set(data: dict[str, Any]) -> bytes:
     """Serialize client variable set message
 
     Args:
-        data: Dictionary with senderClientNo, targetClientNo, variableName,
+        data: Dictionary with senderClientNo, deviceId, targetClientNo, variableName,
             variableValue
     """
     buffer = bytearray()
@@ -763,6 +771,9 @@ def serialize_client_var_set(data: dict[str, Any]) -> bytes:
 
     # Sender client number (2 bytes)
     buffer.extend(struct.pack("<H", data.get("senderClientNo", 0)))
+
+    # Sender device ID for control identity binding.
+    _pack_string(buffer, data.get("deviceId", ""))
 
     # Target client number (2 bytes)
     buffer.extend(struct.pack("<H", data.get("targetClientNo", 0)))
@@ -782,7 +793,7 @@ def serialize_client_var_clear(data: dict[str, Any]) -> bytes:
     """Serialize client variable clear message.
 
     Args:
-        data: Dictionary with senderClientNo.
+        data: Dictionary with senderClientNo and deviceId.
     """
     buffer = bytearray()
 
@@ -791,6 +802,9 @@ def serialize_client_var_clear(data: dict[str, Any]) -> bytes:
 
     # Sender client number (2 bytes)
     buffer.extend(struct.pack("<H", data.get("senderClientNo", 0)))
+
+    # Sender device ID for control identity binding.
+    _pack_string(buffer, data.get("deviceId", ""))
 
     return bytes(buffer)
 
@@ -1180,6 +1194,8 @@ def _deserialize_rpc_message(data: bytes, offset: int) -> dict[str, Any]:
     result["senderClientNo"] = struct.unpack("<H", data[offset : offset + 2])[0]
     offset += 2
 
+    result["deviceId"], offset = _unpack_string(data, offset)
+
     target_count = data[offset]
     offset += 1
     target_client_nos: list[int] = []
@@ -1267,6 +1283,8 @@ def _deserialize_global_var_set(data: bytes, offset: int) -> dict[str, Any]:
     result["senderClientNo"] = struct.unpack("<H", data[offset : offset + 2])[0]
     offset += 2
 
+    result["deviceId"], offset = _unpack_string(data, offset)
+
     # Variable name
     result["variableName"], offset = _unpack_string(data, offset)
 
@@ -1304,6 +1322,8 @@ def _deserialize_client_var_set(data: bytes, offset: int) -> dict[str, Any]:
     result["senderClientNo"] = struct.unpack("<H", data[offset : offset + 2])[0]
     offset += 2
 
+    result["deviceId"], offset = _unpack_string(data, offset)
+
     # Target client number (2 bytes)
     result["targetClientNo"] = struct.unpack("<H", data[offset : offset + 2])[0]
     offset += 2
@@ -1323,6 +1343,9 @@ def _deserialize_client_var_clear(data: bytes, offset: int) -> dict[str, Any]:
 
     # Sender client number (2 bytes)
     result["senderClientNo"] = struct.unpack("<H", data[offset : offset + 2])[0]
+    offset += 2
+
+    result["deviceId"], offset = _unpack_string(data, offset)
 
     return result
 
@@ -1538,6 +1561,11 @@ def _deserialize_room_objects(data: bytes, offset: int) -> dict[str, Any]:
 def _deserialize_object_ownership_request(data: bytes, offset: int) -> dict[str, Any]:
     """Deserialize ownership request (Client -> Server)."""
     result: dict[str, Any] = {}
+    protocol_version = data[offset]
+    offset += 1
+    if protocol_version != PROTOCOL_VERSION:
+        raise ValueError(f"Unsupported protocol version: {protocol_version}")
+    result["deviceId"], offset = _unpack_string(data, offset)
     result["operationType"] = data[offset]
     offset += 1
     result["objectId"] = struct.unpack("<I", data[offset : offset + 4])[0]

--- a/STYLY-NetSync-Server/src/styly_netsync/client.py
+++ b/STYLY-NetSync-Server/src/styly_netsync/client.py
@@ -1228,6 +1228,7 @@ class net_sync_manager:
         try:
             rpc_data = {
                 "senderClientNo": self._client_no,
+                "deviceId": self._device_id,
                 "targetClientNos": target_client_nos or [],
                 "functionName": function_name,
                 "argumentsJson": json.dumps(args),
@@ -1248,6 +1249,7 @@ class net_sync_manager:
         try:
             var_data = {
                 "senderClientNo": self._client_no,
+                "deviceId": self._device_id,
                 "variableName": name,
                 "variableValue": value,
             }
@@ -1268,6 +1270,7 @@ class net_sync_manager:
         try:
             var_data = {
                 "senderClientNo": self._client_no,
+                "deviceId": self._device_id,
                 "targetClientNo": target_client_no,
                 "variableName": name,
                 "variableValue": value,
@@ -1289,6 +1292,7 @@ class net_sync_manager:
         try:
             clear_data = {
                 "senderClientNo": self._client_no,
+                "deviceId": self._device_id,
             }
             message = binary_serializer.serialize_client_var_clear(clear_data)
             sent = self._enqueue_control(

--- a/STYLY-NetSync-Server/src/styly_netsync/client_simulator.py
+++ b/STYLY-NetSync-Server/src/styly_netsync/client_simulator.py
@@ -678,7 +678,12 @@ class NetworkTransport:
             return False
 
     def send_client_variable(
-        self, room_id: str, sender_client_no: int, var_name: str, value: str
+        self,
+        room_id: str,
+        sender_client_no: int,
+        device_id: str,
+        var_name: str,
+        value: str,
     ) -> bool:
         """Send client variable data to server."""
         if not self.socket:
@@ -687,6 +692,9 @@ class NetworkTransport:
         try:
             var_data = {
                 "senderClientNo": sender_client_no,
+                # Stable device ID required by v8 for control-identity binding;
+                # the server drops client-originated control messages without it.
+                "deviceId": device_id,
                 "targetClientNo": sender_client_no,  # Set variable for ourselves
                 "variableName": var_name,
                 "variableValue": value,
@@ -1184,7 +1192,11 @@ class SimulatedClient:
         ):
             battery_value = f"{self.battery_level:.2f}"
             if self.transport.send_client_variable(
-                self.room_id, self.client_number, "BatteryLevel", battery_value
+                self.room_id,
+                self.client_number,
+                self.config.device_id,
+                "BatteryLevel",
+                battery_value,
             ):
                 self.logger.debug(f"Sent battery level: {battery_value} (normalized)")
             else:

--- a/STYLY-NetSync-Server/src/styly_netsync/server.py
+++ b/STYLY-NetSync-Server/src/styly_netsync/server.py
@@ -778,76 +778,86 @@ class NetSyncServer:
 
             logger.info(f"Created new room: {room_id}")
 
-    def _get_device_id_from_identity(
-        self, client_identity: bytes, room_id: str
+    def _refresh_control_identity_from_device_id(
+        self, client_identity: bytes, room_id: str, device_id_raw: object
     ) -> str | None:
-        """Get device ID from any known client identity."""
-        return self._get_device_id_from_lane_identity(
-            client_identity, room_id, "control_identity"
-        ) or self._get_device_id_from_lane_identity(
-            client_identity, room_id, "transform_identity"
-        )
-
-    def _get_device_id_from_control_identity(
-        self, client_identity: bytes, room_id: str
-    ) -> str | None:
-        """Get device ID from a control-lane identity."""
-        return self._get_device_id_from_lane_identity(
-            client_identity, room_id, "control_identity"
-        )
-
-    def _refresh_control_identity_from_sender_client_no(
-        self, client_identity: bytes, room_id: str, sender_client_no_raw: object
-    ) -> str | None:
-        """Rebind a known client number to the control identity that sent a message."""
-        if isinstance(sender_client_no_raw, int):
-            sender_client_no = sender_client_no_raw
-        elif isinstance(sender_client_no_raw, str):
-            try:
-                sender_client_no = int(sender_client_no_raw)
-            except ValueError:
-                return None
-        else:
+        """Bind the sending control identity to its stable device ID."""
+        if not isinstance(device_id_raw, str) or not device_id_raw:
             return None
 
-        if sender_client_no <= 0:
-            return None
-
+        device_id = device_id_raw
+        now = time.monotonic()
         with self._rooms_lock:
-            device_id = self.room_client_no_to_device_id.get(room_id, {}).get(
-                sender_client_no
-            )
-            if device_id is None:
-                return None
+            self._initialize_room(room_id)
+            client_no = self._get_or_assign_client_no(room_id, device_id)
+            room = self.rooms[room_id]
 
-            room = self.rooms.get(room_id)
-            if room is None or device_id not in room:
-                return None
+            if device_id not in room:
+                room[device_id] = {
+                    "control_identity": client_identity,
+                    "transform_identity": None,
+                    "last_update": now,
+                    "transform_data": None,
+                    "client_no": client_no,
+                    "is_stealth": False,
+                }
+                self.room_id_mapping_dirty[room_id] = True
+                logger.info(
+                    "Registered control identity from control message: room={}, "
+                    "client={}, device={}",
+                    room_id,
+                    client_no,
+                    device_id[:8],
+                )
+                return device_id
 
             client_data = room[device_id]
             old_identity = client_data.get("control_identity")
             if old_identity != client_identity:
                 client_data["control_identity"] = client_identity
-                client_data["last_update"] = time.monotonic()
                 self.room_id_mapping_dirty[room_id] = True
                 logger.info(
-                    "Refreshed control identity from client number: room={}, client={}, device={}",
+                    "Refreshed control identity from device ID: room={}, client={}, "
+                    "device={}",
                     room_id,
-                    sender_client_no,
+                    client_no,
                     device_id[:8],
                 )
+            client_data["last_update"] = now
+            client_data["client_no"] = client_no
             return device_id
 
-    def _get_device_id_from_lane_identity(
-        self, client_identity: bytes, room_id: str, identity_key: str
-    ) -> str | None:
-        """Get device ID from a lane-specific ZeroMQ identity."""
-        with self._rooms_lock:
-            if room_id in self.rooms:
-                for device_id, client_data in self.rooms[room_id].items():
-                    if client_data.get(identity_key) == client_identity:
-                        return device_id
-        return None
+    def _resolve_control_sender(
+        self,
+        client_identity: bytes,
+        room_id: str,
+        data: dict[str, Any],
+        message_name: str,
+    ) -> tuple[str, int] | None:
+        """Resolve and refresh the sender of a client-originated control message."""
+        device_id = self._refresh_control_identity_from_device_id(
+            client_identity, room_id, data.get("deviceId")
+        )
+        if device_id is None:
+            logger.warning(
+                "%s ignored: missing or invalid deviceId in room %s",
+                message_name,
+                room_id,
+            )
+            return None
+
+        client_no = self._get_client_no_for_device_id(room_id, device_id)
+        if client_no <= 0:
+            logger.warning(
+                "%s ignored: device %s is not mapped in room %s",
+                message_name,
+                device_id,
+                room_id,
+            )
+            return None
+
+        data["senderClientNo"] = client_no
+        return device_id, client_no
 
     def _get_client_no_for_device_id(self, room_id: str, device_id: str) -> int:
         """Get client number for a given device ID in a room"""
@@ -1197,43 +1207,38 @@ class NetSyncServer:
         if msg_type == binary_serializer.MSG_CLIENT_HELLO:
             self._handle_client_hello(client_identity, room_id, data)
         elif msg_type == binary_serializer.MSG_RPC:
-            sender_device_id = self._get_device_id_from_control_identity(
-                client_identity, room_id
-            )
-            if sender_device_id is None:
-                sender_device_id = self._refresh_control_identity_from_sender_client_no(
-                    client_identity, room_id, data.get("senderClientNo", 0)
-                )
-            if sender_device_id:
-                data["senderClientNo"] = self._get_client_no_for_device_id(
-                    room_id, sender_device_id
-                )
+            sender = self._resolve_control_sender(client_identity, room_id, data, "RPC")
+            if sender is None:
+                return
             self._send_rpc_to_room(room_id, data)
         elif msg_type == binary_serializer.MSG_GLOBAL_VAR_SET:
-            self._refresh_control_identity_from_sender_client_no(
-                client_identity, room_id, data.get("senderClientNo", 0)
+            sender = self._resolve_control_sender(
+                client_identity, room_id, data, "Global variable set"
             )
+            if sender is None:
+                return
             self._buffer_global_var_set(room_id, data)
             self._monitor_nv_sliding_window(room_id)
         elif msg_type == binary_serializer.MSG_CLIENT_VAR_SET:
-            self._refresh_control_identity_from_sender_client_no(
-                client_identity, room_id, data.get("senderClientNo", 0)
+            sender = self._resolve_control_sender(
+                client_identity, room_id, data, "Client variable set"
             )
+            if sender is None:
+                return
             self._buffer_client_var_set(room_id, data)
             self._monitor_nv_sliding_window(room_id)
         elif msg_type == binary_serializer.MSG_CLIENT_VAR_CLEAR:
             self._handle_client_var_clear(client_identity, room_id, data)
         elif msg_type == binary_serializer.MSG_OBJECT_OWNERSHIP_REQUEST:
-            sender_device_id = self._get_device_id_from_control_identity(
-                client_identity, room_id
+            sender = self._resolve_control_sender(
+                client_identity, room_id, data, "Object ownership request"
             )
-            if sender_device_id:
-                sender_client_no = self._get_client_no_for_device_id(
-                    room_id, sender_device_id
-                )
-                self._handle_object_ownership_request(
-                    client_identity, room_id, sender_client_no, data
-                )
+            if sender is None:
+                return
+            _, sender_client_no = sender
+            self._handle_object_ownership_request(
+                client_identity, room_id, sender_client_no, data
+            )
         else:
             self._drop_wrong_lane("control", room_id, msg_type)
 
@@ -2012,30 +2017,14 @@ class NetSyncServer:
         self, client_identity: bytes, room_id: str, data: dict[str, Any]
     ) -> None:
         """Clear all client variables for the sending client."""
+        sender = self._resolve_control_sender(
+            client_identity, room_id, data, "Client variable clear"
+        )
+        if sender is None:
+            return
+        device_id, client_no = sender
+
         with self._rooms_lock:
-            device_id = self._get_device_id_from_control_identity(
-                client_identity, room_id
-            )
-            if device_id is None:
-                device_id = self._refresh_control_identity_from_sender_client_no(
-                    client_identity, room_id, data.get("senderClientNo", 0)
-                )
-            if device_id is None:
-                logger.warning(
-                    "Client variable clear ignored: sender is not mapped in room %s",
-                    room_id,
-                )
-                return
-
-            client_no = self.room_device_id_to_client_no.get(room_id, {}).get(device_id)
-            if client_no is None:
-                logger.warning(
-                    "Client variable clear ignored: device %s is not mapped in room %s",
-                    device_id,
-                    room_id,
-                )
-                return
-
             room_vars = self.client_variables.get(room_id, {})
             deleted_count = len(room_vars.get(device_id, {}))
             room_vars.pop(device_id, None)

--- a/STYLY-NetSync-Server/tests/integration/test_client.py
+++ b/STYLY-NetSync-Server/tests/integration/test_client.py
@@ -241,6 +241,7 @@ class TestClient:
         # Set global variable
         global_var_data = {
             "senderClientNo": self.client_no or 0,
+            "deviceId": self.device_id,
             "variableName": "TimeGlobal",
             "variableValue": current_time_str,
             "timestamp": current_time,
@@ -253,6 +254,7 @@ class TestClient:
         if self.client_no is not None:
             client_var_data = {
                 "senderClientNo": self.client_no,
+                "deviceId": self.device_id,
                 "targetClientNo": self.client_no,  # Set for self
                 "variableName": "TimeLocal",
                 "variableValue": current_time_str,
@@ -277,6 +279,7 @@ class TestClient:
         # Send RPC
         rpc_data = {
             "senderClientNo": self.client_no,
+            "deviceId": self.device_id,
             "functionName": "TestRPC",
             "argumentsJson": json.dumps(["TestRPC", current_time_str]),
         }

--- a/STYLY-NetSync-Server/tests/test_binary_serializer.py
+++ b/STYLY-NetSync-Server/tests/test_binary_serializer.py
@@ -288,12 +288,12 @@ def _reconstruct_physical_from_head_and_delta(
     return (px, ty, pz), physical_rot
 
 
-class TestTransformSerializationV5:
-    """Tests for protocol v7 transform compact serialization."""
+class TestTransformSerializationV8:
+    """Tests for protocol v8 transform compact serialization."""
 
-    def test_protocol_version_is_v7(self) -> None:
-        """Protocol version constant should be at v7."""
-        assert binary_serializer.PROTOCOL_VERSION == 7
+    def test_protocol_version_is_v8(self) -> None:
+        """Protocol version constant should be at v8."""
+        assert binary_serializer.PROTOCOL_VERSION == 8
 
     def test_client_roundtrip_without_flags_infers_valid_bits(self) -> None:
         """Serializer should infer valid bits when flags are omitted."""
@@ -418,7 +418,7 @@ class TestTransformSerializationV5:
 
             assert msg_type == binary_serializer.MSG_CLIENT_POSE
             assert decoded is not None
-            assert decoded["protocolVersion"] == 7
+            assert decoded["protocolVersion"] == 8
             assert len(raw) > 0
 
             o_head = original["head"]
@@ -822,7 +822,7 @@ class TestTransformSerializationV5:
 
         assert msg_type == binary_serializer.MSG_ROOM_POSE
         assert decoded is not None
-        assert decoded["protocolVersion"] == 7
+        assert decoded["protocolVersion"] == 8
         assert decoded["roomId"] == "room-v5"
         assert len(decoded["clients"]) == 2
 
@@ -991,6 +991,7 @@ class TestRPCMessageSerialization:
         """Broadcast RPC: 0 targets round-trips correctly."""
         data = {
             "senderClientNo": 42,
+            "deviceId": "device-a",
             "targetClientNos": [],
             "functionName": "SayHello",
             "argumentsJson": '["arg1","arg2"]',
@@ -1001,6 +1002,7 @@ class TestRPCMessageSerialization:
 
         assert msg_type == binary_serializer.MSG_RPC
         assert result["senderClientNo"] == 42
+        assert result["deviceId"] == "device-a"
         assert result["targetClientNos"] == []
         assert result["functionName"] == "SayHello"
         assert result["argumentsJson"] == '["arg1","arg2"]'
@@ -1009,6 +1011,7 @@ class TestRPCMessageSerialization:
         """Single-target RPC round-trips correctly."""
         data = {
             "senderClientNo": 1,
+            "deviceId": "device-a",
             "targetClientNos": [7],
             "functionName": "Ping",
             "argumentsJson": "[]",
@@ -1027,6 +1030,7 @@ class TestRPCMessageSerialization:
         targets = [1, 2, 50, 65535]
         data = {
             "senderClientNo": 100,
+            "deviceId": "device-a",
             "targetClientNos": targets,
             "functionName": "Broadcast",
             "argumentsJson": '["hello"]',
@@ -1042,6 +1046,7 @@ class TestRPCMessageSerialization:
         targets = list(range(255))
         data = {
             "senderClientNo": 0,
+            "deviceId": "device-a",
             "targetClientNos": targets,
             "functionName": "F",
             "argumentsJson": "",
@@ -1056,6 +1061,7 @@ class TestRPCMessageSerialization:
         """>255 targets raises ValueError."""
         data = {
             "senderClientNo": 0,
+            "deviceId": "device-a",
             "targetClientNos": list(range(256)),
             "functionName": "F",
             "argumentsJson": "",
@@ -1068,6 +1074,7 @@ class TestRPCMessageSerialization:
         """targetClientNos=None treated as broadcast (0 targets)."""
         data = {
             "senderClientNo": 5,
+            "deviceId": "device-a",
             "targetClientNos": None,
             "functionName": "Test",
             "argumentsJson": "[]",
@@ -1082,6 +1089,7 @@ class TestRPCMessageSerialization:
         """Omitted targetClientNos key treated as broadcast."""
         data = {
             "senderClientNo": 5,
+            "deviceId": "device-a",
             "functionName": "Test",
             "argumentsJson": "[]",
         }
@@ -1095,6 +1103,7 @@ class TestRPCMessageSerialization:
         """UTF-8 function name round-trips correctly."""
         data = {
             "senderClientNo": 1,
+            "deviceId": "device-a",
             "targetClientNos": [],
             "functionName": "OnDamage_テスト",
             "argumentsJson": "[]",
@@ -1106,12 +1115,47 @@ class TestRPCMessageSerialization:
         assert result["functionName"] == "OnDamage_テスト"
 
 
+class TestNetworkVariableSetSerialization:
+    """Tests for client-originated Network Variable set messages."""
+
+    def test_global_variable_set_roundtrip_with_device_id(self) -> None:
+        """Global variable set carries the sender device ID."""
+        data = {
+            "senderClientNo": 7,
+            "deviceId": "device-a",
+            "variableName": "score",
+            "variableValue": "10",
+        }
+
+        serialized = binary_serializer.serialize_global_var_set(data)
+        msg_type, result, _ = binary_serializer.deserialize(serialized)
+
+        assert msg_type == binary_serializer.MSG_GLOBAL_VAR_SET
+        assert result == data
+
+    def test_client_variable_set_roundtrip_with_device_id(self) -> None:
+        """Client variable set carries the sender device ID."""
+        data = {
+            "senderClientNo": 7,
+            "deviceId": "device-a",
+            "targetClientNo": 8,
+            "variableName": "hp",
+            "variableValue": "5",
+        }
+
+        serialized = binary_serializer.serialize_client_var_set(data)
+        msg_type, result, _ = binary_serializer.deserialize(serialized)
+
+        assert msg_type == binary_serializer.MSG_CLIENT_VAR_SET
+        assert result == data
+
+
 class TestClientVariableClearSerialization:
     """Tests for client variable clear serialization/deserialization."""
 
     def test_roundtrip_client_variable_clear(self) -> None:
         """Client variable clear message round-trips correctly."""
-        data = {"senderClientNo": 7}
+        data = {"senderClientNo": 7, "deviceId": "device-a"}
 
         serialized = binary_serializer.serialize_client_var_clear(data)
         msg_type, result, _ = binary_serializer.deserialize(serialized)

--- a/STYLY-NetSync-Server/tests/test_client_variable_device_store.py
+++ b/STYLY-NetSync-Server/tests/test_client_variable_device_store.py
@@ -201,7 +201,9 @@ class TestServerClientVariableDeviceStore:
         server._send_ctrl_to_room_via_router.reset_mock()
 
         server._handle_client_var_clear(
-            b"ident-a", "room1", {"senderClientNo": 7, "timestamp": time.time()}
+            b"ident-a",
+            "room1",
+            {"senderClientNo": 7, "deviceId": "device-a", "timestamp": time.time()},
         )
 
         assert "device-a" not in server.client_variables["room1"]
@@ -218,7 +220,9 @@ class TestServerClientVariableDeviceStore:
         _connect_device(server, "room1", "device-a", 7, b"ident-a")
 
         server._handle_client_var_clear(
-            b"ident-a", "room1", {"senderClientNo": 7, "timestamp": time.time()}
+            b"ident-a",
+            "room1",
+            {"senderClientNo": 7, "deviceId": "device-a", "timestamp": time.time()},
         )
 
         server._send_ctrl_to_room_via_router.assert_called_once()

--- a/STYLY-NetSync-Server/tests/test_object_sync.py
+++ b/STYLY-NetSync-Server/tests/test_object_sync.py
@@ -180,26 +180,34 @@ class TestRoomObjectsSerialization:
 class TestOwnershipRequestSerialization:
     """Test MSG_OBJECT_OWNERSHIP_REQUEST (15) deserialize."""
 
-    def test_release_ownership(self) -> None:
+    @staticmethod
+    def _request_payload(operation_type: int, object_id: int) -> bytes:
+        device_id = b"device-a"
         buf = bytearray()
         buf.append(MSG_OBJECT_OWNERSHIP_REQUEST)
-        buf.append(1)  # ReleaseOwnership
-        buf.extend(struct.pack("<I", _OBJ_ID_1))
+        buf.append(binary_serializer.PROTOCOL_VERSION)
+        buf.append(len(device_id))
+        buf.extend(device_id)
+        buf.append(operation_type)
+        buf.extend(struct.pack("<I", object_id))
+        return bytes(buf)
 
-        msg_type, result, _ = deserialize(bytes(buf))
+    def test_release_ownership(self) -> None:
+        msg_type, result, _ = deserialize(
+            self._request_payload(1, _OBJ_ID_1)  # ReleaseOwnership
+        )
         assert msg_type == MSG_OBJECT_OWNERSHIP_REQUEST
         assert result is not None
+        assert result["deviceId"] == "device-a"
         assert result["operationType"] == 1
         assert result["objectId"] == _OBJ_ID_1
 
     def test_request_ownership(self) -> None:
-        buf = bytearray()
-        buf.append(MSG_OBJECT_OWNERSHIP_REQUEST)
-        buf.append(2)  # RequestOwnership
-        buf.extend(struct.pack("<I", _OBJ_ID_1))
-
-        _, result, _ = deserialize(bytes(buf))
+        _, result, _ = deserialize(
+            self._request_payload(2, _OBJ_ID_1)  # RequestOwnership
+        )
         assert result is not None
+        assert result["deviceId"] == "device-a"
         assert result["operationType"] == 2
 
 

--- a/STYLY-NetSync-Server/tests/test_transport_split.py
+++ b/STYLY-NetSync-Server/tests/test_transport_split.py
@@ -130,6 +130,7 @@ def test_global_variable_set_rebinds_stale_control_identity() -> None:
         binary_serializer.MSG_GLOBAL_VAR_SET,
         {
             "senderClientNo": client_no,
+            "deviceId": device_id,
             "variableName": "score",
             "variableValue": "10",
         },
@@ -173,6 +174,38 @@ def _seed_stale_control_client(
         srv.room_client_no_to_device_id[room_id][client_no] = device_id
 
 
+def test_global_var_set_with_device_id_reaches_active_control_identity() -> None:
+    """An NV write must not echo its sync to a stale control identity."""
+    srv = NetSyncServer(enable_server_discovery=False)
+    room_id = "stale-control-room"
+    device_id = "device-a"
+    client_no = 1
+    _seed_stale_control_client(srv, room_id, device_id, client_no)
+
+    srv._handle_control_message(
+        b"active-control",
+        room_id,
+        binary_serializer.MSG_GLOBAL_VAR_SET,
+        {
+            "senderClientNo": 0,
+            "deviceId": device_id,
+            "variableName": "score",
+            "variableValue": "10",
+        },
+    )
+    srv._flush_nv_drain(room_id)
+
+    with srv._rooms_lock:
+        assert srv.global_variables[room_id]["score"]["value"] == "10"
+
+    queued = srv._router_queue_ctrl.get_nowait()
+    assert queued[0] == b"active-control"
+    assert queued[1] == room_id.encode("utf-8")
+    msg_type, data, _ = binary_serializer.deserialize(queued[2])
+    assert msg_type == binary_serializer.MSG_GLOBAL_VAR_SYNC
+    assert data["variables"][0]["lastWriterClientNo"] == client_no
+
+
 def test_client_variable_set_rebinds_stale_control_identity() -> None:
     """A client-var write from a known client refreshes its stale control identity."""
     srv = NetSyncServer(enable_server_discovery=False)
@@ -187,6 +220,7 @@ def test_client_variable_set_rebinds_stale_control_identity() -> None:
         binary_serializer.MSG_CLIENT_VAR_SET,
         {
             "senderClientNo": client_no,
+            "deviceId": device_id,
             "targetClientNo": client_no,
             "variableName": "hp",
             "variableValue": "5",
@@ -211,7 +245,7 @@ def test_client_variable_clear_rebinds_stale_control_identity() -> None:
         b"active-control",
         room_id,
         binary_serializer.MSG_CLIENT_VAR_CLEAR,
-        {"senderClientNo": client_no},
+        {"senderClientNo": client_no, "deviceId": device_id},
     )
 
     with srv._rooms_lock:
@@ -233,7 +267,8 @@ def test_rpc_rebinds_stale_control_identity_and_rewrites_sender() -> None:
         room_id,
         binary_serializer.MSG_RPC,
         {
-            "senderClientNo": client_no,  # client reports its own number
+            "senderClientNo": 0,
+            "deviceId": device_id,
             "functionName": "Ping",
             "args": ["v"],
             "targetClientNos": [],  # broadcast to room
@@ -252,37 +287,25 @@ def test_rpc_rebinds_stale_control_identity_and_rewrites_sender() -> None:
     assert data["senderClientNo"] == client_no
 
 
-def test_refresh_control_identity_rejects_unknown_or_invalid_client_no() -> None:
-    """The rebind helper only acts on a known, positive, numeric client number."""
+def test_refresh_control_identity_rejects_invalid_device_id() -> None:
+    """The rebind helper only acts on a non-empty device ID."""
     srv = NetSyncServer(enable_server_discovery=False)
     room_id = "stale-control-room"
     device_id = "device-a"
     client_no = 1
     _seed_stale_control_client(srv, room_id, device_id, client_no)
 
-    # Unknown client number, non-positive, and non-numeric inputs are ignored.
+    assert srv._refresh_control_identity_from_device_id(b"active", room_id, "") is None
     assert (
-        srv._refresh_control_identity_from_sender_client_no(b"active", room_id, 999)
-        is None
-    )
-    assert (
-        srv._refresh_control_identity_from_sender_client_no(b"active", room_id, 0)
-        is None
-    )
-    assert (
-        srv._refresh_control_identity_from_sender_client_no(b"active", room_id, "x")
-        is None
+        srv._refresh_control_identity_from_device_id(b"active", room_id, None) is None
     )
 
     with srv._rooms_lock:
         # None of the rejected calls mutated the stored identity.
         assert srv.rooms[room_id][device_id]["control_identity"] == b"stale-control"
 
-    # A known numeric string is accepted and rebinds.
     assert (
-        srv._refresh_control_identity_from_sender_client_no(
-            b"active", room_id, str(client_no)
-        )
+        srv._refresh_control_identity_from_device_id(b"active", room_id, device_id)
         == device_id
     )
     with srv._rooms_lock:

--- a/STYLY-NetSync-Unity/AGENTS.md
+++ b/STYLY-NetSync-Unity/AGENTS.md
@@ -36,7 +36,7 @@
 - **TransformSyncManager**: Transform sync with SendRate cap, only-on-change filtering, 1Hz idle heartbeat
 - **RPCManager**: Remote procedure calls with priority-based sending and targeted delivery
 - **NetworkVariableManager**: Synchronized key-value storage
-- **BinarySerializer**: Protocol v7 pose serialization/deserialization
+- **BinarySerializer**: Protocol v8 pose serialization/deserialization
 - **MessageProcessor**: Binary protocol message handling
 - **AvatarManager**: Player spawn/despawn management
 

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/BinarySerializer.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/BinarySerializer.cs
@@ -7,11 +7,13 @@ namespace Styly.NetSync
 {
     internal static class BinarySerializer
     {
+        // v8: Client-originated control messages carry deviceId so the server can
+        // refresh stale control-lane identities independently of volatile client numbers.
         // v7: Control and transform traffic use separate sockets, and clients register
         // their control identity with MSG_CLIENT_HELLO.
         // Bumped so mixed old/new builds fail the handshake instead of silently
         // misparsing NV traffic (the version byte rides on transform/object messages).
-        public const byte PROTOCOL_VERSION = 7;
+        public const byte PROTOCOL_VERSION = 8;
 
         // Message type identifiers
         public const byte MSG_CLIENT_TRANSFORM = 1;
@@ -36,7 +38,7 @@ namespace Styly.NetSync
 
         public const byte CLIENT_HELLO_FLAG_STEALTH = 0x01;
 
-        // Protocol v7 pose encoding constants
+        // Protocol v8 pose encoding constants
         private const float ABS_POS_SCALE = 0.01f;
         private const float LOCO_POS_SCALE = 0.01f;
         private const float REL_POS_SCALE = 0.005f;
@@ -646,9 +648,14 @@ namespace Styly.NetSync
             writer.Write(CompressQuaternionSmallestThree(NormalizeQuaternionSafe(rotation)));
         }
 
-        public static void SerializeObjectOwnershipRequestInto(BinaryWriter writer, byte operationType, uint objectId)
+        public static void SerializeObjectOwnershipRequestInto(BinaryWriter writer, string deviceId, byte operationType, uint objectId)
         {
             writer.Write(MSG_OBJECT_OWNERSHIP_REQUEST);
+            writer.Write(PROTOCOL_VERSION);
+            var deviceIdBytes = System.Text.Encoding.UTF8.GetBytes(deviceId ?? "");
+            var deviceIdLength = System.Math.Min(deviceIdBytes.Length, byte.MaxValue);
+            writer.Write((byte)deviceIdLength);
+            writer.Write(deviceIdBytes, 0, deviceIdLength);
             writer.Write(operationType);
             writer.Write(objectId);
         }
@@ -976,6 +983,14 @@ namespace Styly.NetSync
             writer.Write(MSG_RPC);
             // Sender client number (2 bytes)
             writer.Write((ushort)msg.senderClientNo);
+            // Sender device ID for control identity binding.
+            var deviceIdBytes = System.Text.Encoding.UTF8.GetBytes(msg.deviceId ?? string.Empty);
+            if (deviceIdBytes.Length > byte.MaxValue)
+            {
+                throw new ArgumentException("Device ID is too long. Maximum length is 255 bytes.");
+            }
+            writer.Write((byte)deviceIdBytes.Length);
+            writer.Write(deviceIdBytes);
             // Target client numbers (count + each clientNo as ushort). 0 count means broadcast.
             var targets = msg.targetClientNos;
             var targetCount = targets != null ? targets.Length : 0;
@@ -1031,6 +1046,13 @@ namespace Styly.NetSync
             var senderClientNo = data.TryGetValue("senderClientNo", out var senderObj) ? Convert.ToUInt16(senderObj) : (ushort)0;
             writer.Write(senderClientNo);
 
+            // Sender device ID for control identity binding.
+            var deviceId = data.TryGetValue("deviceId", out var deviceObj) ? (deviceObj != null ? deviceObj.ToString() : "") : "";
+            var deviceIdBytes = System.Text.Encoding.UTF8.GetBytes(deviceId);
+            var deviceIdLength = System.Math.Min(deviceIdBytes.Length, byte.MaxValue);
+            writer.Write((byte)deviceIdLength);
+            writer.Write(deviceIdBytes, 0, deviceIdLength);
+
             // Variable name (max 64 bytes)
             var varName = data.TryGetValue("variableName", out var nameObj) ? (nameObj != null ? nameObj.ToString() : "") : "";
             if (varName.Length > 64) varName = varName.Substring(0, 64);
@@ -1069,6 +1091,13 @@ namespace Styly.NetSync
             var senderClientNo = data.TryGetValue("senderClientNo", out var senderObj) ? Convert.ToUInt16(senderObj) : (ushort)0;
             writer.Write(senderClientNo);
 
+            // Sender device ID for control identity binding.
+            var deviceId = data.TryGetValue("deviceId", out var deviceObj) ? (deviceObj != null ? deviceObj.ToString() : "") : "";
+            var deviceIdBytes = System.Text.Encoding.UTF8.GetBytes(deviceId);
+            var deviceIdLength = System.Math.Min(deviceIdBytes.Length, byte.MaxValue);
+            writer.Write((byte)deviceIdLength);
+            writer.Write(deviceIdBytes, 0, deviceIdLength);
+
             // Target client number (2 bytes)
             var targetClientNo = data.TryGetValue("targetClientNo", out var targetObj) ? Convert.ToUInt16(targetObj) : (ushort)0;
             writer.Write(targetClientNo);
@@ -1101,6 +1130,12 @@ namespace Styly.NetSync
             var senderClientNo = data.TryGetValue("senderClientNo", out var senderObj) ? Convert.ToUInt16(senderObj) : (ushort)0;
             writer.Write(senderClientNo);
 
+            var deviceId = data.TryGetValue("deviceId", out var deviceObj) ? (deviceObj != null ? deviceObj.ToString() : "") : "";
+            var deviceIdBytes = System.Text.Encoding.UTF8.GetBytes(deviceId);
+            var deviceIdLength = System.Math.Min(deviceIdBytes.Length, byte.MaxValue);
+            writer.Write((byte)deviceIdLength);
+            writer.Write(deviceIdBytes, 0, deviceIdLength);
+
             return ms.ToArray();
         }
 
@@ -1111,6 +1146,8 @@ namespace Styly.NetSync
         {
             // Sender client number (2 bytes)
             var senderClientNo = reader.ReadUInt16();
+            var deviceIdLength = reader.ReadByte();
+            var deviceId = System.Text.Encoding.UTF8.GetString(reader.ReadBytes(deviceIdLength));
             // Target client numbers
             var targetCount = reader.ReadByte();
             var targetClientNos = targetCount == 0 ? Array.Empty<int>() : new int[targetCount];
@@ -1127,6 +1164,7 @@ namespace Styly.NetSync
             return new RPCMessage
             {
                 senderClientNo = senderClientNo,
+                deviceId = deviceId,
                 targetClientNos = targetClientNos,
                 functionName = name,
                 argumentsJson = argsJson

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/DataStructure.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/DataStructure.cs
@@ -95,6 +95,8 @@ namespace Styly.NetSync
     {
         // Client number of the sender
         public int senderClientNo;
+        // Stable sender device ID used for control identity binding
+        public string deviceId;
         // Target client numbers. Empty means broadcast.
         public int[] targetClientNos;
         // Name of function to call

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/NetworkVariableManager.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/NetworkVariableManager.cs
@@ -185,13 +185,14 @@ namespace Styly.NetSync
             var data = new Dictionary<string, object>
             {
                 ["senderClientNo"] = _netSyncManager.ClientNo,
+                ["deviceId"] = _deviceId,
                 ["variableName"] = name,
                 ["variableValue"] = value
             };
 
             try
             {
-                var required = EstimateGlobalVarSetSize(name, value);
+                var required = EstimateGlobalVarSetSize(_deviceId, name, value);
                 _buf.EnsureCapacity(required);
 
                 _buf.Stream.Position = 0;
@@ -291,6 +292,7 @@ namespace Styly.NetSync
             var data = new Dictionary<string, object>
             {
                 ["senderClientNo"] = _netSyncManager.ClientNo,
+                ["deviceId"] = _deviceId,
                 ["targetClientNo"] = targetClientNo,
                 ["variableName"] = name,
                 ["variableValue"] = value
@@ -298,7 +300,7 @@ namespace Styly.NetSync
 
             try
             {
-                var required = EstimateClientVarSetSize(name, value);
+                var required = EstimateClientVarSetSize(_deviceId, name, value);
                 _buf.EnsureCapacity(required);
 
                 _buf.Stream.Position = 0;
@@ -344,7 +346,8 @@ namespace Styly.NetSync
 
             var data = new Dictionary<string, object>
             {
-                ["senderClientNo"] = clientNo
+                ["senderClientNo"] = clientNo,
+                ["deviceId"] = _deviceId
             };
 
             try
@@ -575,20 +578,22 @@ namespace Styly.NetSync
 
         // Buffer growth handled by ReusableBufferWriter
 
-        private static int EstimateGlobalVarSetSize(string name, string value)
+        private static int EstimateGlobalVarSetSize(string deviceId, string name, string value)
         {
-            // 1 (type) + 2 (sender) + 1 + nameLen + 2 + valueLen
+            // 1 (type) + 2 (sender) + 1 + deviceIdLen + 1 + nameLen + 2 + valueLen
+            int deviceIdLen = ClampedUtf8Length(deviceId, 255);
             int nameLen = ClampedUtf8Length(name, 64);
             int valueLen = ClampedUtf8Length(value, 1024);
-            return 1 + 2 + 1 + nameLen + 2 + valueLen;
+            return 1 + 2 + 1 + deviceIdLen + 1 + nameLen + 2 + valueLen;
         }
 
-        private static int EstimateClientVarSetSize(string name, string value)
+        private static int EstimateClientVarSetSize(string deviceId, string name, string value)
         {
-            // 1 (type) + 2 (sender) + 2 (target) + 1 + nameLen + 2 + valueLen
+            // 1 (type) + 2 (sender) + 1 + deviceIdLen + 2 (target) + 1 + nameLen + 2 + valueLen
+            int deviceIdLen = ClampedUtf8Length(deviceId, 255);
             int nameLen = ClampedUtf8Length(name, 64);
             int valueLen = ClampedUtf8Length(value, 1024);
-            return 1 + 2 + 2 + 1 + nameLen + 2 + valueLen;
+            return 1 + 2 + 1 + deviceIdLen + 2 + 1 + nameLen + 2 + valueLen;
         }
 
         private static int ClampedUtf8Length(string s, int max)

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/ObjectSyncManager.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/ObjectSyncManager.cs
@@ -11,6 +11,7 @@ namespace Styly.NetSync
         private readonly IConnectionManager _connectionManager;
         private readonly MessageProcessor _messageProcessor;
         private readonly NetSyncTimeEstimator _timeEstimator;
+        private readonly string _deviceId;
         private readonly bool _enableDebugLogs;
 
         private readonly Dictionary<uint, NetSyncObject> _registeredObjects = new();
@@ -34,11 +35,13 @@ namespace Styly.NetSync
             IConnectionManager connectionManager,
             MessageProcessor messageProcessor,
             NetSyncTimeEstimator timeEstimator,
+            string deviceId,
             bool enableDebugLogs)
         {
             _connectionManager = connectionManager;
             _messageProcessor = messageProcessor;
             _timeEstimator = timeEstimator;
+            _deviceId = deviceId;
             _enableDebugLogs = enableDebugLogs;
 
             _messageProcessor.OnRoomObjectsReceived += HandleRoomObjects;
@@ -71,7 +74,7 @@ namespace Styly.NetSync
             if (objectId == 0u) return;
             _buf.EnsureCapacity(128);
             _buf.Stream.Position = 0;
-            BinarySerializer.SerializeObjectOwnershipRequestInto(_buf.Writer, operationType, objectId);
+            BinarySerializer.SerializeObjectOwnershipRequestInto(_buf.Writer, _deviceId, operationType, objectId);
             _buf.Writer.Flush();
 
             var length = (int)_buf.Stream.Position;

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/RPCManager.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/RPCManager.cs
@@ -115,6 +115,7 @@ namespace Styly.NetSync
                 functionName = functionName,
                 argumentsJson = JsonConvert.SerializeObject(args),
                 senderClientNo = _netSyncManager.ClientNo,
+                deviceId = _deviceId,
                 targetClientNos = targetClientNos ?? Array.Empty<int>()
             };
             // Estimate and ensure capacity
@@ -239,9 +240,11 @@ namespace Styly.NetSync
         {
             var nameLen = msg != null && msg.functionName != null ? Encoding.UTF8.GetByteCount(msg.functionName) : 0;
             if (nameLen > 255) nameLen = 255; // capped by serializer
+            var deviceIdLen = msg != null && msg.deviceId != null ? Encoding.UTF8.GetByteCount(msg.deviceId) : 0;
+            if (deviceIdLen > 255) deviceIdLen = 255;
             var argsLen = msg != null && msg.argumentsJson != null ? Encoding.UTF8.GetByteCount(msg.argumentsJson) : 0;
             var targetCount = msg != null && msg.targetClientNos != null ? msg.targetClientNos.Length : 0;
-            return 1 + 2 + 1 + (2 * targetCount) + 1 + nameLen + 2 + argsLen;
+            return 1 + 2 + 1 + deviceIdLen + 1 + (2 * targetCount) + 1 + nameLen + 2 + argsLen;
         }
 
         /// <summary>

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/NetSyncManager.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/NetSyncManager.cs
@@ -915,7 +915,7 @@ namespace Styly.NetSync
             _discoveryManager.SetServerDiscoveryPort(ServerDiscoveryPort);
             _networkVariableManager = new NetworkVariableManager(_connectionManager, _deviceId, this);
             _humanPresenceManager = new HumanPresenceManager(this, _enableDebugLogs);
-            _objectSyncManager = new ObjectSyncManager(_connectionManager, _messageProcessor, _timeEstimator, _enableDebugLogs);
+            _objectSyncManager = new ObjectSyncManager(_connectionManager, _messageProcessor, _timeEstimator, _deviceId, _enableDebugLogs);
             // Setup events
             _connectionManager.OnConnectionError += HandleConnectionError;
             _connectionManager.OnConnectionEstablished += OnConnectionEstablished;


### PR DESCRIPTION
## Summary

Bumps the binary wire protocol **v7 → v8** and makes client-originated control
messages carry a stable **`deviceId`**, so the server rebinds control-lane
identities by device ID instead of volatile client numbers. This preserves
control identity (RPC / Network Variables / object ownership) when client
numbers churn — fixing Global Variable notifications and other control traffic
losing their sender binding.

### Protocol changes (v8)
- `deviceId` (length-prefixed UTF-8) added to `MSG_RPC`, `MSG_GLOBAL_VAR_SET`,
  `MSG_CLIENT_VAR_SET`, `MSG_CLIENT_VAR_CLEAR`, and `MSG_OBJECT_OWNERSHIP_REQUEST`.
- Server identity resolution refactored: `_get_device_id_from_control_identity` /
  `_refresh_control_identity_from_sender_client_no` replaced by
  `_refresh_control_identity_from_device_id` + `_resolve_control_sender`. Control
  handlers now resolve the sender by `deviceId` and bail on missing/invalid IDs.
- Python (`binary_serializer.py`, `client.py`, `server.py`) and Unity
  (`BinarySerializer.cs`, `RPCManager.cs`, `NetworkVariableManager.cs`,
  `ObjectSyncManager.cs`, `DataStructure.cs`, `NetSyncManager.cs`) updated in
  parity; buffer-size estimators account for the new `deviceId` field.

> Breaking wire change — server and clients must deploy together (per repo
> compatibility policy).

## Multi-LLM review + follow-up fixes

Reviewed with 4 models (review-netsync/Claude, github-copilot/GPT-5.4,
agy/Gemini, codex/GPT-5.5). Two consensus findings were fixed in this branch:

- **Simulator parity (3/4 reviewers):** `client_simulator.py send_client_variable`
  omitted `deviceId`, so the v8 server silently dropped the load simulator's
  client-variable writes. Now threads `self.config.device_id` through.
- **Docs (3/4 reviewers):** the three `AGENTS.md` files still said protocol v7
  (READMEs were already v8). Updated to v8 and documented the new `deviceId`
  field.

### Known follow-ups (not in this PR)
- Auto-registering a client from a control message in
  `_refresh_control_identity_from_device_id` can bypass new-client NV/object
  state sync (narrow reachability; design decision deferred).
- Pre-existing: `ClampedUtf8Length` underestimates multi-byte `value` buffers
  (unrelated to this branch).

## Test evidence
- `black` ✅ · `ruff` ✅ · `mypy` (15 files, no issues) ✅
- `pytest` full suite ✅ (2 pre-existing legacy integration skips)
- Unity: no C# behavior changes in the follow-up fixes; serializer parity
  verified byte-for-byte against Python.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
