### PR TITLE
fix: transform sync stutter from uncoverable server relay wait

### DIFF
--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/DataStructure.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/DataStructure.cs
@@ -59,6 +59,10 @@ namespace Styly.NetSync
         public string deviceId;
         public int clientNo;  // Client number assigned by server (0 if not assigned)
         public double poseTime;
+        // Not on the wire: broadcastTime of the room broadcast that carried this pose,
+        // stamped on receive. broadcastTime - poseTime measures how long the pose sat
+        // on the server before being relayed (both are server-monotonic seconds).
+        public double relayBroadcastTime;
         public ushort poseSeq;
         public PoseFlags flags;
         // XROrigin locomotion delta (SE(2)): x/z translation in meters and yaw delta in degrees.

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/MessageProcessor.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/MessageProcessor.cs
@@ -367,6 +367,10 @@ namespace Styly.NetSync
                     // Skip local avatar by client number
                     if (c.clientNo == _localClientNo) { continue; }
 
+                    // Stamp the carrying broadcast's time so the applier can
+                    // measure the server relay wait (broadcastTime - poseTime).
+                    c.relayBroadcastTime = room.broadcastTime;
+
                     alive.Add(c.clientNo);
 
                     // Check if avatar already exists and just needs update

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/NetSyncSmoothing.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/NetSyncSmoothing.cs
@@ -195,6 +195,72 @@ namespace Styly.NetSync
         }
     }
 
