### PR TITLE
fix: treat frozen wrist pose as hand-tracking lost

### DIFF
--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/HandPoseNormalizer.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/HandPoseNormalizer.cs
@@ -70,10 +70,12 @@ namespace Styly.NetSync.Internal
         // jitters, so an exactly-repeated pose sustained this long does not occur during genuine
         // tracking.
         private Vector3 _staleLastWristPos;
+        private Quaternion _staleLastWristRot;
         private bool _staleHasLastWristPos = false;
         private float _staleUnchangedSince = 0f;
-        private const float PoseStaleEpsilon = 1e-6f;  // only a bit-identical repeat stays under this
-        private const float PoseStaleSeconds = 0.5f;   // sustained no-change before treating as lost
+        private const float PoseStaleEpsilon = 1e-6f;     // only a bit-identical position repeat stays under this
+        private const float PoseStaleRotEpsilon = 1e-3f;  // degrees; only a bit-identical rotation repeat stays under this
+        private const float PoseStaleSeconds = 0.5f;      // sustained no-change before treating as lost
 
         // Head transform reference for maintaining relative position during lost state
         private Transform _headTransform;
@@ -285,14 +287,21 @@ namespace Styly.NetSync.Internal
             {
                 _staleHasLastWristPos = true;
                 _staleLastWristPos = hasPose ? wristPose.position : Vector3.zero;
+                _staleLastWristRot = hasPose ? wristPose.rotation : Quaternion.identity;
                 _staleUnchangedSince = now;
                 return false;
             }
 
-            bool moved = hasPose && Vector3.Distance(wristPose.position, _staleLastWristPos) > PoseStaleEpsilon;
+            // Position OR rotation delta counts as movement. Rotation is included so a wrist that
+            // turns in place (near-constant position, live orientation) is not misread as stale;
+            // ORing it only makes `moved` fire more often, so it can only reduce false positives.
+            bool moved = hasPose && (
+                Vector3.Distance(wristPose.position, _staleLastWristPos) > PoseStaleEpsilon ||
+                Quaternion.Angle(wristPose.rotation, _staleLastWristRot) > PoseStaleRotEpsilon);
             if (moved)
             {
                 _staleLastWristPos = wristPose.position;
+                _staleLastWristRot = wristPose.rotation;
                 _staleUnchangedSince = now;
                 return false;
             }

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/HandPoseNormalizer.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/HandPoseNormalizer.cs
@@ -61,6 +61,20 @@ namespace Styly.NetSync.Internal
         private int _lostCheckFrameCount = 0;
         private const int LostCheckDelayFrames = 3; // Wait 3 frames before confirming lost
 
+        // --- Pose-staleness lost detection ---
+        // Some runtimes keep XRHand.isTracked == true while the wrist pose stops updating (the
+        // subsystem returns the bit-identical pose every frame), and the joint trackingState does
+        // NOT degrade in that case. The only reliable signal is pose staleness: when the wrist pose
+        // is unchanged for PoseStaleSeconds while tracked, treat the hand as lost so the validity
+        // flag clears and remote hands hide instead of freezing in place. A live tracked hand always
+        // jitters, so an exactly-repeated pose sustained this long does not occur during genuine
+        // tracking.
+        private Vector3 _staleLastWristPos;
+        private bool _staleHasLastWristPos = false;
+        private float _staleUnchangedSince = 0f;
+        private const float PoseStaleEpsilon = 1e-6f;  // only a bit-identical repeat stays under this
+        private const float PoseStaleSeconds = 0.5f;   // sustained no-change before treating as lost
+
         // Head transform reference for maintaining relative position during lost state
         private Transform _headTransform;
 
@@ -251,6 +265,43 @@ namespace Styly.NetSync.Internal
         }
 
         /// <summary>
