### PR TITLE
fix: derive release tag from event payload in publish-to-pypi

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -20,6 +20,13 @@ jobs:
 
       # Check that tag and pyproject version match (to prevent mistakes)
       - name: Ensure tag == project.version (PEP 440)
+        env:
+          # For a release event, read the tag straight from the event payload.
+          # GITHUB_REF_NAME is unreliable here: when the tag, develop, and main all
+          # point to the same commit, GitHub resolves the run's ref to a branch
+          # instead of the tag, leaving GITHUB_REF_NAME without the tag value.
+          # Fall back to GITHUB_REF_NAME for manual workflow_dispatch runs.
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: |
           python - <<'PY'
           import os, sys, re
@@ -28,7 +35,7 @@ jobs:
           except ModuleNotFoundError:
               import tomli as tomllib  # fallback
 
-          ref = os.environ.get("GITHUB_REF_NAME", "")
+          ref = os.environ.get("RELEASE_TAG") or os.environ.get("GITHUB_REF_NAME", "")
           tag = ref[1:] if ref.startswith("v") else ref
 
           with open("STYLY-NetSync-Server/pyproject.toml", "rb") as f:


### PR DESCRIPTION
## Problem

The v0.16.2 release publish failed at the **Ensure tag == project.version** step with:

```
##[error]Git tag () != project.version (0.16.2)
```

The tag came through as an empty string.

## Root cause

The guard read the tag from `GITHUB_REF_NAME`. A `release` event normally sets that to the tag, but for v0.16.2 the tag, `develop`, and `main` all pointed to the same commit (`30a31c6`). With an ambiguous ref, GitHub resolved the run to a branch (`head_branch: develop`) instead of `refs/tags/v0.16.2`, so `GITHUB_REF_NAME` never carried the tag.

Prior releases passed only because `develop` had moved ahead of the tag commit before publish (their run `headBranch` was `v0.16.1`, `v0.16.0`, …). This release had no follow-up commit after the version bump, so the collision survived. The flaw was latent in the workflow since it was written.

## Fix

Read the tag from `github.event.release.tag_name` (authoritative for release events), falling back to `GITHUB_REF_NAME` only for manual `workflow_dispatch` runs.

## Test evidence

To be validated by re-running the publish flow for v0.16.2 after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)