+    internal static class SequenceUtil
+    {
+        /// <summary>
+        /// True when sequence number <paramref name="a"/> comes strictly after
+        /// <paramref name="b"/>, using RFC 1982 serial number arithmetic to
+        /// handle 65535->0 wrap-around.
+        /// </summary>
+        public static bool IsNewer(ushort a, ushort b)
+        {
+            return a != b && (ushort)(a - b) < 0x8000;
+        }
+    }
+
+    /// <summary>
+    /// Tracks how long poses sit on the server before being relayed
+    /// (broadcastTime - poseTime, both server-monotonic seconds). The server
+    /// rebroadcasts at its own rate, so a pose can wait up to one broadcast
+    /// interval before relay; that wait drifts slowly (beat between the client
+    /// send clock and the server broadcast clock) and is invisible to the
+    /// broadcast-offset jitter estimator. Keeps a slowly decaying maximum so
+    /// the render buffer can absorb the relay wait without a fixed worst-case
+    /// latency penalty.
+    /// </summary>
+    internal sealed class RelayAgeEnvelope
+    {
+        // Ignore pathological ages (e.g. first broadcast after a receive stall).
+        private const double MaxAgeSeconds = 0.5;
+        // Shrink 50 ms per second once the relay wait improves; rises are instant.
+        private const double DecayPerSecond = 0.05;
+
+        private double _envelope;
+        private double _lastSampleTime;
+        private bool _has;
+
+        public void Reset()
+        {
+            _has = false;
+            _envelope = 0;
+            _lastSampleTime = 0;
+        }
+
+        public void AddSample(double ageSeconds, double localNow)
+        {
+            if (double.IsNaN(ageSeconds)) return;
+            if (ageSeconds < 0) ageSeconds = 0;
+            if (ageSeconds > MaxAgeSeconds) ageSeconds = MaxAgeSeconds;
+            _envelope = Math.Max(Decayed(localNow), ageSeconds);
+            _lastSampleTime = localNow;
+            _has = true;
+        }
+
+        public double Current(double localNow)
+        {
+            return Decayed(localNow);
+        }
+
+        private double Decayed(double localNow)
+        {
+            if (!_has) return 0;
+            var dt = localNow - _lastSampleTime;
+            if (dt <= 0) return _envelope;
+            var decayed = _envelope - dt * DecayPerSecond;
+            return decayed > 0 ? decayed : 0;
+        }
+    }
+
     internal enum SampleState
     {
         Empty,
@@ -423,14 +489,17 @@ namespace Styly.NetSync
     [Serializable]
     internal sealed class NetSyncSmoothingSettings
     {
-        public double BaseBufferMultiplier = 0.45;
+        // Covers the client send interval plus network jitter. The server-side
+        // relay wait (up to one broadcast interval) is compensated separately by
+        // RelayAgeEnvelope in NetSyncTransformApplier, so this stays small.
+        public double BaseBufferMultiplier = 1.3;
         public bool DynamicBuffer = true;
-        public double DynamicTolerance = 0.1;
-        public double MinBufferMultiplier = 1.1;
-        public double MaxBufferMultiplier = 1.2;
+        public double DynamicTolerance = 0.3;
+        public double MinBufferMultiplier = 1.25;
+        public double MaxBufferMultiplier = 2.0;
 
         public PoseChannelSettings Physical = new PoseChannelSettings { MaxExtrapolationSeconds = 0.08, TauMinSeconds = 0.02f, TauMaxSeconds = 0.06f };
-        public PoseChannelSettings Head = new PoseChannelSettings { MaxExtrapolationSeconds = 0.08, EnableSecondPhaseSmoothing = false, TauMinSeconds = 0.02f, TauMaxSeconds = 0.05f };
+        public PoseChannelSettings Head = new PoseChannelSettings { MaxExtrapolationSeconds = 0.08, TauMinSeconds = 0.02f, TauMaxSeconds = 0.05f };
         public PoseChannelSettings Right = new PoseChannelSettings { MaxExtrapolationSeconds = 0.08, TauMinSeconds = 0.01f, TauMaxSeconds = 0.03f };
         public PoseChannelSettings Left = new PoseChannelSettings { MaxExtrapolationSeconds = 0.08, TauMinSeconds = 0.01f, TauMaxSeconds = 0.03f };
         public PoseChannelSettings Virtual = new PoseChannelSettings { MaxExtrapolationSeconds = 0.08, TauMinSeconds = 0.05f, TauMaxSeconds = 0.12f };

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/NetSyncSmoothing.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/NetSyncSmoothing.cs
@@ -329,13 +329,14 @@ namespace Styly.NetSync
         /// <summary>
         /// Compares two 16-bit sequence numbers accounting for wrap-around.
         /// Uses the RFC 1982 serial number arithmetic approach:
-        /// a is less than or equal to b if (a - b) interpreted as unsigned >= 0x8000.
+        /// a is less than or equal to b if the values are equal, or if
+        /// (a - b) interpreted as unsigned is >= 0x8000.
         /// This correctly handles wrap-around when sequence numbers cross 65535->0.
         /// Example: SequenceLE(65535, 0) returns true (65535 comes before 0 after wrap).
         /// </summary>
         private static bool SequenceLE(ushort a, ushort b)
         {
-            return (ushort)(a - b) >= 0x8000;
+            return a == b || (ushort)(a - b) >= 0x8000;
         }
     }
 

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/NetSyncTransformApplier.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/NetSyncTransformApplier.cs
@@ -29,6 +29,14 @@ namespace Styly.NetSync
         private readonly SendIntervalEstimator _intervalEstimator = new SendIntervalEstimator();
         private double _configuredSendIntervalSeconds = 0.1;
 
+        // Measures how long poses waited on the server before relay
+        // (broadcastTime - poseTime). Sampled only when the pose sequence
+        // advances, so rebroadcasts of an unchanged pose don't inflate it.
+        private readonly RelayAgeEnvelope _relayAge = new RelayAgeEnvelope();
+        private ushort _lastRelaySeq;
+        private double _lastRelayPoseTime;
+        private bool _hasRelaySample;
+
         private PoseChannel _physical;
         private PoseChannel _head;
         private PoseChannel _rightHand;
@@ -117,6 +125,7 @@ namespace Styly.NetSync
             _lastTickApplied = false;
             ClearLastAvatarSamples();
             _intervalEstimator.Reset();
+            ResetRelayAgeTracking();
         }
 
         public void InitializeForSingle(
@@ -147,6 +156,52 @@ namespace Styly.NetSync
             _lastTickApplied = false;
             ClearLastAvatarSamples();
             _intervalEstimator.Reset();
+            ResetRelayAgeTracking();
+        }
+
+        private void ResetRelayAgeTracking()
+        {
+            _relayAge.Reset();
+            _hasRelaySample = false;
+            _lastRelaySeq = 0;
+            _lastRelayPoseTime = 0;
+        }
+
+        /// <summary>
+        /// Feed one relay-age observation (broadcastTime - poseTime) when the pose
+        /// sequence actually advanced. Rebroadcasts of an unchanged pose carry a
+        /// growing age that says nothing about relay latency, so they are skipped.
+        /// </summary>
+        private void SampleRelayAge(double broadcastTime, double poseTime, ushort poseSeq)
+        {
+            if (broadcastTime <= 0 || poseTime <= 0)
+            {
+                return;
+            }
+
+            bool isNew;
+            if (!_hasRelaySample)
+            {
+                isNew = true;
+            }
+            else if (poseSeq != 0 && _lastRelaySeq != 0)
+            {
+                isNew = SequenceUtil.IsNewer(poseSeq, _lastRelaySeq);
+            }
+            else
+            {
+                isNew = poseTime > _lastRelayPoseTime;
+            }
+
+            if (!isNew)
+            {
+                return;
+            }
+
+            _lastRelaySeq = poseSeq;
+            _lastRelayPoseTime = poseTime;
+            _hasRelaySample = true;
+            _relayAge.AddSample(broadcastTime - poseTime, NetSyncClock.NowSeconds());
         }
 
         public void AddSnapshot(ClientTransformData data)
@@ -170,6 +225,7 @@ namespace Styly.NetSync
             _isMovingFloorLocal = movingFloorLocal;
             _hasAnySnapshot = true;
             _intervalEstimator.OnPoseTime(data.poseTime);
