### PR TITLE
Add NetSync log export endpoint

### DIFF
--- a/STYLY-NetSync-Server/README.md
+++ b/STYLY-NetSync-Server/README.md
@@ -229,6 +229,26 @@ The response includes the room ID and whether each key was `"applied"`, `"queued
   curl -sS "http://127.0.0.1:8800/v1/rooms/default_room/global-variables/score"
   ```
 
+### Log export
+
+- Endpoint: `GET /logs/export`
+- Requires file logging to be enabled (`--log-dir DIR`, see [Logging](#logging)). Without it the endpoint returns `404 {"detail": "file logging is not enabled"}`.
+- Streams matching JSONL entries from `DIR/netsync-server*.log` (including rotated files) as `application/x-ndjson` — one original loguru JSON line per row.
+- Query parameters:
+  - `from` (required): ISO 8601 start timestamp, inclusive.
+  - `to` (required): ISO 8601 end timestamp, inclusive. Must be greater than or equal to `from`.
+  - `min_severity` (optional): minimum log level to include. One of `TRACE`, `DEBUG`, `INFO`, `SUCCESS`, `WARN`, `WARNING`, `ERROR`, `CRITICAL` (case-insensitive). Lines below this level are skipped.
+- Timestamps are compared in UTC; naive (offset-less) values are treated as UTC.
+- Errors:
+  - `400` — unparseable `from`/`to`, `to` earlier than `from`, or an unsupported `min_severity`.
+  - `404 {"detail": "file logging is not enabled"}` — `--log-dir` was not configured.
+  - `404 {"detail": "log directory is not available"}` — `--log-dir` was configured but the directory does not exist.
+- Example:
+
+  ```bash
+  curl -sS "http://127.0.0.1:8800/logs/export?from=2026-06-26T00:00:00Z&to=2026-06-26T23:59:59Z&min_severity=ERROR"
+  ```
+
 ### Read consistency
 
 GET endpoints return a snapshot of the REST bridge's in-process cache, which is populated by control-lane sync messages from the server. The first request to a room lazily creates a bridge and may return an empty snapshot until the initial sync arrives — retry after a short delay if needed.

--- a/STYLY-NetSync-Server/src/styly_netsync/logging_utils.py
+++ b/STYLY-NetSync-Server/src/styly_netsync/logging_utils.py
@@ -1,11 +1,12 @@
 # logging_utils.py
 from __future__ import annotations
 
+import json
 import logging
 import sys
 import threading
-from collections.abc import Callable
-from datetime import time, timedelta
+from collections.abc import Callable, Iterator
+from datetime import UTC, datetime, time, timedelta
 from pathlib import Path
 from typing import Any
 
@@ -20,6 +21,16 @@ LOG_ROTATION_SIZE_BYTES = 10 * 1024 * 1024
 LOG_ROTATION_MAX_AGE = timedelta(days=7)
 LOG_RETENTION_MAX_FILES = 20
 DEFAULT_LOG_FILENAME = "netsync-server.log"
+LOG_LEVEL_SEVERITY = {
+    "TRACE": 5,
+    "DEBUG": 10,
+    "INFO": 20,
+    "SUCCESS": 25,
+    "WARNING": 30,
+    "WARN": 30,
+    "ERROR": 40,
+    "CRITICAL": 50,
+}
 RotationRule = str | int | time | timedelta | Callable[..., bool]
 RetentionRule = str | int | timedelta | Callable[[list[str]], None]
 
@@ -222,6 +233,103 @@ def configure_logging(
 
     logging.basicConfig(handlers=[InterceptHandler()], level=logging.NOTSET, force=True)
     logging.captureWarnings(True)
+
+
+def iter_exported_log_lines(
+    log_dir: Path,
+    from_ts: datetime,
+    to_ts: datetime,
+    min_severity: str | None = None,
+) -> Iterator[str]:
+    """Yield original loguru JSONL lines matching the requested time window."""
+
+    min_level_no = _parse_min_severity(min_severity)
+    from_utc = _to_utc(from_ts)
+    to_utc = _to_utc(to_ts)
+
+    for log_file in sorted(log_dir.glob("netsync-server*.log")):
+        if not log_file.is_file():
+            continue
+        try:
+            with log_file.open("r", encoding="utf-8") as file:
+                for raw_line in file:
+                    line = raw_line.rstrip("\r\n")
+                    if not line:
+                        continue
+                    try:
+                        payload = json.loads(line)
+                    except json.JSONDecodeError:
+                        logger.warning(f"Skipping malformed NetSync log line in {log_file}")
+                        continue
+                    record = payload.get("record")
+                    if not isinstance(record, dict):
+                        logger.warning(f"Skipping NetSync log line without record in {log_file}")
+                        continue
+                    record_time = _extract_record_time(record)
+                    if record_time is None:
+                        logger.warning(f"Skipping NetSync log line without timestamp in {log_file}")
+                        continue
+                    record_time_utc = _to_utc(record_time)
+                    if record_time_utc < from_utc or record_time_utc > to_utc:
+                        continue
+                    if min_level_no is not None:
+                        level_no = _extract_level_no(record)
+                        if level_no is None or level_no < min_level_no:
+                            continue
+                    yield line
+        except OSError as exc:
+            logger.warning(f"Failed to read NetSync log file {log_file}: {exc}")
+
+
+def _parse_min_severity(min_severity: str | None) -> int | None:
+    if min_severity is None:
+        return None
+    normalized = min_severity.strip().upper()
+    if not normalized:
+        return None
+    if normalized not in LOG_LEVEL_SEVERITY:
+        raise ValueError(f"Unsupported min_severity: {min_severity}")
+    return LOG_LEVEL_SEVERITY[normalized]
+
+
+def _extract_record_time(record: dict[str, Any]) -> datetime | None:
+    time_value = record.get("time")
+    if not isinstance(time_value, dict):
+        return None
+
+    timestamp = time_value.get("timestamp")
+    if isinstance(timestamp, int | float):
+        return datetime.fromtimestamp(timestamp, tz=UTC)
+
+    repr_value = time_value.get("repr")
+    if isinstance(repr_value, str):
+        normalized = repr_value.replace("Z", "+00:00")
+        try:
+            return datetime.fromisoformat(normalized)
+        except ValueError:
+            return None
+    return None
+
+
+def _extract_level_no(record: dict[str, Any]) -> int | None:
+    level = record.get("level")
+    if not isinstance(level, dict):
+        return None
+
+    level_no = level.get("no")
+    if isinstance(level_no, int):
+        return level_no
+
+    level_name = level.get("name")
+    if isinstance(level_name, str):
+        return LOG_LEVEL_SEVERITY.get(level_name.upper())
+    return None
+
+
+def _to_utc(value: datetime) -> datetime:
+    if value.tzinfo is None:
+        return value.replace(tzinfo=UTC)
+    return value.astimezone(UTC)
 
 
 def reset_rotation_state() -> None:

--- a/STYLY-NetSync-Server/src/styly_netsync/logging_utils.py
+++ b/STYLY-NetSync-Server/src/styly_netsync/logging_utils.py
@@ -31,6 +31,10 @@ LOG_LEVEL_SEVERITY = {
     "ERROR": 40,
     "CRITICAL": 50,
 }
+# Severity names accepted by the log export API, ordered from least to most severe.
+VALID_MIN_SEVERITIES = tuple(
+    sorted(LOG_LEVEL_SEVERITY, key=lambda name: (LOG_LEVEL_SEVERITY[name], name))
+)
 RotationRule = str | int | time | timedelta | Callable[..., bool]
 RetentionRule = str | int | timedelta | Callable[[list[str]], None]
 
@@ -259,15 +263,21 @@ def iter_exported_log_lines(
                     try:
                         payload = json.loads(line)
                     except json.JSONDecodeError:
-                        logger.warning(f"Skipping malformed NetSync log line in {log_file}")
+                        logger.warning(
+                            f"Skipping malformed NetSync log line in {log_file}"
+                        )
                         continue
                     record = payload.get("record")
                     if not isinstance(record, dict):
-                        logger.warning(f"Skipping NetSync log line without record in {log_file}")
+                        logger.warning(
+                            f"Skipping NetSync log line without record in {log_file}"
+                        )
                         continue
                     record_time = _extract_record_time(record)
                     if record_time is None:
-                        logger.warning(f"Skipping NetSync log line without timestamp in {log_file}")
+                        logger.warning(
+                            f"Skipping NetSync log line without timestamp in {log_file}"
+                        )
                         continue
                     record_time_utc = _to_utc(record_time)
                     if record_time_utc < from_utc or record_time_utc > to_utc:

--- a/STYLY-NetSync-Server/src/styly_netsync/rest_bridge.py
+++ b/STYLY-NetSync-Server/src/styly_netsync/rest_bridge.py
@@ -14,7 +14,11 @@ from fastapi.responses import StreamingResponse
 from pydantic import BaseModel, Field, StringConstraints
 
 from .client import net_sync_manager
-from .logging_utils import LOG_LEVEL_SEVERITY, iter_exported_log_lines
+from .logging_utils import (
+    LOG_LEVEL_SEVERITY,
+    VALID_MIN_SEVERITIES,
+    iter_exported_log_lines,
+)
 
 if TYPE_CHECKING:
     import uvicorn
@@ -347,6 +351,10 @@ def create_app(
         """Stream filtered server JSONL logs from the configured log directory."""
         if log_dir is None:
             raise HTTPException(status_code=404, detail="file logging is not enabled")
+        if not log_dir.is_dir():
+            raise HTTPException(
+                status_code=404, detail="log directory is not available"
+            )
 
         try:
             from_ts = _parse_iso_datetime(from_, "from")
@@ -363,8 +371,7 @@ def create_app(
                 raise HTTPException(
                     status_code=400,
                     detail=(
-                        "min_severity must be one of "
-                        "DEBUG, INFO, WARNING, ERROR, CRITICAL"
+                        "min_severity must be one of " + ", ".join(VALID_MIN_SEVERITIES)
                     ),
                 )
 

--- a/STYLY-NetSync-Server/src/styly_netsync/rest_bridge.py
+++ b/STYLY-NetSync-Server/src/styly_netsync/rest_bridge.py
@@ -3,13 +3,18 @@ from __future__ import annotations
 import logging
 import threading
 import time
+from collections.abc import Iterator
+from datetime import datetime
+from pathlib import Path
 from typing import TYPE_CHECKING, Annotated, Protocol
 
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, HTTPException, Query
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import StreamingResponse
 from pydantic import BaseModel, Field, StringConstraints
 
 from .client import net_sync_manager
+from .logging_utils import LOG_LEVEL_SEVERITY, iter_exported_log_lines
 
 if TYPE_CHECKING:
     import uvicorn
@@ -312,6 +317,7 @@ def create_app(
     sub_port: int,
     transform_port: int = 5557,
     server: ClientVariableServer | None = None,
+    log_dir: Path | None = None,
 ) -> FastAPI:
     """Create the FastAPI application hosting the REST bridge."""
     app = FastAPI(title="NetSync REST Bridge", version="1.0.0")
@@ -331,6 +337,47 @@ def create_app(
     def health_check() -> dict[str, str]:
         """Health check endpoint."""
         return {"status": "ok"}
+
+    @app.get("/logs/export")
+    def export_logs(
+        from_: Annotated[str, Query(alias="from")],
+        to: str,
+        min_severity: str | None = None,
+    ) -> StreamingResponse:
+        """Stream filtered server JSONL logs from the configured log directory."""
+        if log_dir is None:
+            raise HTTPException(status_code=404, detail="file logging is not enabled")
+
+        try:
+            from_ts = _parse_iso_datetime(from_, "from")
+            to_ts = _parse_iso_datetime(to, "to")
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+        if to_ts < from_ts:
+            raise HTTPException(status_code=400, detail="to must be after from")
+
+        if min_severity is not None:
+            normalized = min_severity.strip().upper()
+            if normalized and normalized not in LOG_LEVEL_SEVERITY:
+                raise HTTPException(
+                    status_code=400,
+                    detail=(
+                        "min_severity must be one of "
+                        "DEBUG, INFO, WARNING, ERROR, CRITICAL"
+                    ),
+                )
+
+        def line_stream() -> Iterator[str]:
+            for line in iter_exported_log_lines(
+                log_dir,
+                from_ts,
+                to_ts,
+                min_severity=min_severity,
+            ):
+                yield f"{line}\n"
+
+        return StreamingResponse(line_stream(), media_type="application/x-ndjson")
 
     @app.post("/v1/rooms/{room_id}/devices/{device_id}/client-variables")
     def upsert(room_id: str, device_id: str, body: UpsertBody) -> dict[str, object]:
@@ -451,6 +498,13 @@ def create_app(
         return {"clientNo": client_no, "deletedCount": deleted_count}
 
     return app
+
+
+def _parse_iso_datetime(value: str, field_name: str) -> datetime:
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise ValueError(f"{field_name} must be an ISO 8601 timestamp") from exc
 
 
 def run_uvicorn_in_thread(

--- a/STYLY-NetSync-Server/src/styly_netsync/server.py
+++ b/STYLY-NetSync-Server/src/styly_netsync/server.py
@@ -992,6 +992,9 @@ class NetSyncServer:
                     transform_port=self.transform_port,
                     sub_port=self.pub_port,
                     server=self,
+                    log_dir=Path(self._config.log_dir)
+                    if self._config.log_dir
+                    else None,
                 )
                 rest_api_port = self._config.rest_api_port
                 self._rest_thread, self._rest_server = run_uvicorn_in_thread(

--- a/STYLY-NetSync-Server/tests/test_rest_bridge.py
+++ b/STYLY-NetSync-Server/tests/test_rest_bridge.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import json
+from datetime import datetime
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -329,6 +332,32 @@ def _make_get_client(mock_bridge: MagicMock) -> TestClient:
         return TestClient(app)
 
 
+def _make_log_export_client(log_dir: Path) -> TestClient:
+    with patch("styly_netsync.rest_bridge.BridgeManager"):
+        app = create_app("localhost", 5555, 5556, log_dir=log_dir)
+        return TestClient(app)
+
+
+def _write_log_line(
+    path: Path, *, ts: str, level_name: str, level_no: int, message: str
+) -> None:
+    payload = {
+        "text": f"{message}\n",
+        "record": {
+            "message": message,
+            "time": {
+                "repr": ts,
+                "timestamp": datetime.fromisoformat(
+                    ts.replace("Z", "+00:00")
+                ).timestamp(),
+            },
+            "level": {"name": level_name, "no": level_no},
+        },
+    }
+    with path.open("a", encoding="utf-8") as file:
+        file.write(json.dumps(payload) + "\n")
+
+
 class TestGlobalVariablesGetEndpoint:
     def test_get_all_returns_snapshot(self) -> None:
         mock_bridge = MagicMock()
@@ -416,3 +445,114 @@ class TestClientVariablesGetEndpoint:
         long_name = "x" * 65
         resp = tc.get(f"/v1/rooms/room1/devices/device-x/client-variables/{long_name}")
         assert resp.status_code == 422
+
+
+class TestLogExportEndpoint:
+    def test_export_returns_filtered_ndjson(self, tmp_path: Path) -> None:
+        log_file = tmp_path / "netsync-server.log"
+        _write_log_line(
+            log_file,
+            ts="2026-06-18T00:00:00+00:00",
+            level_name="INFO",
+            level_no=20,
+            message="before",
+        )
+        _write_log_line(
+            log_file,
+            ts="2026-06-18T01:00:00+00:00",
+            level_name="INFO",
+            level_no=20,
+            message="inside",
+        )
+        _write_log_line(
+            log_file,
+            ts="2026-06-18T02:00:00+00:00",
+            level_name="INFO",
+            level_no=20,
+            message="after",
+        )
+
+        tc = _make_log_export_client(tmp_path)
+        resp = tc.get(
+            "/logs/export",
+            params={
+                "from": "2026-06-18T00:30:00Z",
+                "to": "2026-06-18T01:30:00Z",
+            },
+        )
+
+        assert resp.status_code == 200
+        assert resp.headers["content-type"].startswith("application/x-ndjson")
+        lines = [json.loads(line) for line in resp.text.splitlines()]
+        assert [line["record"]["message"] for line in lines] == ["inside"]
+
+    def test_export_scans_rotated_files_and_filters_severity(
+        self, tmp_path: Path
+    ) -> None:
+        current = tmp_path / "netsync-server.log"
+        rotated = tmp_path / "netsync-server.2026-06-18_00-00-00_000000.log"
+        _write_log_line(
+            rotated,
+            ts="2026-06-18T01:00:00+00:00",
+            level_name="INFO",
+            level_no=20,
+            message="info",
+        )
+        _write_log_line(
+            current,
+            ts="2026-06-18T01:05:00+00:00",
+            level_name="ERROR",
+            level_no=40,
+            message="error",
+        )
+
+        tc = _make_log_export_client(tmp_path)
+        resp = tc.get(
+            "/logs/export",
+            params={
+                "from": "2026-06-18T00:00:00Z",
+                "to": "2026-06-18T02:00:00Z",
+                "min_severity": "ERROR",
+            },
+        )
+
+        assert resp.status_code == 200
+        lines = [json.loads(line) for line in resp.text.splitlines()]
+        assert [line["record"]["message"] for line in lines] == ["error"]
+
+    def test_export_without_log_dir_returns_404(self) -> None:
+        with patch("styly_netsync.rest_bridge.BridgeManager"):
+            app = create_app("localhost", 5555, 5556)
+            tc = TestClient(app)
+
+        resp = tc.get(
+            "/logs/export",
+            params={
+                "from": "2026-06-18T00:00:00Z",
+                "to": "2026-06-18T02:00:00Z",
+            },
+        )
+        assert resp.status_code == 404
+
+    def test_export_invalid_severity_returns_400(self, tmp_path: Path) -> None:
+        tc = _make_log_export_client(tmp_path)
+        resp = tc.get(
+            "/logs/export",
+            params={
+                "from": "2026-06-18T00:00:00Z",
+                "to": "2026-06-18T02:00:00Z",
+                "min_severity": "NOPE",
+            },
+        )
+        assert resp.status_code == 400
+
+    def test_export_invalid_range_returns_400(self, tmp_path: Path) -> None:
+        tc = _make_log_export_client(tmp_path)
+        resp = tc.get(
+            "/logs/export",
+            params={
+                "from": "2026-06-18T02:00:00Z",
+                "to": "2026-06-18T00:00:00Z",
+            },
+        )
+        assert resp.status_code == 400

--- a/STYLY-NetSync-Server/tests/test_rest_bridge.py
+++ b/STYLY-NetSync-Server/tests/test_rest_bridge.py
@@ -534,6 +534,18 @@ class TestLogExportEndpoint:
         )
         assert resp.status_code == 404
 
+    def test_export_missing_log_dir_returns_404(self, tmp_path: Path) -> None:
+        missing = tmp_path / "does-not-exist"
+        tc = _make_log_export_client(missing)
+        resp = tc.get(
+            "/logs/export",
+            params={
+                "from": "2026-06-18T00:00:00Z",
+                "to": "2026-06-18T02:00:00Z",
+            },
+        )
+        assert resp.status_code == 404
+
     def test_export_invalid_severity_returns_400(self, tmp_path: Path) -> None:
         tc = _make_log_export_client(tmp_path)
         resp = tc.get(


### PR DESCRIPTION
## Summary

Adds a REST endpoint for exporting NetSync server logs as NDJSON so GameMaster can include NetSync logs in operator log exports.

## Changes

- Added `GET /logs/export`.
- Supports required `from` and `to` ISO 8601 query parameters.
- Supports optional `min_severity`.
- Streams matching `netsync-server*.log` JSONL entries from the configured `--log-dir`.
- Filters by log timestamp and severity.
- Passes configured `log_dir` into the REST bridge.
- Adds tests for export success, filtering, validation, and missing log directory behavior.

___________

## 概要

GameMasterがオペレーター向けログエクスポートにNetSyncログを含められるように、NetSyncサーバーログをNDJSON形式でエクスポートするRESTエンドポイントを追加します。

## 変更内容

- `GET /logs/export`を追加。
- 必須の`from`および`to` ISO 8601クエリパラメーターをサポート。
- オプションの`min_severity`をサポート。
- 設定された`--log-dir`から、条件に一致する`netsync-server*.log` JSONLエントリーをストリーミング。
- ログのタイムスタンプと重大度でフィルタリング。
- 設定された`log_dir`をRESTブリッジへ渡すように変更。
- エクスポート成功、フィルタリング、バリデーション、およびログディレクトリーが存在しない場合の動作を検証するテストを追加。
