### PR TITLE
fix: send ID mapping before NV snapshot on client hello

### DIFF
--- a/STYLY-NetSync-Server/src/styly_netsync/server.py
+++ b/STYLY-NetSync-Server/src/styly_netsync/server.py
@@ -1422,15 +1422,19 @@ class NetSyncServer:
             if is_stealth:
                 self.room_dirty_flags[room_id] = True
 
+            if is_new_client or is_reconnect:
+                # Queue the local client's ID mapping before releasing
+                # _rooms_lock. Once the new control identity is visible in the
+                # room, a periodic/NV broadcast can target it; enqueueing here
+                # closes that ordering race.
+                mapping_payload = self._build_id_mapping_payload(room_id)
+                if mapping_payload is not None:
+                    self._enqueue_router(client_identity, room_id, mapping_payload)
+
         if is_new_client:
-            # Assign the client its ClientNo (via ID mapping) before the NV
-            # snapshot so NV-changed handlers that fire before OnReady already
-            # read a valid ClientNo instead of 0.
-            self._sync_id_mapping_to_client(room_id, client_identity)
             self._sync_network_variables_to_new_client(room_id)
             self._sync_objects_to_new_client(client_identity, room_id)
         elif is_reconnect:
-            self._sync_id_mapping_to_client(room_id, client_identity)
             self._sync_network_variables_to_client(room_id, client_identity)
             # If a transform message created this entry before the hello arrived,
             # the control lane is binding for the first time here. Send the
@@ -2303,21 +2307,6 @@ class NetSyncServer:
         if message_bytes is not None:
             self._send_ctrl_to_room_via_router(room_id, message_bytes)
             logger.info(f"Broadcasted ID mappings to room {room_id} via ROUTER")
-
-    def _sync_id_mapping_to_client(self, room_id: str, identity: bytes) -> None:
-        """Unicast the current device ID mapping to a single client.
-
-        Sent before the NV snapshot on (re)connect so the client's local client
-        number is assigned before any NV change event fires. Both messages travel
-        the same ROUTER control queue, which a single receive thread drains FIFO
-        per identity, so enqueueing the mapping first guarantees the client sees
-        it first and reads a valid ClientNo inside NV-changed handlers.
-        """
-        with self._rooms_lock:
-            message_bytes = self._build_id_mapping_payload(room_id)
-
-        if message_bytes is not None:
-            self._enqueue_router(identity, room_id, message_bytes)
 
     def _flush_debounced_id_mapping_broadcasts(self, current_time: float) -> None:
         """Flush ID mapping broadcasts that have been debounced long enough."""

--- a/STYLY-NetSync-Server/src/styly_netsync/server.py
+++ b/STYLY-NetSync-Server/src/styly_netsync/server.py
@@ -1423,9 +1423,14 @@ class NetSyncServer:
                 self.room_dirty_flags[room_id] = True
 
         if is_new_client:
+            # Assign the client its ClientNo (via ID mapping) before the NV
+            # snapshot so NV-changed handlers that fire before OnReady already
+            # read a valid ClientNo instead of 0.
+            self._sync_id_mapping_to_client(room_id, client_identity)
             self._sync_network_variables_to_new_client(room_id)
             self._sync_objects_to_new_client(client_identity, room_id)
         elif is_reconnect:
+            self._sync_id_mapping_to_client(room_id, client_identity)
             self._sync_network_variables_to_client(room_id, client_identity)
             # If a transform message created this entry before the hello arrived,
             # the control lane is binding for the first time here. Send the
@@ -2259,6 +2264,33 @@ class NetSyncServer:
         else:
             logger.debug(f"NV flush took {elapsed_ms:.2f} ms (room={room_id})")
 
+    def _build_id_mapping_payload(self, room_id: str) -> bytes | None:
+        """Serialize the current device ID mappings for a room.
+
+        Caller must hold ``_rooms_lock``. Returns ``None`` when the room has no
+        connected clients to include in the mapping.
+        """
+        if room_id not in self.room_device_id_to_client_no:
+            return None
+
+        # Collect mappings only for clients still connected in the room
+        mappings: list[tuple[int, str, bool]] = []
+        room_clients = self.rooms.get(room_id, {})
+        for device_id, client_no in self.room_device_id_to_client_no[room_id].items():
+            # Skip clients that have been cleaned up from self.rooms
+            # (their mapping entry is kept for device ID reuse)
+            if device_id not in room_clients:
+                continue
+            client_data = room_clients[device_id]
+            is_stealth = client_data.get("is_stealth", False)
+            mappings.append((client_no, device_id, is_stealth))
+
+        if not mappings:
+            return None
+
+        server_version = binary_serializer.parse_version(get_version())
+        return binary_serializer.serialize_device_id_mapping(mappings, server_version)
+
     def _broadcast_id_mappings(self, room_id: str) -> None:
         """Broadcast all device ID mappings for a room via ROUTER unicast.
 
@@ -2266,35 +2298,26 @@ class NetSyncServer:
         rather than via PUB which can drop messages under load.
         """
         with self._rooms_lock:
