### PR TITLE
chore: update STYLY XR Rig to 0.4.22

### DIFF
--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/package.json
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/package.json
@@ -10,7 +10,7 @@
     "org.nuget.netmq": "4.0.2",
     "com.unity.xr.core-utils": "2.1.1",
     "com.unity.nuget.newtonsoft-json": "3.2.1",
-    "com.styly.styly-xr-rig": "0.4.20"
+    "com.styly.styly-xr-rig": "0.4.22"
   },
   "author": {
     "name": "STYLY, Inc.",

--- a/STYLY-NetSync-Unity/Packages/packages-lock.json
+++ b/STYLY-NetSync-Unity/Packages/packages-lock.json
@@ -24,11 +24,11 @@
         "org.nuget.netmq": "4.0.2",
         "com.unity.xr.core-utils": "2.1.1",
         "com.unity.nuget.newtonsoft-json": "3.2.1",
-        "com.styly.styly-xr-rig": "0.4.20"
+        "com.styly.styly-xr-rig": "0.4.22"
       }
     },
     "com.styly.styly-xr-rig": {
-      "version": "0.4.20",
+      "version": "0.4.22",
       "depth": 1,
       "source": "registry",
       "dependencies": {


### PR DESCRIPTION
## Summary
- Update the STYLY XR Rig dependency from v0.4.20 to v0.4.22.
- Synchronize the embedded package dependency and Unity package lock.

## Validation
- Parsed package.json and packages-lock.json successfully.
- Unity editor/device validation not run.