### PR TITLE
fix: drop stale pending value when NV send-side dedupe skips

### DIFF
--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/NetworkVariableManager.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/NetworkVariableManager.cs
@@ -147,9 +147,18 @@ namespace Styly.NetSync
                 return true;
             }
 
-            // Dedupe: same as the last actually sent value -> skip, but treat as success
+            // Dedupe: same as the last actually sent value -> skip, but treat as success.
+            // Also cancel any pending (now-stale) trailing value: when the incoming value
+            // already equals what is on the wire, it is the most recent intent, so any
+            // surviving pending entry is necessarily an older opposite value that a later
+            // trailing flush would wrongly send. Dropping it is always correct and never
+            // loses a legitimate update.
             if (_lastSentGlobal.TryGetValue(name, out var lastSent) && lastSent == value)
+            {
+                _pendingGlobal.Remove(name);
+                _dueGlobal.Remove(name);
                 return true;
+            }
 
             double now = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() / 1000.0;
 
@@ -255,9 +264,19 @@ namespace Styly.NetSync
 
             var key = (targetClientNo, name);
 
-            // Dedupe: same as the last actually sent value -> skip, but treat as success
+            // Dedupe: same as the last actually sent value -> skip, but treat as success.
+            // Also cancel any pending (now-stale) trailing value: when the incoming value
+            // already equals what is on the wire, it is the most recent intent, so any
+            // surviving pending entry is necessarily an older opposite value that a later
+            // trailing flush would wrongly send. Dropping it is always correct and never
+            // loses a legitimate update. (Fixes A->B->A within the debounce window where the
+            // final A was dropped and the stale pending B overwrote the server value.)
             if (_lastSentClient.TryGetValue(key, out var lastSent) && lastSent == value)
+            {
+                _pendingClient.Remove(key);
+                _dueClient.Remove(key);
                 return true;
+            }
 
             double now = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() / 1000.0;
 


### PR DESCRIPTION
## Problem

`SetClientVariable` / `SetGlobalVariable` use leading-edge + trailing debounce (100ms) with a send-side dedupe against the last actually-sent value. The dedupe returned early when the incoming value equaled the last sent value, but left any pending (trailing) value scheduled.

With an **A → B → A** sequence inside the debounce window, the final `A` was dropped by the dedupe while the stale pending `B` survived and was flushed — so `B` became the server-confirmed value instead of the latest intent `A`.

This surfaced downstream as a client variable (e.g. a hand-visibility flag) getting stuck at the wrong value under rapid toggling.

## Fix

On the dedupe-skip path, also cancel the pending/due entry (`_pending*.Remove` + `_due*.Remove`). When the incoming value already equals what is on the wire it is the most recent intent, so any surviving pending entry is necessarily an older opposite value — dropping it is always correct and never loses a legitimate update.

Applied symmetrically to client and global variables.

## Scope / parity

- Unity client only. The Python client has no send-side debounce, and the server is last-write-wins, so no changes are needed there.

## Test evidence

- Consumer device test (Pico): with their reactive resend-workaround disabled, the "value stuck" detector reported 0 occurrences and `GetClientVariable(self)` converged to the latest value. Re-confirmation under heavier flicker is pending.
- This is an independent correctness fix; it is **not** the cause of the downstream frozen-hand issue (that is fixed separately by the pose-staleness PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
