### PR TITLE
feat: refuse to start on discovery port conflict

### DIFF
--- a/STYLY-NetSync-Server/README.md
+++ b/STYLY-NetSync-Server/README.md
@@ -121,6 +121,10 @@ Bridging: stdlib `logging` is routed to loguru automatically.
 
 The server launches an embedded FastAPI application that exposes REST endpoints for managing Network Variables. Default port: `8800` (override with `--rest-api-port` CLI argument or `rest_api_port` in config file). The REST bridge is required: if it cannot start, server startup fails before discovery is advertised. Server discovery includes the REST bridge port only after the bridge has started successfully.
 
+## Server discovery
+
+Clients locate the server via a UDP broadcast handshake on `server_discovery_port` (default `9999`). At startup the server probes that port with a broadcast: if another STYLY-NetSync server is already responding on it, the server **refuses to start** so clients on the LAN cannot silently connect to the wrong server. Stop the other server, choose a different `--server-discovery-port`, or pass `--allow-discovery-port-conflict` (config: `allow_discovery_port_conflict = true`) to start anyway despite the conflict. Disable discovery entirely with `--no-server-discovery`.
+
 ### Client variables
 
 - Endpoint: `POST /v1/rooms/{roomId}/devices/{deviceId}/client-variables`

--- a/STYLY-NetSync-Server/src/styly_netsync/config.py
+++ b/STYLY-NetSync-Server/src/styly_netsync/config.py
@@ -70,6 +70,7 @@ class ServerConfig:
     rest_api_port: int
     server_name: str
     enable_server_discovery: bool
+    allow_discovery_port_conflict: bool
 
     # Timing settings
     idle_broadcast_interval: float
