### PR TITLE
fix: shorten wrist pose-stale lost timeout to hide frozen hands sooner

### DIFF
--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/HandPoseNormalizer.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/HandPoseNormalizer.cs
@@ -75,7 +75,7 @@ namespace Styly.NetSync.Internal
         private float _staleUnchangedSince = 0f;
         private const float PoseStaleEpsilon = 1e-6f;     // only a bit-identical position repeat stays under this
         private const float PoseStaleRotEpsilon = 1e-3f;  // degrees; only a bit-identical rotation repeat stays under this
-        private const float PoseStaleSeconds = 0.5f;      // sustained no-change before treating as lost
+        private const float PoseStaleSeconds = 0.1f;      // sustained no-change before treating as lost
 
         // Head transform reference for maintaining relative position during lost state
         private Transform _headTransform;


### PR DESCRIPTION
## Summary

Tune the wrist pose-staleness lost-detection in `HandPoseNormalizer` so frozen remote hands hide faster.

`HandPoseNormalizer` treats an unchanged (bit-identical) wrist pose while `XRHand.isTracked` stays `true` as a frozen/lost hand (some runtimes, e.g. Pico, keep `isTracked == true` while the wrist pose stops updating). When detected, the hand is treated as not-tracked so remote hands hide instead of freezing in place.

The confirmation window `PoseStaleSeconds` was `0.5s`, which left the hand lingering unnaturally on screen before it disappeared.

## Change

- `PoseStaleSeconds`: `0.5f` → `0.1f`

With the existing 3-frame `LostCheckDelayFrames` confirm, the effective hide latency is ~0.14s (was ~0.54s).

## Why this is safe

- The stale thresholds (`PoseStaleEpsilon = 1e-6`, `PoseStaleRotEpsilon = 1e-3°`) only match a bit-identical pose repeat. A live tracked hand always jitters above these, so genuine tracking is not misread as stale.
- 0.1s stays comfortably above the hand-tracking sample cadence (~30–60Hz), leaving ~3 samples of margin before a false positive.

## Test plan

- [ ] On-device (Pico) check: remote hand hides promptly when hand tracking is lost, without visible lingering.
- [ ] No flicker (hand momentarily disappearing) during continuous, genuine hand tracking.

## Notes

Independent follow-up tuning of the staleness detection that is already on `develop`; unrelated to the moving-floor remote-hand fix in #499.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
