### PR TITLE
fix: stop rescanning the XR rig every frame in HandPoseNormalizer

### DIFF
--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/HandPoseNormalizer.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/HandPoseNormalizer.cs
@@ -61,6 +61,18 @@ namespace Styly.NetSync.Internal
         private int _lostCheckFrameCount = 0;
         private const int LostCheckDelayFrames = 3; // Wait 3 frames before confirming lost
 
+        // --- Rig scan gating ---
+        // Both rig scans (FindHandTransform / TryFindActiveWristTransform) walk every Transform
+        // under XROrigin and marshal a managed string per Transform via Transform.name, so neither
+        // may run per frame. A wrist GameObject only becomes active while the hand is tracked, so
+        // the scans are gated on isTracked; the interval bounds the residual case where a tracked
+        // hand never matches a wrist (the first attempt still runs immediately).
+        private float _nextWristScanTime = 0f;
+        private const float WristScanIntervalSeconds = 0.5f;
+
+        // Reused so the subsystem lookup below allocates nothing when called every frame.
+        private readonly List<XRHandSubsystem> _handSubsystems = new();
+
         // --- Pose-staleness lost detection ---
         // Some runtimes keep XRHand.isTracked == true while the wrist pose stops updating (the
         // subsystem returns the bit-identical pose every frame), and the joint trackingState does
@@ -160,10 +172,15 @@ namespace Styly.NetSync.Internal
                     return;
             }
 