@@ -115,6 +116,7 @@ _VALID_KEYS: set[str] = {
     "rest_api_port",
     "server_name",
     "enable_server_discovery",
+    "allow_discovery_port_conflict",
     # Timing settings
     "idle_broadcast_interval",
     "transform_broadcast_rate",
@@ -406,6 +408,13 @@ def merge_cli_args(config: ServerConfig, args: argparse.Namespace) -> ServerConf
     # Special handling for --no-server-discovery flag
     if hasattr(args, "no_server_discovery") and args.no_server_discovery:
         updates["enable_server_discovery"] = False
+
+    # Special handling for --allow-discovery-port-conflict flag
+    if (
+        hasattr(args, "allow_discovery_port_conflict")
+        and args.allow_discovery_port_conflict
+    ):
+        updates["allow_discovery_port_conflict"] = True
 
     # Logging settings from CLI
     if hasattr(args, "log_dir") and args.log_dir is not None:

--- a/STYLY-NetSync-Server/src/styly_netsync/default.toml
+++ b/STYLY-NetSync-Server/src/styly_netsync/default.toml
@@ -35,6 +35,12 @@ server_name = "STYLY-NetSync-Server"
 # Enable/disable UDP discovery service
 enable_server_discovery = true
 
+# Refuse to start when another server is already responding on the same
+# discovery port (detected via a UDP broadcast probe at startup). This prevents
+# clients on the LAN from silently connecting to the wrong server. Set to true
+# to start anyway despite a detected conflict.
+allow_discovery_port_conflict = false
+
 # Timing Settings
 # Broadcast interval when server is idle (0.5Hz default)
 idle_broadcast_interval = 2.0

--- a/STYLY-NetSync-Server/src/styly_netsync/server.py
+++ b/STYLY-NetSync-Server/src/styly_netsync/server.py
@@ -2733,35 +2733,25 @@ class NetSyncServer:
 
     @staticmethod
     def _parse_discovery_server_name(response: str) -> str | None:
-        """Extract the server name from a discovery response of any known
-        format, or None if the payload is not a recognizable discovery reply.
+        """Extract the server name from a current-format discovery response, or
+        None if the payload is not a recognizable discovery reply.
 
-        Current and older formats are all accepted for conflict detection only;
-        clients still require the current format. A stale v1/v2 server on the
-        LAN is a legitimate conflict — it usually means a previous server was
-        not shut down before an upgrade."""
+        Only the current format is recognized: a reply in any other shape is
+        simply not a compatible server, so it is not treated as a conflict."""
         text = response.rstrip()
-        if text.startswith(discovery.DISCOVERY_RESPONSE_PREFIX):
-            # STYLY-NETSYNC3|control|transform|pub|rest|name  (name may contain '|')
-            parts = text.split("|", 5)
-            int_field_count, name_index = 4, 5
-        elif text.startswith("STYLY-NETSYNC2|"):
-            parts = text.split("|")
-            int_field_count, name_index = 3, 4
-        elif text.startswith("STYLY-NETSYNC|"):
-            parts = text.split("|")
-            int_field_count, name_index = 2, 3
-        else:
+        if not text.startswith(discovery.DISCOVERY_RESPONSE_PREFIX):
             return None
 
-        if len(parts) <= name_index:
+        # STYLY-NETSYNC3|control|transform|pub|rest|name  (name may contain '|')
+        parts = text.split("|", 5)
+        if len(parts) < 6:
             return None
         try:
-            for i in range(1, int_field_count + 1):
-                int(parts[i])
+            for field in parts[1:5]:
+                int(field)
         except ValueError:
             return None
-        return parts[name_index]
+        return parts[5]
 
     def _probe_existing_discovery_server(self) -> str | None:
         """Send a UDP broadcast probe to check if another server is already

--- a/STYLY-NetSync-Server/src/styly_netsync/server.py
+++ b/STYLY-NetSync-Server/src/styly_netsync/server.py
@@ -231,6 +231,9 @@ class NetSyncServer:
         self.server_name = (
             server_name if server_name is not None else config.server_name
         )
+        # Refuse to start when another server already owns the discovery port,
+        # unless the operator explicitly allows it.
+        self.allow_discovery_port_conflict = config.allow_discovery_port_conflict
         self.server_discovery_socket: socket.socket | None = None
         self.server_discovery_thread: threading.Thread | None = None
         self.server_discovery_running = False
@@ -935,6 +938,32 @@ class NetSyncServer:
     def start(self, ip_addresses: list[str] | None = None) -> None:
         """Start the server"""
         try:
+            # Refuse to start if another server already owns this discovery port,
+            # so clients on the LAN cannot silently connect to the wrong server.
+            # Probe before binding anything, so a conflict aborts cleanly with no
+            # partial startup to tear down. The operator can override.
+            if self.enable_server_discovery:
+                conflict = self._probe_existing_discovery_server()
+                if conflict is not None:
+                    if self.allow_discovery_port_conflict:
+                        logger.opt(colors=True).warning(
+                            f"<yellow>⚠ DISCOVERY PORT CONFLICT (ignored):</yellow> "
+                            f"{conflict} is already responding on discovery port "
+                            f"{self.server_discovery_port}. Starting anyway because "
+                            f"allow_discovery_port_conflict is set; clients on this "
+                            f"LAN may connect to the wrong server."
+                        )
+                    else:
+                        logger.opt(colors=True).error(
+                            f"<red>⚠ DISCOVERY PORT CONFLICT:</red> {conflict} is "
+                            f"already responding on discovery port "
+                            f"{self.server_discovery_port}. Refusing to start so "
+                            f"clients cannot connect to the wrong server. Stop the "
+                            f"other server, choose a different --server-discovery-port, "
+                            f"or pass --allow-discovery-port-conflict to start anyway."
+                        )
+                        raise SystemExit(1)
+
             # Raise FD soft limit early to avoid connection drops when many clients connect
             self._bump_fd_soft_limit(self.DEFAULT_FD_LIMIT)
 
@@ -2702,10 +2731,46 @@ class NetSyncServer:
         for room_id, changed_msg in ownership_release_broadcasts:
             self._send_ctrl_to_room_via_router(room_id, changed_msg)
 
-    def _probe_existing_discovery_server(self) -> None:
+    @staticmethod
+    def _parse_discovery_server_name(response: str) -> str | None:
+        """Extract the server name from a discovery response of any known
+        format, or None if the payload is not a recognizable discovery reply.
+
+        Current and older formats are all accepted for conflict detection only;
+        clients still require the current format. A stale v1/v2 server on the
+        LAN is a legitimate conflict — it usually means a previous server was
+        not shut down before an upgrade."""
+        text = response.rstrip()
+        if text.startswith(discovery.DISCOVERY_RESPONSE_PREFIX):
+            # STYLY-NETSYNC3|control|transform|pub|rest|name  (name may contain '|')
+            parts = text.split("|", 5)
+            int_field_count, name_index = 4, 5
+        elif text.startswith("STYLY-NETSYNC2|"):
+            parts = text.split("|")
+            int_field_count, name_index = 3, 4
+        elif text.startswith("STYLY-NETSYNC|"):
+            parts = text.split("|")
+            int_field_count, name_index = 2, 3
+        else:
+            return None
+
+        if len(parts) <= name_index:
+            return None
+        try:
+            for i in range(1, int_field_count + 1):
+                int(parts[i])
+        except ValueError:
+            return None
+        return parts[name_index]
+
+    def _probe_existing_discovery_server(self) -> str | None:
         """Send a UDP broadcast probe to check if another server is already
-        responding on the same discovery port.  Logs a warning if a valid
-        response is received; never blocks startup."""
+        responding on the same discovery port.
+
+        Returns a human-readable description of the conflicting server (name and
+        source address) if a valid discovery response is received, or None when
+        no conflict is detected. Never raises. Self-detection is impossible
+        because this runs before the server binds its own discovery socket."""
         probe_sock: socket.socket | None = None
         try:
             probe_sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
@@ -2719,64 +2784,12 @@ class NetSyncServer:
             try:
                 data, addr = probe_sock.recvfrom(1024)
                 response = data.decode("utf-8", errors="replace")
-                # Accept current and older discovery responses for conflict
-                # detection only. Clients still require the current format.
-                if response.startswith(discovery.DISCOVERY_RESPONSE_PREFIX):
-                    parts = response.rstrip().split("|", 5)
-                    if len(parts) >= 6:
-                        try:
-                            int(parts[1])
-                            int(parts[2])
-                            int(parts[3])
-                            int(parts[4])
-                        except ValueError:
-                            return
-                        server_name = parts[5]
-                        logger.opt(colors=True).warning(
-                            f"<red>⚠ DISCOVERY PORT CONFLICT:</red> "
-                            f"Another STYLY-NetSync server "
-                            f"('{server_name}') is already responding "
-                            f"on discovery port {self.server_discovery_port} "
-                            f"(from {addr[0]}:{addr[1]}). Clients on this "
-                            f"LAN may connect to the wrong server."
-                        )
-                elif response.startswith("STYLY-NETSYNC2|"):
-                    parts = response.rstrip().split("|")
-                    if len(parts) >= 5:
-                        try:
-                            int(parts[1])
-                            int(parts[2])
-                            int(parts[3])
-                        except ValueError:
-                            return
-                        server_name = parts[4]
-                        logger.opt(colors=True).warning(
-                            f"<red>⚠ DISCOVERY PORT CONFLICT:</red> "
-                            f"Another STYLY-NetSync server "
-                            f"('{server_name}') is already responding "
-                            f"on discovery port {self.server_discovery_port} "
-                            f"(from {addr[0]}:{addr[1]}). Clients on this "
-                            f"LAN may connect to the wrong server."
-                        )
-                elif response.startswith("STYLY-NETSYNC|"):
-                    parts = response.rstrip().split("|")
-                    if len(parts) >= 4:
-                        try:
-                            int(parts[1])
-                            int(parts[2])
-                        except ValueError:
-                            return
-                        server_name = parts[3]
-                        # Highlight the marker in red on color-capable sinks.
-                        # File/JSON sinks strip color tags automatically.
-                        logger.opt(colors=True).warning(
-                            f"<red>⚠ DISCOVERY PORT CONFLICT:</red> "
-                            f"Another STYLY-NetSync server "
-                            f"('{server_name}') is already responding "
-                            f"on discovery port {self.server_discovery_port} "
-                            f"(from {addr[0]}:{addr[1]}). Clients on this "
-                            f"LAN may connect to the wrong server."
-                        )
+                server_name = self._parse_discovery_server_name(response)
+                if server_name is not None:
+                    return (
+                        f"Another STYLY-NetSync server ('{server_name}') "
+                        f"from {addr[0]}:{addr[1]}"
+                    )
             except TimeoutError:
                 # No response — no conflict detected
                 pass
@@ -2785,12 +2798,13 @@ class NetSyncServer:
         finally:
             if probe_sock is not None:
                 probe_sock.close()
+        return None
 
     def _start_server_discovery(self) -> None:
-        """Start server discovery service to respond to client requests"""
-        # Probe for existing servers before binding
-        self._probe_existing_discovery_server()
+        """Start server discovery service to respond to client requests.
 
+        The discovery-port conflict probe runs earlier in start() so a conflict
+        can abort before any sockets bind; do not re-probe here."""
         # Start UDP server discovery
         try:
             self.server_discovery_socket = socket.socket(
@@ -2991,6 +3005,14 @@ def main() -> None:
     )
     parser.add_argument(
         "--no-server-discovery", action="store_true", help="Disable server discovery"
+    )
+    parser.add_argument(
+        "--allow-discovery-port-conflict",
+        action="store_true",
+        help=(
+            "Start even if another server is already responding on the discovery "
+            "port (default: refuse to start on conflict)"
+        ),
     )
     parser.add_argument(
         "-V",

--- a/STYLY-NetSync-Server/tests/test_config.py
+++ b/STYLY-NetSync-Server/tests/test_config.py
@@ -95,6 +95,7 @@ class TestServerConfig:
             rest_api_port=9900,
             server_name="Custom Server",
             enable_server_discovery=False,
+            allow_discovery_port_conflict=True,
             idle_broadcast_interval=default_config.idle_broadcast_interval,
             transform_broadcast_rate=default_config.transform_broadcast_rate,
             client_timeout=default_config.client_timeout,
@@ -128,6 +129,7 @@ class TestServerConfig:
         assert config.rest_api_port == 9900
         assert config.server_name == "Custom Server"
         assert config.enable_server_discovery is False
+        assert config.allow_discovery_port_conflict is True
 
 
 class TestLoadConfigFromToml:
@@ -637,6 +639,33 @@ class TestMergeCliArgs:
 
         merged = merge_cli_args(default_config, args)
         assert merged.enable_server_discovery is False
+
+    def test_allow_discovery_port_conflict_flag(
+        self, default_config: ServerConfig
+    ) -> None:
+        """--allow-discovery-port-conflict flips the config to True."""
+        assert default_config.allow_discovery_port_conflict is False
+        args = argparse.Namespace(
+            server_discovery_port=None,
+            no_server_discovery=False,
+            allow_discovery_port_conflict=True,
+        )
+
+        merged = merge_cli_args(default_config, args)
+        assert merged.allow_discovery_port_conflict is True
+
+    def test_allow_discovery_port_conflict_default_false(
+        self, default_config: ServerConfig
+    ) -> None:
+        """Without the flag the conflict guard stays enabled (config False)."""
+        args = argparse.Namespace(
+            server_discovery_port=None,
+            no_server_discovery=False,
+            allow_discovery_port_conflict=False,
+        )
+
+        merged = merge_cli_args(default_config, args)
+        assert merged.allow_discovery_port_conflict is False
 
     def test_none_values_dont_override(self, default_config: ServerConfig) -> None:
         """Test that None CLI values don't override config."""

--- a/STYLY-NetSync-Server/tests/test_discovery_probe.py
+++ b/STYLY-NetSync-Server/tests/test_discovery_probe.py
@@ -2,13 +2,10 @@
 
 from __future__ import annotations
 
-import io
 import socket
 import threading
 from dataclasses import replace
 from unittest.mock import patch
-
-from loguru import logger
 
 from styly_netsync.config import load_default_config
 from styly_netsync.server import NetSyncServer
@@ -40,7 +37,7 @@ class TestDiscoveryProbe:
         assert server._build_discovery_response(newline=True) == f"{expected}\n"
 
     def test_no_conflict_when_no_other_server(self) -> None:
-        """Probe should produce no warning when nobody responds."""
+        """Probe should return None when nobody responds."""
         port = _find_free_port()
         server = NetSyncServer(
             dealer_port=_find_free_port(),
@@ -48,16 +45,10 @@ class TestDiscoveryProbe:
             server_discovery_port=port,
             enable_server_discovery=False,
         )
-        sink = io.StringIO()
-        handler_id = logger.add(sink, level="WARNING", format="{message}")
-        try:
-            server._probe_existing_discovery_server()
-        finally:
-            logger.remove(handler_id)
-        assert "Another STYLY-NetSync server" not in sink.getvalue()
+        assert server._probe_existing_discovery_server() is None
 
-    def test_warns_when_another_server_responds(self) -> None:
-        """Probe should log a warning when an existing server responds."""
+    def test_detects_conflict_when_another_server_responds(self) -> None:
+        """Probe should return a conflict description when a server responds."""
         port = _find_free_port()
 
         # Simulate an existing server that responds to DISCOVER probes
@@ -93,22 +84,18 @@ class TestDiscoveryProbe:
                 server_discovery_port=port,
                 enable_server_discovery=False,
             )
-            sink = io.StringIO()
-            handler_id = logger.add(sink, level="WARNING", format="{message}")
-            try:
-                server._probe_existing_discovery_server()
-            finally:
-                logger.remove(handler_id)
+            conflict = server._probe_existing_discovery_server()
 
-            output = sink.getvalue()
-            assert "Another STYLY-NetSync server" in output
-            assert str(port) in output
+            assert conflict is not None
+            assert "Another STYLY-NetSync server" in conflict
+            assert "FakeServer" in conflict
+            assert str(port) in conflict
         finally:
             stop_event.set()
             t.join(timeout=2)
 
     def test_probe_does_not_block_on_exception(self) -> None:
-        """Probe should not raise even if socket operations fail."""
+        """Probe should return None (not raise) if socket operations fail."""
         server = NetSyncServer(
             dealer_port=_find_free_port(),
             pub_port=_find_free_port(),
@@ -116,5 +103,50 @@ class TestDiscoveryProbe:
             enable_server_discovery=False,
         )
         with patch("socket.socket", side_effect=OSError("mock error")):
-            # Should not raise
-            server._probe_existing_discovery_server()
+            assert server._probe_existing_discovery_server() is None
+
+
+class TestParseDiscoveryServerName:
+    """Tests for _parse_discovery_server_name across known response formats."""
+
+    def test_parses_current_v3_response(self) -> None:
+        name = NetSyncServer._parse_discovery_server_name(
+            "STYLY-NETSYNC3|5555|5557|5556|8800|MyServer"
+        )
+        assert name == "MyServer"
+
+    def test_v3_name_may_contain_pipe(self) -> None:
+        # maxsplit keeps everything after the 5th '|' as the name.
+        name = NetSyncServer._parse_discovery_server_name(
+            "STYLY-NETSYNC3|5555|5557|5556|8800|Room|A"
+        )
+        assert name == "Room|A"
+
+    def test_parses_legacy_v2_response(self) -> None:
+        name = NetSyncServer._parse_discovery_server_name(
+            "STYLY-NETSYNC2|5555|5557|5556|LegacyServer"
+        )
+        assert name == "LegacyServer"
+
+    def test_parses_legacy_v1_response(self) -> None:
+        name = NetSyncServer._parse_discovery_server_name(
+            "STYLY-NETSYNC|5555|5557|OldServer"
+        )
+        assert name == "OldServer"
+
+    def test_rejects_unrelated_payload(self) -> None:
+        assert NetSyncServer._parse_discovery_server_name("HELLO-WORLD") is None
+
+    def test_rejects_non_integer_ports(self) -> None:
+        assert (
+            NetSyncServer._parse_discovery_server_name(
+                "STYLY-NETSYNC3|5555|abc|5556|8800|MyServer"
+            )
+            is None
+        )
+
+    def test_rejects_truncated_response(self) -> None:
+        assert (
+            NetSyncServer._parse_discovery_server_name("STYLY-NETSYNC3|5555|5557")
+            is None
+        )

--- a/STYLY-NetSync-Server/tests/test_discovery_probe.py
+++ b/STYLY-NetSync-Server/tests/test_discovery_probe.py
@@ -107,7 +107,7 @@ class TestDiscoveryProbe:
 
 
 class TestParseDiscoveryServerName:
-    """Tests for _parse_discovery_server_name across known response formats."""
+    """Tests for _parse_discovery_server_name against the current format."""
 
     def test_parses_current_v3_response(self) -> None:
         name = NetSyncServer._parse_discovery_server_name(
@@ -122,17 +122,21 @@ class TestParseDiscoveryServerName:
         )
         assert name == "Room|A"
 
-    def test_parses_legacy_v2_response(self) -> None:
-        name = NetSyncServer._parse_discovery_server_name(
-            "STYLY-NETSYNC2|5555|5557|5556|LegacyServer"
+    def test_rejects_older_response_formats(self) -> None:
+        # Only the current format counts as a conflict; older shapes are simply
+        # not a compatible server (see the repo backward-compatibility policy).
+        assert (
+            NetSyncServer._parse_discovery_server_name(
+                "STYLY-NETSYNC2|5555|5557|5556|LegacyServer"
+            )
+            is None
         )
-        assert name == "LegacyServer"
-
-    def test_parses_legacy_v1_response(self) -> None:
-        name = NetSyncServer._parse_discovery_server_name(
-            "STYLY-NETSYNC|5555|5557|OldServer"
+        assert (
+            NetSyncServer._parse_discovery_server_name(
+                "STYLY-NETSYNC|5555|5557|OldServer"
+            )
+            is None
         )
-        assert name == "OldServer"
 
     def test_rejects_unrelated_payload(self) -> None:
         assert NetSyncServer._parse_discovery_server_name("HELLO-WORLD") is None

--- a/STYLY-NetSync-Server/tests/test_port_error_message.py
+++ b/STYLY-NetSync-Server/tests/test_port_error_message.py
@@ -3,11 +3,37 @@
 Test platform-specific error messages when port is already in use.
 """
 
+import socket
 import unittest.mock as mock
+from dataclasses import replace
 
 import pytest
 
+from styly_netsync.config import load_default_config
 from styly_netsync.server import NetSyncServer
+
+
+def _free_tcp_port() -> int:
+    """Return a free TCP port."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return int(s.getsockname()[1])
+
+
+def _make_server(control_port: int, pub_port: int) -> NetSyncServer:
+    """Build a server that isolates the ZMQ port-conflict path.
+
+    Discovery is disabled so the discovery-port conflict probe cannot preempt
+    the ZMQ "address already in use" error, and the REST bridge uses a free
+    port so the test does not depend on the default REST port being available.
+    """
+    config = replace(load_default_config(), rest_api_port=_free_tcp_port())
+    return NetSyncServer(
+        dealer_port=control_port,
+        pub_port=pub_port,
+        enable_server_discovery=False,
+        config=config,
+    )
 
 
 class TestPortErrorMessage:
@@ -18,12 +44,12 @@ class TestPortErrorMessage:
         with mock.patch("platform.system", return_value="Linux"):
             with mock.patch("styly_netsync.server.logger") as mock_logger:
                 # Create a server to bind to a port
-                server1 = NetSyncServer(dealer_port=15555, pub_port=15556)
+                server1 = _make_server(control_port=15555, pub_port=15556)
                 try:
                     server1.start()
 
                     # Try to create a second server on the same port
-                    server2 = NetSyncServer(dealer_port=15555, pub_port=15557)
+                    server2 = _make_server(control_port=15555, pub_port=15557)
                     with pytest.raises(SystemExit):
                         server2.start()
 
@@ -51,12 +77,12 @@ class TestPortErrorMessage:
         with mock.patch("platform.system", return_value="Windows"):
             with mock.patch("styly_netsync.server.logger") as mock_logger:
                 # Create a server to bind to a port
-                server1 = NetSyncServer(dealer_port=16555, pub_port=16556)
+                server1 = _make_server(control_port=16555, pub_port=16556)
                 try:
                     server1.start()
 
                     # Try to create a second server on the same port
-                    server2 = NetSyncServer(dealer_port=16555, pub_port=16557)
+                    server2 = _make_server(control_port=16555, pub_port=16557)
                     with pytest.raises(SystemExit):
                         server2.start()
 
@@ -85,12 +111,12 @@ class TestPortErrorMessage:
         with mock.patch("platform.system", return_value="Darwin"):
             with mock.patch("styly_netsync.server.logger") as mock_logger:
                 # Create a server to bind to a port
-                server1 = NetSyncServer(dealer_port=17555, pub_port=17556)
+                server1 = _make_server(control_port=17555, pub_port=17556)
                 try:
                     server1.start()
 
                     # Try to create a second server on the same port
-                    server2 = NetSyncServer(dealer_port=17555, pub_port=17557)
+                    server2 = _make_server(control_port=17555, pub_port=17557)
                     with pytest.raises(SystemExit):
                         server2.start()
 

--- a/STYLY-NetSync-Server/tests/test_server_discovery_rest_startup.py
+++ b/STYLY-NetSync-Server/tests/test_server_discovery_rest_startup.py
@@ -50,6 +50,7 @@ def test_discovery_starts_after_rest_bridge_success() -> None:
                 return_value=(rest_thread, rest_server),
             ) as run_rest,
             patch("styly_netsync.server.display_logo"),
+            patch.object(server, "_probe_existing_discovery_server", return_value=None),
             patch.object(server, "_start_server_discovery") as start_discovery,
         ):
             server.start()
@@ -69,6 +70,7 @@ def test_server_start_fails_when_rest_bridge_fails() -> None:
             "styly_netsync.rest_bridge.run_uvicorn_in_thread",
             side_effect=RuntimeError("rest bind failed"),
         ) as run_rest,
