### PR TITLE
fix: hold remote hand visibility until moving floor resolves

### DIFF
--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/NetSyncAvatar.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/NetSyncAvatar.cs
@@ -654,11 +654,36 @@ namespace Styly.NetSync
             var rightValid = headValid && (data.flags & PoseFlags.RightValid) != 0 && data.rightHand != null;
             var leftValid = headValid && (data.flags & PoseFlags.LeftValid) != 0 && data.leftHand != null;
 
-            ApplyRemoteHandVisibility(_rightHand, _rightHandInitialActiveSelf, rightValid, rightValid ? data.rightHand : null);
-            ApplyRemoteHandVisibility(_leftHand, _leftHandInitialActiveSelf, leftValid, leftValid ? data.leftHand : null);
+            // When the sender is on a moving floor, hand poses arrive in floor-local space
+            // (see FillFromTransform on send / BinarySerializer on receive). Resolving them to
+            // world requires the moving-floor transform, which is delivered on a separate
+            // channel (@system:movingFloor client variable) and may not be resolved yet on this
+            // side. Until it is, hold hand visibility instead of activating a hand at raw
+            // floor-local coordinates interpreted as world space — that would fling the hand
+            // tens of meters from the body until the floor id finally resolves. This mirrors
+            // NetSyncTransformApplier.Tick, which holds head/hands while the floor is unresolved.
+            // Note: data.clientNo is used (not _clientNo) because SetTransformData assigns
+            // _clientNo only after this call.
+            var movingFloorLocal = data != null && (data.flags & PoseFlags.MovingFloorLocal) != 0;
+            Transform movingFloor = null;
+            if (movingFloorLocal)
+            {
+                bool floorResolved = _netSyncManager != null
+                    && _netSyncManager.TryGetMovingFloorForClient(data.clientNo, false, out movingFloor)
+                    && movingFloor != null;
+                if (!floorResolved)
+                {
+                    // Floor not resolved yet: freeze current hand visibility, consistent with the
+                    // held head/hands in Tick. Hands appear (correctly placed) once it resolves.
+                    return;
+                }
+            }
+
+            ApplyRemoteHandVisibility(_rightHand, _rightHandInitialActiveSelf, rightValid, rightValid ? data.rightHand : null, movingFloor);
+            ApplyRemoteHandVisibility(_leftHand, _leftHandInitialActiveSelf, leftValid, leftValid ? data.leftHand : null, movingFloor);
         }
 
-        private static void ApplyRemoteHandVisibility(Transform handTransform, bool initialActiveSelf, bool isValid, TransformData handData)
+        private static void ApplyRemoteHandVisibility(Transform handTransform, bool initialActiveSelf, bool isValid, TransformData handData, Transform movingFloor)
         {
             if (handTransform == null) { return; }
 
@@ -666,8 +691,20 @@ namespace Styly.NetSync
             var shouldBeActive = initialActiveSelf && isValid;
             if (shouldBeActive && !handObject.activeSelf && handData != null)
             {
-                handTransform.position = handData.GetPosition();
-                handTransform.rotation = handData.GetRotation();
+                // Snap to the incoming pose on activation so the hand doesn't flash at its stale
+                // position for a frame before Tick catches up. Project through the moving floor
+                // when present so floor-local coordinates land in world space (matches
+                // NetSyncTransformApplier.ApplyBinding).
+                if (movingFloor != null)
+                {
+                    handTransform.position = movingFloor.TransformPoint(handData.GetPosition());
+                    handTransform.rotation = movingFloor.rotation * handData.GetRotation();
+                }
+                else
+                {
+                    handTransform.position = handData.GetPosition();
+                    handTransform.rotation = handData.GetRotation();
+                }
             }
 
             if (handObject.activeSelf != shouldBeActive)


### PR DESCRIPTION
## Summary

Remote hand trackers could appear tens of meters from the body when a peer **boarded a moving floor** while hand-tracking (bare hands). Field logs (63 devices, 2026-07-02) showed 18k+ `Holding the last applied avatar pose` warnings with hold windows of **p50=21s / p90=82s**, matching the reported "hands floating far away for tens of seconds".

### Root cause

On a moving floor, hand poses are sent in **floor-local space** with `PoseFlags.MovingFloorLocal`, while the floor id travels on a **separate channel** (`@system:movingFloor` client variable). There is an arrival-order race between the two.

While the floor id is unresolved on the receiver (variable not yet arrived **or** floor not yet registered), `NetSyncTransformApplier.Tick` correctly **holds** head/hands (early-return). But `NetSyncAvatar.SetTransformData` still calls `ApplyRemoteHandVisibility` on every snapshot, and on an `invalid -> valid` hand transition it assigned the **raw floor-local coordinates directly as world space**. Because `Tick` was held, that wrong pose was never corrected — the hand stayed flung far from the body until the floor id resolved.

### Fix (Unity-only)

Make `ApplyRemoteHandVisibility` moving-floor-aware:

- **Floor unresolved** (and sender is on a moving floor): hold hand visibility instead of activating at raw floor-local coordinates — consistent with `Tick` holding head/hands.
- **Floor resolved**: project the activation snap through the floor transform (`movingFloor.TransformPoint` / `movingFloor.rotation * ...`), matching `NetSyncTransformApplier.ApplyBinding`, so floor-local coordinates land in world space.

The floor lookup keys off `data.clientNo` (not `_clientNo`, which `SetTransformData` assigns only after the call). Runs on the main thread via `ProcessMessageQueue`, so `TryGetMovingFloorForClient` is safe to call here.

No protocol / wire change, so the Python client (headless, no rendering) needs no parity change.

### Scope note

This stops the **floating hands**. It does **not** address the separate "avatar frozen for tens of seconds right after boarding" symptom, nor the `floor not registered` half of the hold window — both belong to the deeper cross-channel-race fix (embed `floorId` in the pose packet), which is a protocol change deferred to a follow-up.

## Test evidence

- Compilation and behavior confirmed by the reporter/maintainer.
- Deterministic repro (withhold floor registration N seconds after board, then flick a hand) reproduces the flung hand before the fix; with the fix the hand stays hidden until the floor resolves, then appears in the correct place.

## Linked issues

None filed in this repo; originates from an internal field bug report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)