### PR TITLE
fix: instantiate avatars in NetSyncManager scene

### DIFF
--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/AvatarManager.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/AvatarManager.cs
@@ -321,26 +321,7 @@ namespace Styly.NetSync
         private static GameObject InstantiateInManagerScene(GameObject prefab, NetSyncManager netSyncManager)
         {
             var managerScene = netSyncManager.gameObject.scene;
-            if (!managerScene.IsValid())
-            {
-                Debug.LogError("[NetSync] Cannot instantiate an avatar because NetSyncManager is not in a valid scene.");
-                return null;
-            }
-
-            if (managerScene.isLoaded)
-            {
-                return (GameObject)Object.Instantiate(prefab, managerScene);
-            }
-
-            // During scene activation, isLoaded can still be false while the manager's
-            // OnEnable is already running. Parent the avatar to the manager first so its
-            // Awake and OnEnable callbacks run in the manager scene. These callbacks
-            // temporarily observe netSyncManager.transform as the parent. Detach after
-            // instantiation while preserving the avatar's world transform; only the
-            // returned instance is guaranteed to be a scene root.
-            var instance = Object.Instantiate(prefab, netSyncManager.transform, true);
-            instance.transform.SetParent(null, true);
-            return instance;
+            return (GameObject)Object.Instantiate(prefab, managerScene);
         }
 
         /// <summary>

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/AvatarManager.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/AvatarManager.cs
@@ -45,7 +45,7 @@ namespace Styly.NetSync
             }
             else
             {
-                localGO = Object.Instantiate(localAvatarPrefab);
+                localGO = InstantiateInManagerScene(localAvatarPrefab, netSyncManager);
 
                 // Resolve the transform that the local avatar root should
                 // follow. Shares its priority order (XROrigin first, then
@@ -86,7 +86,8 @@ namespace Styly.NetSync
                 return;
             }
 
-            var go = Object.Instantiate(remoteAvatarPrefab);
+            var go = InstantiateInManagerScene(remoteAvatarPrefab, netSyncManager);
+
             var net = go.GetComponent<NetSyncAvatar>();
             if (!net)
             {
@@ -315,6 +316,31 @@ namespace Styly.NetSync
                 // Subscribe to hand tracking state changes
                 leftNormalizer.OnTrackingStateChanged += HandleHandTrackingStateChanged;
             }
+        }
+
+        private static GameObject InstantiateInManagerScene(GameObject prefab, NetSyncManager netSyncManager)
+        {
+            var managerScene = netSyncManager.gameObject.scene;
+            if (!managerScene.IsValid())
+            {
+                Debug.LogError("[NetSync] Cannot instantiate an avatar because NetSyncManager is not in a valid scene.");
+                return null;
+            }
+
+            if (managerScene.isLoaded)
+            {
+                return (GameObject)Object.Instantiate(prefab, managerScene);
+            }
+
+            // During scene activation, isLoaded can still be false while the manager's
+            // OnEnable is already running. Parent the avatar to the manager first so its
+            // Awake and OnEnable callbacks run in the manager scene. These callbacks
+            // temporarily observe netSyncManager.transform as the parent. Detach after
+            // instantiation while preserving the avatar's world transform; only the
+            // returned instance is guaranteed to be a scene root.
+            var instance = Object.Instantiate(prefab, netSyncManager.transform, true);
+            instance.transform.SetParent(null, true);
+            return instance;
         }
 
         /// <summary>

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/HumanPresenceManager.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/HumanPresenceManager.cs
@@ -47,8 +47,8 @@ namespace Styly.NetSync
                 return;
             }
 
-            // Instantiate presence
-            GameObject go = Object.Instantiate(prefab);
+            // Keep presence in the manager scene even when no remote avatar is configured.
+            GameObject go = (GameObject)Object.Instantiate(prefab, _netSyncManager.gameObject.scene);
             if (go != null)
             {
                 go.name = $"HumanPresence ({clientNo})";

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/NetSyncManager.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/NetSyncManager.cs
@@ -790,8 +790,8 @@ namespace Styly.NetSync
                     CompleteDeviceIdResolution();
                 }
 
-                _avatarManager.InitializeLocalAvatar(_localAvatarPrefab, _deviceId, this);
                 _startupPending = false;
+                _avatarManager.InitializeLocalAvatar(_localAvatarPrefab, _deviceId, this);
                 StartNetworking();
             }
 

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/NetSyncManager.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/NetSyncManager.cs
@@ -558,7 +558,9 @@ namespace Styly.NetSync
 
         // Async device ID resolution
         private DeviceIdResolver _deviceIdResolver;
-        private bool _networkingPending;
+
+        // Defer avatar creation until Update so the manager scene has finished activation.
+        private bool _startupPending;
         #endregion ------------------------------------------------------------------------
 
         #region === Public Properties ===
@@ -654,7 +656,6 @@ namespace Styly.NetSync
             if (_deviceIdResolver.IsResolved)
             {
                 CompleteDeviceIdResolution();
-                _networkingPending = false; // Prevent double-init by disabling the deferred Update() initialization path
             }
             // Otherwise, Update() will complete initialization when the resolver finishes
         }
@@ -682,24 +683,14 @@ namespace Styly.NetSync
         {
             if (_isDuplicateInstance) { return; }
 
-            if (_deviceIdResolver != null && _deviceIdResolver.IsResolved)
-            {
-                _avatarManager.InitializeLocalAvatar(_localAvatarPrefab, _deviceId, this);
-                StartNetworking();
-            }
-            else
-            {
-                // Device ID not yet resolved (async permission dialog on Android).
-                // Networking will start once the resolver completes.
-                _networkingPending = true;
-            }
+            _startupPending = true;
         }
 
         private void OnDisable()
         {
             if (_isDuplicateInstance) { return; }
 
-            _networkingPending = false;
+            _startupPending = false;
 
             if (_connectionManager != null)
             {
@@ -789,12 +780,18 @@ namespace Styly.NetSync
                 _deviceIdResolver.Tick();
             }
 
-            // Complete deferred device ID resolution (async Android permission path)
-            if (_networkingPending && _deviceIdResolver != null && _deviceIdResolver.IsResolved)
+            if (_startupPending)
             {
-                _networkingPending = false;
-                CompleteDeviceIdResolution();
+                if (_deviceIdResolver == null || !_deviceIdResolver.IsResolved) { return; }
+
+                // The synchronous path already initialized managers in Awake.
+                if (_connectionManager == null)
+                {
+                    CompleteDeviceIdResolution();
+                }
+
                 _avatarManager.InitializeLocalAvatar(_localAvatarPrefab, _deviceId, this);
+                _startupPending = false;
                 StartNetworking();
             }
 
@@ -1203,6 +1200,9 @@ namespace Styly.NetSync
         #region === Networking ===
         private void StartNetworking()
         {
+            // Focus and resume callbacks must wait until the avatar is initialized.
+            if (_startupPending) { return; }
+
             if (_offlineMode)
             {
                 _connectionManager.Connect("", 0, 0, 0, _roomId);


### PR DESCRIPTION
## Summary
- Instantiate avatars and Human Presence in the NetSyncManager scene.
- Defer startup from OnEnable to Update, removing temporary parenting.
- Stop updates and networking after initialization exceptions; preserve Stealth mode.

## Behavior changes
- Local avatars are created after scene scripts' Start callbacks.
- Avatar lifetime follows the manager scene, including DontDestroyOnLoad.
- OnAvatarConnected ordering and OnReady conditions are unchanged.