+        patch.object(server, "_probe_existing_discovery_server", return_value=None),
         patch.object(server, "_start_server_discovery") as start_discovery,
         pytest.raises(SystemExit),
     ):
@@ -79,6 +81,59 @@ def test_server_start_fails_when_rest_bridge_fails() -> None:
     assert server.running is False
     assert server.server_discovery_running is False
     assert server.tcp_server_discovery_running is False
+
+
+def test_server_start_aborts_on_discovery_port_conflict() -> None:
+    """A detected discovery-port conflict must abort before binding anything."""
+    server = _make_server()
+
+    try:
+        with (
+            patch.object(
+                server,
+                "_probe_existing_discovery_server",
+                return_value="Another STYLY-NetSync server ('Other') from 10.0.0.2:9999",
+            ),
+            patch("styly_netsync.rest_bridge.run_uvicorn_in_thread") as run_rest,
+            patch.object(server, "_start_server_discovery") as start_discovery,
+            pytest.raises(SystemExit),
+        ):
+            server.start()
+
+        # Aborted before any partial startup: no REST bridge, no discovery, no run.
+        run_rest.assert_not_called()
+        start_discovery.assert_not_called()
+        assert server.running is False
+    finally:
+        server.stop()
+
+
+def test_server_start_proceeds_on_conflict_when_allowed() -> None:
+    """With allow_discovery_port_conflict set, a conflict only warns."""
+    server = _make_server()
+    server.allow_discovery_port_conflict = True
+    rest_thread, rest_server = _fake_rest_lifecycle()
+
+    try:
+        with (
+            patch.object(
+                server,
+                "_probe_existing_discovery_server",
+                return_value="Another STYLY-NetSync server ('Other') from 10.0.0.2:9999",
+            ),
+            patch(
+                "styly_netsync.rest_bridge.run_uvicorn_in_thread",
+                return_value=(rest_thread, rest_server),
+            ) as run_rest,
+            patch("styly_netsync.server.display_logo"),
+            patch.object(server, "_start_server_discovery") as start_discovery,
+        ):
+            server.start()
+
+        run_rest.assert_called_once()
+        start_discovery.assert_called_once()
+    finally:
+        server.stop()
 
 
 def test_server_start_fails_without_discovery_when_rest_bridge_fails() -> None:


### PR DESCRIPTION
## Summary

At startup the server probes its discovery port with a UDP broadcast. It previously only **logged a warning** when another server already responded — easy to miss in logs, leaving clients on the LAN free to connect to the wrong server.

This change makes the server **refuse to start** on a detected discovery-port conflict, probing *before* binding any socket so the abort is clean with no partial startup to tear down. An opt-out flag restores the old start-anyway behavior.

## Changes

- `start()` probes the discovery port at the very top (before any bind); on conflict it aborts (`SystemExit`) unless overridden.
- New `--allow-discovery-port-conflict` CLI flag / `allow_discovery_port_conflict` config (default `false`) to start anyway despite a conflict.
- `_probe_existing_discovery_server()` now returns a conflict description (`str | None`) instead of logging; response parsing split into `_parse_discovery_server_name()`. The caller decides warn-vs-abort.
- Conflict detection recognizes the **current discovery format only** (`STYLY-NETSYNC3`), per the repo backward-compatibility policy — a reply in any other shape is simply not a compatible server.
- `--no-server-discovery` skips the probe entirely.
- Docs: new "Server discovery" section in the server README; documented default in `default.toml`.
- `test_port_error_message` made hermetic (discovery off + free REST port) so the discovery probe cannot preempt the ZMQ port-in-use path.