+        /// Returns true when the wrist pose has been unchanged (stale) for at least PoseStaleSeconds
+        /// while the hand is tracked. Some runtimes keep isTracked == true while the subsystem returns
+        /// the bit-identical wrist pose every frame; that frozen source must be treated as not-tracked.
+        /// Must be called once per frame with the current subsystem hand.
+        /// </summary>
+        private bool IsWristPoseStale(XRHand hand, bool rawTracked)
+        {
+            if (!rawTracked)
+            {
+                _staleHasLastWristPos = false;
+                return false;
+            }
+
+            float now = Time.time;
+            bool hasPose = hand.GetJoint(XRHandJointID.Wrist).TryGetPose(out var wristPose);
+
+            if (!_staleHasLastWristPos)
+            {
+                _staleHasLastWristPos = true;
+                _staleLastWristPos = hasPose ? wristPose.position : Vector3.zero;
+                _staleUnchangedSince = now;
+                return false;
+            }
+
+            bool moved = hasPose && Vector3.Distance(wristPose.position, _staleLastWristPos) > PoseStaleEpsilon;
+            if (moved)
+            {
+                _staleLastWristPos = wristPose.position;
+                _staleUnchangedSince = now;
+                return false;
+            }
+
+            // Pose unchanged (stale repeat) or no fresh pose while still tracked.
+            return (now - _staleUnchangedSince) >= PoseStaleSeconds;
+        }
+
+        /// <summary>
         /// Updates hand tracking state from XRHandSubsystem using state machine.
         /// Uses delayed check for lost detection to distinguish controller switch from true lost.
         /// </summary>
@@ -264,6 +315,9 @@ namespace Styly.NetSync.Internal
                     _trackingState = TrackingState.Unknown;
                     _lostCheckFrameCount = 0;
                 }
+                // Re-init staleness on next available frame so a subsystem drop/reacquire can't be
+                // misread as a stale (frozen) pose from before the gap.
+                _staleHasLastWristPos = false;
                 return;
             }
 
@@ -271,7 +325,11 @@ namespace Styly.NetSync.Internal
             var hand = _handedness == Handedness.Left
                 ? _handSubsystem.leftHand
                 : _handSubsystem.rightHand;
-            bool isTracked = hand.isTracked;
+            bool rawTracked = hand.isTracked;
+            // A frozen (stale) wrist pose while isTracked stays true is treated as not-tracked, so
+            // the existing lost path fires and remote hands hide instead of freezing in place.
+            bool poseStale = IsWristPoseStale(hand, rawTracked);
+            bool isTracked = rawTracked && !poseStale;
 
             // State machine transitions
             switch (_trackingState)


### PR DESCRIPTION
## Problem

Some XR hand-tracking runtimes (observed on Pico) keep `XRHand.isTracked == true` while the wrist pose stops updating — the subsystem returns the bit-identical pose every frame. The wrist joint `trackingState` does **not** degrade in this case (`Radius, Pose, HighFidelityPose` throughout), so neither the high-level tracked flag nor joint confidence signals the loss.

As a result no `OnHandTrackingLost` fired, the hand-pose validity flag stayed `true`, and remote clients showed the hand frozen at its last pose (downstream consumer issue: TheMoonCruise, issue 240).

## Fix

Add pose-staleness detection in `HandPoseNormalizer`: when the wrist pose is unchanged for `PoseStaleSeconds` (0.5s) while tracked, treat the hand as not-tracked and feed that into the existing lost path (`PendingLostCheck → TrueLost`), which clears the hand-pose validity flag and lets remote hands hide. Recovery is detected when the pose starts moving again.

A live tracked hand always jitters, so an exactly-repeated pose (`delta < 1e-6`) sustained this long does not occur during genuine tracking. Verified on-device: during the freeze the joint `trackingState` never degraded and the wrist pose held a bit-identical value (`delta = 0.00000`) for ~4.8s.

## Caveat

This is a **client-side mitigation** for a runtime that misreports `isTracked`; the true cause is the platform runtime. The threshold is tunable via `PoseStaleSeconds`.

**Open verification (reviewers please confirm on-device):** a deliberately-still *healthy* hand must NOT be hidden. If the runtime snaps a still hand to a bit-identical pose, pure staleness could false-positive. A cleaner signal (hand-data timestamp / native confidence) would remove the heuristic.

## Scope

- Unity client only. Independent of the NV-debounce fix (separate PR).

## Test evidence

- Consumer device test (Pico, two clients): the frozen-remote-hand symptom is resolved with this fix; their controlled test previously confirmed the NV-debounce fix alone did not resolve it (this detection is required).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
