### PR TITLE
fix: reconcile global variable deduplication after sync

### DIFF
--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/NetworkVariableManager.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/NetworkVariableManager.cs
@@ -448,6 +448,19 @@ namespace Styly.NetSync
 
                         if (!string.IsNullOrEmpty(name) && value != null)
                         {
+                            // Reconcile send-side deduplication with the authoritative value.
+                            // First remove the redundant trailing copy of the last successful
+                            // send. If another client changed the value, invalidate the local
+                            // sent cache so restoring that value is not incorrectly deduped.
+                            if (_lastSentGlobal.TryGetValue(name, out var lastSent))
+                            {
+                                ClearPendingGlobalIfMatches(name, lastSent);
+                                if (!string.Equals(lastSent, value, StringComparison.Ordinal))
+                                {
+                                    _lastSentGlobal.Remove(name);
+                                }
+                            }
+
                             var oldValue = _globalVariables.TryGetValue(name, out var existing) ? existing : null;
                             // Skip if value is unchanged
                             if (object.Equals(oldValue, value))
@@ -665,6 +678,16 @@ namespace Styly.NetSync
             }
 
             return allFlushed;
+        }
+
+        private void ClearPendingGlobalIfMatches(string name, string value)
+        {
+            if (_pendingGlobal.TryGetValue(name, out var pendingValue) &&
+                string.Equals(pendingValue, value, StringComparison.Ordinal))
+            {
+                _pendingGlobal.Remove(name);
+                _dueGlobal.Remove(name);
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary

Fixes Global Variable send-side deduplication after the authoritative value is changed by another client.

When a remote synchronization value differs from the last locally enqueued value, the local deduplication cache is invalidated. This allows the client to restore its previously sent value without the update being incorrectly skipped.

The synchronization handler also removes only the redundant pending value that matches the last successful local send. A different pending value is preserved as the latest local intent.

The remote value is intentionally not stored in `_lastSentGlobal`, preventing a stale synchronization message from causing incorrect deduplication of a newer local update.

## Changes

- Reconcile `_lastSentGlobal` in `HandleGlobalVariableSync`
- Clear redundant trailing pending values after authoritative synchronization
- Preserve pending values that differ from the last successful send
- Add `ClearPendingGlobalIfMatches`

## Compatibility

- No public API changes
- No protocol or serialization changes
- No server-side changes required
- Not a breaking change

## Testing

- Verified the following state transitions:
  - Local `A` → remote `B` → local `A` sends `A` again
  - Local `A` → remote `B` without another local update does not restore stale `A`
  - Local `A` → pending `C` → remote `B` preserves and sends `C`
  - Local `A` → authoritative `A` removes the redundant trailing send

Closes #504