## ⚠ Breaking change

By default the server now **aborts startup** when another server is already responding on the same discovery port, instead of only warning. Pass `--allow-discovery-port-conflict` (or set `allow_discovery_port_conflict = true`) to restore the previous start-anyway behavior. Consistent with the repo policy that server and clients upgrade together.

## Test evidence

- `black --check`, `ruff`, `mypy` clean.
- Full suite green: `315 passed, 2 skipped` (both skips pre-existing legacy NV integration scenarios). Added tests cover the probe return value, current-format parsing (including `|` in server names), rejection of older response shapes, abort-before-bind, allow-override, and CLI→config wiring.
- Real-socket end-to-end: server 1 owns the discovery port → server 2 (default) aborts with the conflict error and `running is False`; server 3 with `--allow-discovery-port-conflict` starts despite the conflict.
- CLI path verified: `--allow-discovery-port-conflict` appears in `--help` and lands in the resolved config (`True` with flag, `False` without).

## Review follow-up

Copilot flagged that the legacy v1/v2 parse branches split without `maxsplit`, truncating server names containing `|`. Resolved in fb4ca79 by removing those branches outright: `AGENTS.md` forbids legacy-version detection branches in the discovery handshake, so the inconsistent code should not have been there. The single remaining `STYLY-NETSYNC3` path keeps `maxsplit=5`.

Deliberate narrowing this implies: a stale *old-format* server left running on the discovery port during an upgrade is no longer reported as a conflict. Accepted — the realistic "two current servers on one LAN" conflict is still caught, and current clients already ignore old-format discovery replies (`client.py` keys off `DISCOVERY_RESPONSE_PREFIX`), so the wrong-server risk this PR targets does not reappear.

## Follow-up

The conflict-refusal (like the existing REST-failure and port-in-use aborts) still exits the process with code **0**, which supervisors/`$?` checks read as success. Deferred by design to keep consistency with the sibling abort paths; tracked in #497 for a broader decision on non-zero exit for fatal startup aborts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