+            SampleRelayAge(data.relayBroadcastTime, data.poseTime, data.poseSeq);
 
             if ((data.flags & PoseFlags.PhysicalValid) != 0 && data.physical != null)
             {
@@ -227,7 +283,7 @@ namespace Styly.NetSync
             }
         }
 
-        public void AddSingleSnapshot(double poseTime, ushort poseSeq, Vector3 position, Quaternion rotation)
+        public void AddSingleSnapshot(double poseTime, ushort poseSeq, Vector3 position, Quaternion rotation, double broadcastTime = 0)
         {
             if (_singleChannel == null)
             {
@@ -236,6 +292,7 @@ namespace Styly.NetSync
 
             _hasAnySnapshot = true;
             _intervalEstimator.OnPoseTime(poseTime);
+            SampleRelayAge(broadcastTime, poseTime, poseSeq);
             _singleChannel.AddSnapshot(poseTime, poseSeq, new PoseSampleData(position, rotation));
         }
 
@@ -279,7 +336,11 @@ namespace Styly.NetSync
                 _settings.DynamicTolerance,
                 _settings.MinBufferMultiplier,
                 _settings.MaxBufferMultiplier);
-            var renderServerTime = serverNow - (bufferMul * sendInterval);
+            // Delay rendering by the buffer (send interval + jitter) plus the
+            // measured server relay wait, so snapshots arrive before the render
+            // point reaches them even when the relay clock beats against the
+            // sender clock.
+            var renderServerTime = serverNow - (bufferMul * sendInterval) - _relayAge.Current(localNow);
 
             if (_singleChannel != null)
             {

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/ObjectSyncManager.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/ObjectSyncManager.cs
@@ -165,7 +165,7 @@ namespace Styly.NetSync
                     var applier = obj.TransformApplier;
                     if (applier != null)
                     {
-                        applier.AddSingleSnapshot(objState.poseTime, objState.poseSeq, objState.position, objState.rotation);
+                        applier.AddSingleSnapshot(objState.poseTime, objState.poseSeq, objState.position, objState.rotation, data.broadcastTime);
                     }
                 }
             }


### PR DESCRIPTION
## Summary

Remote avatar transform sync stuttered periodically (reported as カクつき). Investigation traced it to two compounding receive-side issues:

1. **Interpolation buffer collapse (#342 regression)**: `NetSyncSmoothingSettings` clamped the render buffer to 1.1–1.2 send intervals, so the dynamic jitter adaptation could never engage, and the Head channel had second-phase smoothing disabled — every interpolate/extrapolate/hold transition showed up directly on the avatar.
2. **Unobservable server relay wait**: the server relays a pose up to one broadcast interval after receiving it (default 10 Hz = 0–100 ms). Because the client send clock and server broadcast clock are unsynchronized, this wait drifts slowly through 0–100 ms (beat), and it is invisible to the broadcast-offset jitter estimator — the buffer could not adapt to it, causing periodic extrapolate → hold → snap cycles.

## Changes

- **Restore buffer headroom** (`NetSyncSmoothing.cs`): `BaseBufferMultiplier` 0.45 → 1.3, `DynamicTolerance` 0.1 → 0.3, `Min/MaxBufferMultiplier` 1.1/1.2 → 1.25/2.0, re-enable Head second-phase smoothing.
- **Add `RelayAgeEnvelope`**: measures `broadcastTime − poseTime` (both server-monotonic, so no clock-offset error) whenever the pose sequence advances, keeps a slowly decaying maximum, and subtracts it from the render time. Applied to both avatars and NetSyncObjects.
- **Fix duplicate snapshot acceptance**: `PoseSnapshotBuffer.SequenceLE` treated equal sequence numbers as newer, so rebroadcasts of an unchanged pose polluted the interpolation history.
- `ClientTransformData.relayBroadcastTime` is stamped on receive — **not on the wire, no protocol change** (protocol stays v8).

## Why not raise the server broadcast rate?

Raising `transform_broadcast_rate` to 30 Hz also fixes the stutter (verified) but triples downstream bandwidth in active rooms, which is not acceptable for ~100-client deployments. The adaptive buffer keeps the server at 10 Hz with zero bandwidth increase; latency grows only by the measured relay wait (~50 ms average) instead of a fixed worst-case pad.

## Test evidence

- Manually verified with the Python server (default 10 Hz config) and Unity clients: periodic stutter no longer reproduces after the change (previously it drifted in and out with the send/broadcast clock beat).
- Also verified the diagnostic path: with a 30 Hz relay config the stutter disappeared, confirming the relay-wait root cause before implementing the client-side fix.
- Unity compile clean (0 errors, warnings pre-existing). Python side untouched; the Python client exposes raw transforms and has no interpolation, so no parity change is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013mDzjgUobUgBFTDnJfj5uA