-            // Try to find hand transform if not initialized
+            // Try to find hand transform if not initialized. Rigs can create the wrist objects at
+            // runtime, but only once hand tracking starts, so this retry is gated the same way as
+            // the active-wrist scan below instead of running every frame.
             if (!_isInitialized)
             {
-                FindHandTransform();
+                if (TryBeginWristScan())
+                {
+                    FindHandTransform();
+                }
                 if (!_isInitialized)
                 {
                     // Hand not found - TrackedPoseDriver handles tracking
@@ -201,8 +218,13 @@ namespace Styly.NetSync.Internal
             }
             else
             {
-                // Wrist transform is inactive - might be wrong platform, try to find the correct one
-                TryFindActiveWristTransform();
+                // Wrist transform is inactive - might be wrong platform, try to find the correct one.
+                // Gated: no wrist is active until the hand is tracked, so an ungated retry here costs
+                // a full rig walk per frame for a result that cannot exist yet.
+                if (TryBeginWristScan())
+                {
+                    TryFindActiveWristTransform();
+                }
 
                 // Controller mode: re-enable TrackedPoseDriver
                 EnableTrackedPoseDriver();
@@ -220,10 +242,11 @@ namespace Styly.NetSync.Internal
         {
             if (_handSubsystem == null || !_handSubsystem.running)
             {
-                var subsystems = new List<XRHandSubsystem>();
-                SubsystemManager.GetSubsystems(subsystems);
+                // Reuse the list: while no subsystem is running (the controller-only case) this
+                // path is reached every frame, so allocating a fresh List here would leak per frame.
+                SubsystemManager.GetSubsystems(_handSubsystems);
                 _handSubsystem = null;
-                foreach (var s in subsystems)
+                foreach (var s in _handSubsystems)
                 {
                     if (s.running)
                     {
@@ -234,6 +257,41 @@ namespace Styly.NetSync.Internal
             }
 
             return _handSubsystem != null && _handSubsystem.running;
+        }
+
+        /// <summary>
+        /// Gates the rig scans and claims the next scan slot when it returns true.
+        ///
+        /// Both scans look for an *active* wrist GameObject, and a wrist is only active while the
+        /// hand is tracked - so scanning before that is a guaranteed miss that still walks the whole
+        /// rig and marshals a managed string per Transform. Without this gate a session that never
+        /// acquires hand tracking stays in TrackingState.Unknown and scans every frame, on both
+        /// hands, for its entire lifetime.
+        /// </summary>
+        private bool TryBeginWristScan()
+        {
+            if (!EnsureHandSubsystem())
+            {
+                return false;
+            }
+
+            var hand = _handedness == Handedness.Left
+                ? _handSubsystem.leftHand
+                : _handSubsystem.rightHand;
+            if (!hand.isTracked)
+            {
+                return false;
+            }
+
+            // Tracked but still unmatched: retry on an interval rather than every frame.
+            float now = Time.unscaledTime;
+            if (now < _nextWristScanTime)
+            {
+                return false;
+            }
+
+            _nextWristScanTime = now + WristScanIntervalSeconds;
+            return true;
         }
 
         /// <summary>


### PR DESCRIPTION
Closes #507

## Problem

`HandPoseNormalizer` had two unbounded per-frame paths. Both walk **every Transform under XROrigin** and marshal a managed string per Transform via `Transform.name`:

- `TryFindActiveWristTransform()` — reached whenever `_handTransform` is inactive
- `FindHandTransform()` — reached whenever `_isInitialized` is false

Following the state machine, `Unknown` is only escapable via `isTracked == true`, so **a session that never acquires hand tracking stays in `Unknown` for its entire lifetime** and scans every frame, on both hands.

Both scans look for an *active* wrist, but no wrist is active while hand tracking is off — so every one of those scans is a guaranteed miss.

## Fix

1. `TryBeginWristScan()` gates both scans on `hand.isTracked`. A 0.5s retry interval bounds the residual "tracked but never matched" case; the first attempt still runs immediately, so the normal acquisition path is not delayed.
2. `EnsureHandSubsystem()` reuses a `List<XRHandSubsystem>` field instead of allocating one per call — that path is also reached every frame while no subsystem runs.

## Test evidence

Real `STYLY XR Rig` (**246 Transforms** under XROrigin), `HandTest.unity`, Unity Editor Play Mode.
Counter: `ProfilerRecorder(ProfilerCategory.Memory, "GC Allocated In Frame")`, 150 frames per condition, interleaved ON/OFF/ON.

| | before | after |
|---|---|---|
| whole-app per frame | 40,748 B | **8,824 B** |
| attributable to `HandPoseNormalizer` | 31,924 B/frame | **0 B/frame** |
| per hand | 15,962 B | **0 B** |
| at 72 Hz | ~2.2 MB/s | **0** |

`median == min` in every condition and both ON passes were identical — no drift.
After the fix, ON lands exactly on the pre-recorded OFF floor of 8,824 B.

### Cost breakdown (per call, per hand)

| part | B/call | share |
|---|---|---|
| full scan | 15,958 | 100% |
| `FindFirstObjectByType<XROrigin>()` | 40 | 0.3% |
| `GetComponentsInChildren<Transform>(true)` | 2,000 | 12.5% |
| `Transform.name` marshaling | **13,918** | **87.2%** |

The parts sum to the whole exactly, and an independent A/B method gave 15,962 B/hand/frame — the two agree within 4 bytes. This confirms the issue's design point: **caching only the XROrigin reference would have removed 0.3% of the cost.** Coefficient for other rigs: ~65 B per Transform under XROrigin per scan.

### Behaviour verification

Acquire path exercised in-Editor with the XR Interaction Simulator's `XRDeviceSimulatorHandsSubsystem` (prefab instantiated at runtime; the saved scene is not modified), driving controller → hand → controller:

| stage | Right | Left |
|---|---|---|
| controller | `Unknown`, wrist inactive, TPD on | `Unknown`, wrist inactive, TPD on |
| **hand** | `Tracking`, **wrist active**, TPD disabled | `TrueLost`, **wrist active**, TPD disabled |
| controller | `ControllerMode`, wrist inactive, TPD on | `TrueLost`, TPD still disabled |

The gated scan still resolves the correct wrist on acquisition. The Left/`TrueLost` asymmetry is **pre-existing**: the identical probe run against the original code (fix stashed, recompiled) produced the same outcome — the simulated left hand's pose never changes, so the pose-staleness detector from #474/#500 correctly reports it lost.

Compile: 0 errors, 0 warnings. Console: 0 errors.

## Scope of the win

The leak exists **only while `_trackingState == Unknown`** — `TrueLost` and `ControllerMode` early-return, `Tracking` does not scan, `PendingLostCheck` lasts ≤3 frames. So this is "up to ~2.2 MB/s **for sessions that never acquire hand tracking**", not an unconditional win. A session whose hands are seen even once already allocated ~0 from this path.

## Still to verify on device

- Real Pico hand tracking acquire/loss (the simulator is not the Pico runtime)
- Whether Pico sessions actually sit in `Unknown` — the premise of the win
- Frame-time tail / GC collection frequency (mean bytes/frame cannot show spikes; Editor Mono ≠ device IL2CPP, expect ±10-20% on absolute bytes)

## Notes

- Unity↔Python parity: not applicable — client-side XR input probe, no wire-protocol surface.
- `WristScanIntervalSeconds = 0.5f` is a tunable knob bounding re-match latency after a platform-variant switch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)