-            if room_id not in self.room_device_id_to_client_no:
-                return
+            message_bytes = self._build_id_mapping_payload(room_id)
 
-            # Collect mappings only for clients still connected in the room
-            mappings = []
-            room_clients = self.rooms.get(room_id, {})
-            for device_id, client_no in self.room_device_id_to_client_no[
-                room_id
-            ].items():
-                # Skip clients that have been cleaned up from self.rooms
-                # (their mapping entry is kept for device ID reuse)
-                if device_id not in room_clients:
-                    continue
-                client_data = room_clients[device_id]
-                is_stealth = client_data.get("is_stealth", False)
-                mappings.append((client_no, device_id, is_stealth))
+        if message_bytes is not None:
+            self._send_ctrl_to_room_via_router(room_id, message_bytes)
+            logger.info(f"Broadcasted ID mappings to room {room_id} via ROUTER")
 
-            if mappings:
-                # Serialize and broadcast the mappings with server version
-                server_version = binary_serializer.parse_version(get_version())
-                message_bytes = binary_serializer.serialize_device_id_mapping(
-                    mappings, server_version
-                )
-                # Send via ROUTER unicast (lock is held, but _send_ctrl_to_room_via_router
-                # will acquire the lock again - RLock allows this)
-                self._send_ctrl_to_room_via_router(room_id, message_bytes)
-                logger.info(
-                    f"Broadcasted {len(mappings)} ID mappings to room {room_id} via ROUTER"
-                )
+    def _sync_id_mapping_to_client(self, room_id: str, identity: bytes) -> None:
+        """Unicast the current device ID mapping to a single client.
+
+        Sent before the NV snapshot on (re)connect so the client's local client
+        number is assigned before any NV change event fires. Both messages travel
+        the same ROUTER control queue, which a single receive thread drains FIFO
+        per identity, so enqueueing the mapping first guarantees the client sees
+        it first and reads a valid ClientNo inside NV-changed handlers.
+        """
+        with self._rooms_lock:
+            message_bytes = self._build_id_mapping_payload(room_id)
+
+        if message_bytes is not None:
+            self._enqueue_router(identity, room_id, message_bytes)
 
     def _flush_debounced_id_mapping_broadcasts(self, current_time: float) -> None:
         """Flush ID mapping broadcasts that have been debounced long enough."""

--- a/STYLY-NetSync-Server/tests/test_hello_mapping_ordering.py
+++ b/STYLY-NetSync-Server/tests/test_hello_mapping_ordering.py
@@ -56,6 +56,18 @@ def _spy_enqueue(server: NetSyncServer) -> list[int]:
     return recorded
 
 
