### PR TITLE
chore: update Device-ID-Provider to 0.4.0

### DIFF
--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/package.json
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/package.json
@@ -5,7 +5,7 @@
   "unity": "6000.0",
   "description": "STYLY NetSync",
   "dependencies": {
-    "com.styly.device-id-provider": "0.3.1",
+    "com.styly.device-id-provider": "0.4.0",
     "com.styly.shader-collection.urp": "0.0.5",
     "org.nuget.netmq": "4.0.2",
     "com.unity.xr.core-utils": "2.1.1",

--- a/STYLY-NetSync-Unity/Packages/packages-lock.json
+++ b/STYLY-NetSync-Unity/Packages/packages-lock.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "com.styly.device-id-provider": {
-      "version": "0.3.1",
+      "version": "0.4.0",
       "depth": 1,
       "source": "registry",
       "dependencies": {},
@@ -19,7 +19,7 @@
       "depth": 0,
       "source": "embedded",
       "dependencies": {
-        "com.styly.device-id-provider": "0.3.1",
+        "com.styly.device-id-provider": "0.4.0",
         "com.styly.shader-collection.urp": "0.0.5",
         "org.nuget.netmq": "4.0.2",
         "com.unity.xr.core-utils": "2.1.1",


### PR DESCRIPTION
## Summary
- Update the embedded NetSync package dependency to Device-ID-Provider 0.4.0
- Update packages-lock.json to resolve the same registry version

## Validation
- Confirmed Device-ID-Provider v0.4.0 tag and package version
- JSON validation passed
- git diff --check passed
- Unity Editor/build tests not run; this PR only updates package metadata

## Notes
- Requires Android **API level 29 (Android 10)** or higher.