### PR TITLE
fix: fall back to uv offline cache only when PyPI resolution fails

### DIFF
--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Editor/StartPythonServer.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Editor/StartPythonServer.cs
@@ -400,6 +400,17 @@ echo ''
 echo '========================================='
 echo ''
 
+# Resolve the package. Try online first (downloads if needed); only if that fails
+# (e.g. no network) retry from uv's offline cache. The '--version' probe exits
+# immediately without starting the server, so this never restarts a running server.
+if ! " + uvxCommand + @" --version >/dev/null 2>&1; then
+    if UV_OFFLINE=1 " + uvxCommand + @" --version >/dev/null 2>&1; then
+        echo 'Could not reach PyPI. Using cached packages (offline mode).'
+        echo ''
+        export UV_OFFLINE=1
+    fi
+fi
+
 # Start the server
 " + uvxCommand + @"
 
@@ -535,6 +546,21 @@ Write-Host 'Running: " + EscapeForPowerShellSingleQuote(uvxCommand) + @"' -Foreg
 Write-Host ''
 Write-Host '=========================================' -ForegroundColor Cyan
 Write-Host ''
+
+# Resolve the package. Try online first (downloads if needed); only if that fails
+# (e.g. no network) retry from uv's offline cache. The '--version' probe exits
+# immediately without starting the server, so this never restarts a running server.
+Invoke-Expression '" + EscapeForPowerShellSingleQuote(uvxCommand) + @" --version' *> $null
+if ($LASTEXITCODE -ne 0) {
+    $env:UV_OFFLINE = '1'
+    Invoke-Expression '" + EscapeForPowerShellSingleQuote(uvxCommand) + @" --version' *> $null
+    if ($LASTEXITCODE -eq 0) {
+        Write-Host 'Could not reach PyPI. Using cached packages (offline mode).' -ForegroundColor Yellow
+        Write-Host ''
+    } else {
+        Remove-Item Env:\UV_OFFLINE -ErrorAction SilentlyContinue
+    }
+}
 
 # Start the server
 " + uvxCommand + @"
@@ -696,6 +722,17 @@ echo 'Running: " + EscapeForBashSingleQuote(uvxCommand) + @"'
 echo ''
 echo '========================================='
 echo ''
+
+# Resolve the package. Try online first (downloads if needed); only if that fails
+# (e.g. no network) retry from uv's offline cache. The '--version' probe exits
+# immediately without starting the server, so this never restarts a running server.
+if ! " + uvxCommand + @" --version >/dev/null 2>&1; then
+    if UV_OFFLINE=1 " + uvxCommand + @" --version >/dev/null 2>&1; then
+        echo 'Could not reach PyPI. Using cached packages (offline mode).'
+        echo ''
+        export UV_OFFLINE=1
+    fi
+fi
 
 # Start the server
 " + uvxCommand + @"

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Editor/StartPythonServer.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Editor/StartPythonServer.cs
@@ -405,7 +405,7 @@ echo ''
 # immediately without starting the server, so this never restarts a running server.
 if ! " + uvxCommand + @" --version >/dev/null 2>&1; then
     if UV_OFFLINE=1 " + uvxCommand + @" --version >/dev/null 2>&1; then
-        echo 'Could not reach PyPI. Using cached packages (offline mode).'
+        echo 'Online resolution failed. Using cached packages (offline mode).'
         echo ''
         export UV_OFFLINE=1
     fi
@@ -552,11 +552,16 @@ Write-Host ''
 # immediately without starting the server, so this never restarts a running server.
 Invoke-Expression '" + EscapeForPowerShellSingleQuote(uvxCommand) + @" --version' *> $null
 if ($LASTEXITCODE -ne 0) {
+    # Preserve any pre-existing UV_OFFLINE so we can restore it if the offline probe fails.
+    $hadOffline = Test-Path Env:\UV_OFFLINE
+    $prevOffline = if ($hadOffline) { $env:UV_OFFLINE } else { $null }
     $env:UV_OFFLINE = '1'
     Invoke-Expression '" + EscapeForPowerShellSingleQuote(uvxCommand) + @" --version' *> $null
     if ($LASTEXITCODE -eq 0) {
-        Write-Host 'Could not reach PyPI. Using cached packages (offline mode).' -ForegroundColor Yellow
+        Write-Host 'Online resolution failed. Using cached packages (offline mode).' -ForegroundColor Yellow
         Write-Host ''
+    } elseif ($hadOffline) {
+        $env:UV_OFFLINE = $prevOffline
     } else {
         Remove-Item Env:\UV_OFFLINE -ErrorAction SilentlyContinue
     }
@@ -728,7 +733,7 @@ echo ''
 # immediately without starting the server, so this never restarts a running server.
 if ! " + uvxCommand + @" --version >/dev/null 2>&1; then
     if UV_OFFLINE=1 " + uvxCommand + @" --version >/dev/null 2>&1; then
-        echo 'Could not reach PyPI. Using cached packages (offline mode).'
+        echo 'Online resolution failed. Using cached packages (offline mode).'
         echo ''
         export UV_OFFLINE=1
     fi


### PR DESCRIPTION
## Summary

The scripts that launch the Python server from the Unity menu decided whether to use `UV_OFFLINE` by pre-pinging `pypi.org`. That check produced **false negatives** (offline detected while actually online), forcing cache-only mode and then failing to resolve a version that was not yet cached (e.g. `0.16.1`).

This replaces the connectivity ping with an approach that **falls back to the cache only when an actual resolution attempt fails**.

## What changed

- Removed the pre-flight `curl` / `Invoke-WebRequest` connectivity check.
- Added a resolution probe that runs `uvx ... styly-netsync-server@VER --version`.
  - `--version` is an argparse `action="version"`, so it raises `SystemExit(0)` during `parse_args()` and exits **before any port binding** — it never starts (or restarts) a running server.
  - Online probe succeeds → start normally (no false offline detection).
  - Online probe fails → retry the probe with `UV_OFFLINE=1`; enable offline mode only if that cached probe succeeds.
  - Both fail (offline and not cached) → start normally and let uvx surface the real network error.
- Applied to the macOS / Linux (bash) and Windows (PowerShell) launch scripts.

### Behavior matrix

| Situation | Online probe | Offline probe | Result |
|---|---|---|---|
| Online | success (downloads if needed) | — | normal launch |
| Offline + cached | fail | success | launch in offline mode |
| Offline + not cached | fail | fail | normal launch, surfaces the real network error |

## Notes

- uv has no single option for "prefer online, automatically fall back to cache," which is why the previous code relied on a manual connectivity check. The actual-attempt probe removes the false-negative problem entirely.
- No network/protocol changes — launch scripts only.

## Test evidence

- Verified the fast-exit path used by the probe: `server.py:2965-2971` declares `--version` as `action="version"`, and `cli.py` `cli_main` lets `SystemExit` propagate unchanged.
- Please verify online / offline launch on a real machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)