### PR TITLE
docs: require English for commits, PRs, issues, and code comments

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,6 +105,7 @@ Key mappings: `NetSyncManager.cs` ↔ `client.py`, `ConnectionManager.cs` ↔ co
 
 ## Commit & PR Guidelines
 
+- Write all commit messages, PR titles/descriptions, issues, and code comments in English
 - Conventional Commits (`feat:`, `fix:`, `refactor:`); subject ≤72 chars
 - Target PRs to `develop`; manual PRs to `main` are blocked (use release workflow)
 - PR checklist: description, linked issues, test evidence (logs/screenshots)


### PR DESCRIPTION
## Summary

`AGENTS.md` did not explicitly state which language to use for contributions, even though the project already writes commit messages, PRs, and code comments in English. This makes that convention explicit so contributors (and AI assistants) follow it consistently.

## What changed

- Added one line to the **Commit & PR Guidelines** section of `AGENTS.md`:
  > Write all commit messages, PR titles/descriptions, issues, and code comments in English

## Notes

- Documentation only — no code or behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)