### PR TITLE
fix: retry device ID permission after denial

### DIFF
--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/DeviceIdResolver.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/DeviceIdResolver.cs
@@ -11,12 +11,6 @@ namespace Styly.NetSync.Internal
     /// </summary>
     internal sealed class DeviceIdResolver
     {
-        /// <summary>
-        /// PlayerPrefs key to remember that the user denied the media permission.
-        /// Cleared automatically on app reinstall (PlayerPrefs is wiped).
-        /// </summary>
-        private const string PermissionDeniedKey = "DeviceIdProvider_PermissionDenied";
-
         // Android permission strings required by Device-ID-Provider
         private const string PermissionReadExternalStorage = "android.permission.READ_EXTERNAL_STORAGE";
         private const string PermissionReadMediaImages = "android.permission.READ_MEDIA_IMAGES";
@@ -67,9 +61,7 @@ namespace Styly.NetSync.Internal
             else if (_permissionDenied)
             {
                 _permissionDenied = false;
-                Log("Android: permission denied (deferred), saving denial and using fallback");
-                PlayerPrefs.SetInt(PermissionDeniedKey, 1);
-                PlayerPrefs.Save();
+                Log("Android: permission denied (deferred), using fallback");
                 ResolveWithFallback();
             }
         }
@@ -102,23 +94,8 @@ namespace Styly.NetSync.Internal
             // Check if permission is already granted (e.g., user granted it later in system settings)
             if (UnityEngine.Android.Permission.HasUserAuthorizedPermission(permission))
             {
-                // Clear any stale denial flag so we don't skip the provider path next time
-                if (PlayerPrefs.GetInt(PermissionDeniedKey, 0) == 1)
-                {
-                    PlayerPrefs.DeleteKey(PermissionDeniedKey);
-                    PlayerPrefs.Save();
-                }
                 Log("Android: permission already granted, calling Device-ID-Provider");
                 ResolveWithDeviceIdProvider();
-                return;
-            }
-
-            // If the user previously denied permission, skip straight to fallback
-            // (don't show the dialog again until the app is reinstalled or permission is granted externally)
-            if (PlayerPrefs.GetInt(PermissionDeniedKey, 0) == 1)
-            {
-                Log("Android: permission was previously denied, using fallback");
-                ResolveWithFallback();
                 return;
             }
 
@@ -129,7 +106,9 @@ namespace Styly.NetSync.Internal
             var callbacks = new UnityEngine.Android.PermissionCallbacks();
             callbacks.PermissionGranted += OnPermissionGranted;
             callbacks.PermissionDenied += OnPermissionDenied;
-            callbacks.PermissionDeniedAndDontAskAgain += OnPermissionDenied;
+            callbacks.PermissionRequestDismissed += OnPermissionDenied;
+            // PermissionDeniedAndDontAskAgain is obsolete in Unity 6. When it is not
+            // subscribed, Unity reports that result through PermissionDenied instead.
             UnityEngine.Android.Permission.RequestUserPermission(permission, callbacks);
         }
 


### PR DESCRIPTION
## Summary

- stop persisting media-permission denial state in `PlayerPrefs`
- let a later app launch request the current Android media permission again
- route a dismissed permission request through the same fallback path as a denial
- stop subscribing to Unity 6's obsolete `PermissionDeniedAndDontAskAgain` callback

## Root cause

`DeviceIdResolver` stored `DeviceIdProvider_PermissionDenied=1` after a denied callback. Every later launch checked that cached value and skipped `RequestUserPermission()` entirely, even though the Android permission state may have changed.

This made the fallback path permanent unless the user granted the permission externally or cleared the application data.

## Behavior after this change

A denial or dismissed request still uses the existing fallback for the current launch. It is no longer saved as permanent application state, so the next launch checks the real OS permission state and may request the permission again.

The fallback UUID behavior is intentionally unchanged.

## Scope

This is a minimal NetSync-side fix for the permission-request suppression described in #510.

The following remain out of scope:

- changing or persisting the fallback UUID
- Android 14 selected-photo compatibility
- the synchronous permission-request loop inside `com.styly.device-id-provider` 0.3.1
- an in-app settings flow for Android permanent denial

## Validation

- Unity Editor: `6000.0.70f1`
- batch-mode script compilation: passed
- `git diff --check`: passed
- no new compiler warnings
- existing unrelated warnings remain in `OfflineConnectionManager` and `NetSyncManager`

PICO 4 Ultra device verification is still required because no ADB device was connected during implementation.

Related to #510.