+def _spy_enqueue_with_lock_state(server: NetSyncServer) -> list[tuple[int, bool]]:
+    """Record message types and whether _rooms_lock is held during enqueue."""
+    recorded: list[tuple[int, bool]] = []
+
+    def spy(identity: bytes, room_id: str, message_bytes: bytes) -> None:
+        is_owned = server._rooms_lock._is_owned()
+        recorded.append((message_bytes[0], bool(is_owned)))
+
+    server._enqueue_router = spy  # type: ignore[method-assign]
+    return recorded
+
+
 def test_reconnect_enqueues_mapping_before_nv() -> None:
     """Reconnect hello sends the ID mapping before global and client NV snapshots.
 
@@ -119,3 +131,38 @@ def test_new_client_enqueues_mapping_before_nv() -> None:
     assert recorded.index(binary_serializer.MSG_DEVICE_ID_MAPPING) < recorded.index(
         binary_serializer.MSG_GLOBAL_VAR_SYNC
     ), f"mapping must be enqueued before NV sync, got order: {recorded}"
+
+
+def test_new_client_enqueues_mapping_before_releasing_room_lock() -> None:
+    """First-connect hello does not expose the identity before mapping enqueue.
+
+    A periodic NV broadcast can target the new identity as soon as the hello
+    handler writes it into the room. The ID mapping must be enqueued while the
+    same room-state critical section is still held, otherwise that broadcast can
+    slip in first and deliver NV changes while ClientNo is still 0.
+    """
+    server = _make_server()
+
+    with server._rooms_lock:
+        server._initialize_room(ROOM)
+        other_no = server._get_or_assign_client_no(ROOM, "other-device")
+        server.rooms[ROOM]["other-device"] = {
+            "control_identity": b"other-identity",
+            "transform_identity": None,
+            "last_update": time.monotonic(),
+            "transform_data": None,
+            "client_no": other_no,
+            "is_stealth": False,
+        }
+    assert server._apply_global_var_set(ROOM, other_no, "k", "v")
+
+    recorded = _spy_enqueue_with_lock_state(server)
+
+    server._handle_client_hello(
+        b"fresh-identity", ROOM, {"deviceId": DEVICE_ID, "isStealthMode": False}
+    )
+
+    assert recorded[0] == (
+        binary_serializer.MSG_DEVICE_ID_MAPPING,
+        True,
+    ), f"first enqueue must be the ID mapping under _rooms_lock, got: {recorded}"

--- a/STYLY-NetSync-Server/tests/test_hello_mapping_ordering.py
+++ b/STYLY-NetSync-Server/tests/test_hello_mapping_ordering.py
@@ -1,0 +1,121 @@
+"""
+Tests that a client hello enqueues its ID mapping before the NV snapshot.
+
+On (re)connect the client's local ClientNo is assigned by the ID mapping
+message, while NV-changed events fire as soon as the NV snapshot arrives. If the
+NV snapshot reached the client first, an NV-changed handler running before
+OnReady would read ClientNo == 0. These tests lock down that the server enqueues
+the mapping to the ROUTER control queue *before* the NV sync for the connecting
+identity, for both the new-client and reconnect paths.
+"""
+
+from __future__ import annotations
+
+import time
+
+from styly_netsync import NetSyncServer, binary_serializer
+
+ROOM = "hello_order_test"
+DEVICE_ID = "device-order-0001"
+
+
+def _make_server() -> NetSyncServer:
+    """Return an unstarted server (no sockets, no threads) for direct calls."""
+    return NetSyncServer(
+        dealer_port=15720,
+        pub_port=15721,
+        enable_server_discovery=False,
+    )
+
+
+def _register_client(server: NetSyncServer, identity: bytes) -> int:
+    """Register a client in ROOM with the given control identity."""
+    with server._rooms_lock:
+        server._initialize_room(ROOM)
+        client_no = server._get_or_assign_client_no(ROOM, DEVICE_ID)
+        server.rooms[ROOM][DEVICE_ID] = {
+            "control_identity": identity,
+            "transform_identity": None,
+            "last_update": time.monotonic(),
+            "transform_data": None,
+            "client_no": client_no,
+            "is_stealth": False,
+        }
+    return client_no
+
+
+def _spy_enqueue(server: NetSyncServer) -> list[int]:
+    """Replace _enqueue_router with a spy that records message types in order."""
+    recorded: list[int] = []
+
+    def spy(identity: bytes, room_id: str, message_bytes: bytes) -> None:
+        # First byte is the message type (see binary_serializer.serialize_*).
+        recorded.append(message_bytes[0])
+
+    server._enqueue_router = spy  # type: ignore[method-assign]
+    return recorded
+
+
+def test_reconnect_enqueues_mapping_before_nv() -> None:
+    """Reconnect hello sends the ID mapping before global and client NV snapshots.
+
+    The reported symptom is client-variable-specific: an NV-changed handler that
+    runs before OnReady reads ClientNo == 0 and GetClientVariable(name) silently
+    returns the default. Assert the mapping precedes MSG_CLIENT_VAR_SYNC (and the
+    global sync) so the client number is already assigned when the events fire.
+    """
+    server = _make_server()
+    client_no = _register_client(server, identity=b"old-identity")
+
+    # State to resync so both a global and a client NV snapshot are produced.
+    assert server._apply_global_var_set(ROOM, client_no, "k", "v")
+    assert server._apply_client_var_set(ROOM, client_no, client_no, "ck", "cv")
+
+    recorded = _spy_enqueue(server)
+
+    # Reconnect: same device_id, different control identity.
+    server._handle_client_hello(
+        b"new-identity", ROOM, {"deviceId": DEVICE_ID, "isStealthMode": False}
+    )
+
+    mapping_idx = recorded.index(binary_serializer.MSG_DEVICE_ID_MAPPING)
+    assert binary_serializer.MSG_GLOBAL_VAR_SYNC in recorded
+    assert binary_serializer.MSG_CLIENT_VAR_SYNC in recorded
+    assert mapping_idx < recorded.index(
+        binary_serializer.MSG_GLOBAL_VAR_SYNC
+    ), f"mapping must be enqueued before global NV sync, got order: {recorded}"
+    assert mapping_idx < recorded.index(
+        binary_serializer.MSG_CLIENT_VAR_SYNC
+    ), f"mapping must be enqueued before client NV sync, got order: {recorded}"
+
+
+def test_new_client_enqueues_mapping_before_nv() -> None:
+    """First-connect hello sends the ID mapping before the global NV snapshot."""
+    server = _make_server()
+
+    # Seed a global NV from another client so the new client receives a snapshot.
+    with server._rooms_lock:
+        server._initialize_room(ROOM)
+        other_no = server._get_or_assign_client_no(ROOM, "other-device")
+        server.rooms[ROOM]["other-device"] = {
+            "control_identity": b"other-identity",
+            "transform_identity": None,
+            "last_update": time.monotonic(),
+            "transform_data": None,
+            "client_no": other_no,
+            "is_stealth": False,
+        }
+    assert server._apply_global_var_set(ROOM, other_no, "k", "v")
+
+    recorded = _spy_enqueue(server)
+
+    # First connect for DEVICE_ID (not yet in the room).
+    server._handle_client_hello(
+        b"fresh-identity", ROOM, {"deviceId": DEVICE_ID, "isStealthMode": False}
+    )
+
+    assert binary_serializer.MSG_DEVICE_ID_MAPPING in recorded
+    assert binary_serializer.MSG_GLOBAL_VAR_SYNC in recorded
+    assert recorded.index(binary_serializer.MSG_DEVICE_ID_MAPPING) < recorded.index(
+        binary_serializer.MSG_GLOBAL_VAR_SYNC
+    ), f"mapping must be enqueued before NV sync, got order: {recorded}"


### PR DESCRIPTION
## Summary

Fix a (re)connect ordering bug where a client could receive Network Variable change events before its local `ClientNo` was assigned — the failure users hit after resuming from sleep.

## Root cause

On client hello the server sent the NV snapshot **immediately** from the hello handler (`_sync_network_variables_to_client`), while the device ID mapping — which assigns the client's `ClientNo` — only marked the room dirty and waited for the debounced periodic broadcast (`ID_MAPPING_DEBOUNCE_INTERVAL = 0.5s`). Both travel the same ROUTER control lane, so the NV snapshot arrived first.

A client resuming from sleep then processed NV change events while `ClientNo == 0`. An `OnGlobalVariableChanged` / `OnClientVariableChanged` handler running before `OnReady` read `ClientNo == 0`, and a self-addressed `GetClientVariable(name)` looked up client 0 and silently returned the default.

## Fix

Enqueue the ID mapping to the ROUTER control queue **before** the NV snapshot in both the new-client and reconnect branches of `_handle_client_hello`. A single receive thread drains that queue FIFO per identity (and preserves per-identity order under backpressure via the deferred-packets path), so the client assigns its `ClientNo` before the NV change events fire within the same frame.

Refactor: extracted `_build_id_mapping_payload()` and added `_sync_id_mapping_to_client()` for the unicast. `_broadcast_id_mappings` now builds the payload under the lock and sends outside it, matching the existing `_broadcast_global_var_sync` pattern.

## Scope

This makes `ClientNo` valid **inside the NV-changed handler**. It does **not** change `OnReady` timing relative to NV events (that is the client-side `Update()` ordering and is unchanged). No client-side change is needed — Unity and Python clients both inherit the fix.

## Test evidence

Added `tests/test_hello_mapping_ordering.py` pinning that the mapping is enqueued before global and client NV syncs, for both new-client and reconnect paths.

```
black --check / ruff check : passed
mypy src/                  : Success: no issues found in 16 source files
pytest -q                  : 307 passed, 2 skipped
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)