### PR TITLE
fix: prevent remote hands gliding from origin after hand-tracking recovery

### DIFF
--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/NetSyncSmoothing.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/NetSyncSmoothing.cs
@@ -580,6 +580,16 @@ namespace Styly.NetSync
 
             if (!_hasCurrent)
             {
+                if (sample.State == SampleState.Empty)
+                {
+                    // No data to establish a pose yet (e.g. the channel was Clear()ed
+                    // while hand tracking was lost). Sample.Target is default = origin,
+                    // so adopting it here would pollute _current to (0,0,0) and leave
+                    // _hasCurrent == true, causing the next real snapshot to glide in
+                    // from the origin. Leave _current/_hasCurrent untouched so the first
+                    // snapshot after recovery snaps cleanly via AddSnapshot.
+                    return _current;
+                }
                 _current = sample.Target;
                 _hasCurrent = true;
                 return _current;


### PR DESCRIPTION
## Summary

Fixes the receiving-side bug where a remote avatar's hands glide in from the world origin `(0,0,0)` after the sender's hand tracking is lost and then recovered. The head does not exhibit this because it uses no second-phase smoothing.

Closes #466.

## Root cause

In `PoseChannel.Tick` (`NetSyncSmoothing.cs`), the `!_hasCurrent` branch adopted `sample.Target` into `_current`. While hand tracking is lost, `AddSnapshot` calls `Clear()` each snapshot (empty buffer, `_hasCurrent = false`), so `Tick` samples `default(PoseSampleData)` = origin and set `_current = (0,0,0)`, `_hasCurrent = true`. On recovery, the snap-to-first-sample branch in `AddSnapshot` (guarded by `!_hasCurrent`) was skipped, leaving `_current` at the origin, and the second-phase smoothing then lerped the hand in from origin to the real pose.

## Fix

Skip establishing `_current` from an empty `Sample()` (`SampleState.Empty`). This keeps `_hasCurrent == false` throughout the loss, so:

- The first snapshot after recovery snaps `_current` to the real pose via `AddSnapshot` (`NetSyncSmoothing.cs:500-504`) — next `Tick` lerps realPose → realPose, no glide.
- `Clear()` does not reset `_current`, so the (hidden) hand holds its last real pose during loss instead of jumping to origin.

One-channel change; no protocol or API change.

## Test evidence

- Unity force recompile: **0 errors** (only pre-existing unrelated warnings).
- Logic traced against the loss → recovery sequence (see #466 for the step-by-step).

> Note: full runtime confirmation (the glide visually disappearing) requires a two-avatar setup with HMD hand-tracking loss/recovery, which is not reproducible headless in-editor. Reviewers with a device are welcome to confirm.

## Parity

Receiving-side `PoseChannel` interpolation is Unity-only (rendering concern); the Python client/simulator has no equivalent, so no parity change is needed.
