### PR TITLE
fix: apply RPC rate limit configured before initialization

### DIFF
--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/NetSyncManager.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/NetSyncManager.cs
@@ -139,18 +139,20 @@ namespace Styly.NetSync
         /// <summary>
         /// Configure the RPC rate limit. Set rpcLimit to 0 or less to disable rate limiting.
         /// Safe to call before initialization completes (e.g. while the Android permission
-        /// dialog defers it); the values are stored and applied when the RPC manager is created.
+        /// dialog defers it); the values are applied when the RPC manager is created.
         /// </summary>
         /// <param name="rpcLimit">Maximum number of RPCs allowed per window (0 or less disables)</param>
         /// <param name="windowSeconds">Time window in seconds</param>
         /// <param name="warnCooldown">Minimum seconds between warning messages</param>
         public void ConfigureRpcLimit(int rpcLimit, double windowSeconds = 1.0, double warnCooldown = 0.5)
         {
-            _rpcLimitOverride = (rpcLimit, windowSeconds, warnCooldown);
-
             if (_rpcManager != null)
             {
                 _rpcManager.ConfigureRpcLimit(rpcLimit, windowSeconds, warnCooldown);
+            }
+            else
+            {
+                _pendingRpcLimit = (rpcLimit, windowSeconds, warnCooldown); // applied when RPCManager is created
             }
         }
 
@@ -498,8 +500,6 @@ namespace Styly.NetSync
         private IConnectionManager _connectionManager;
         private AvatarManager _avatarManager;
         private RPCManager _rpcManager;
-        // Last requested RPC rate limit, kept so it survives (and is re-applied on) manager initialization
-        private (int rpcLimit, double windowSeconds, double warnCooldown)? _rpcLimitOverride;
         private TransformSyncManager _transformSyncManager;
         private MessageProcessor _messageProcessor;
         private ServerDiscoveryManager _discoveryManager;
@@ -525,6 +525,7 @@ namespace Styly.NetSync
         private float _reconnectAt;
         private readonly List<(string name, string value)> _pendingSelfClientNV = new List<(string name, string value)>();
         private bool _pendingClearMyClientVariables;
+        private (int rpcLimit, double windowSeconds, double warnCooldown)? _pendingRpcLimit;
         private bool _hasClearedClientNetworkVariablesOnStart;
         private bool _hasInvokedReady = false;
         private bool _shouldCheckReady = false;
@@ -922,11 +923,12 @@ namespace Styly.NetSync
                 _connectionManager = new ConnectionManager(this, _messageProcessor, _enableDebugLogs, _logNetworkTraffic);
             _avatarManager = new AvatarManager(_enableDebugLogs);
             _rpcManager = new RPCManager(_connectionManager, _deviceId, this);
-            if (_rpcLimitOverride.HasValue)
+            if (_pendingRpcLimit.HasValue)
             {
-                var config = _rpcLimitOverride.Value;
+                var config = _pendingRpcLimit.Value;
                 _rpcManager.ConfigureRpcLimit(config.rpcLimit, config.windowSeconds, config.warnCooldown);
-                DebugLog($"Applied deferred RPC rate limit: {config.rpcLimit}/{config.windowSeconds}s");
+                _pendingRpcLimit = null;
+                DebugLog($"Applied pending RPC rate limit: {config.rpcLimit}/{config.windowSeconds}s");
             }
             _transformSyncManager = new TransformSyncManager(_connectionManager, _deviceId, _transformSendRate);
             _discoveryManager = new ServerDiscoveryManager(_enableDebugLogs);

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/NetSyncManager.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/NetSyncManager.cs
@@ -138,12 +138,16 @@ namespace Styly.NetSync
 
         /// <summary>
         /// Configure the RPC rate limit. Set rpcLimit to 0 or less to disable rate limiting.
+        /// Safe to call before initialization completes (e.g. while the Android permission
+        /// dialog defers it); the values are stored and applied when the RPC manager is created.
         /// </summary>
         /// <param name="rpcLimit">Maximum number of RPCs allowed per window (0 or less disables)</param>
         /// <param name="windowSeconds">Time window in seconds</param>
         /// <param name="warnCooldown">Minimum seconds between warning messages</param>
         public void ConfigureRpcLimit(int rpcLimit, double windowSeconds = 1.0, double warnCooldown = 0.5)
         {
+            _rpcLimitOverride = (rpcLimit, windowSeconds, warnCooldown);
+
             if (_rpcManager != null)
             {
                 _rpcManager.ConfigureRpcLimit(rpcLimit, windowSeconds, warnCooldown);
@@ -494,6 +498,8 @@ namespace Styly.NetSync
         private IConnectionManager _connectionManager;
         private AvatarManager _avatarManager;
         private RPCManager _rpcManager;
+        // Last requested RPC rate limit, kept so it survives (and is re-applied on) manager initialization
+        private (int rpcLimit, double windowSeconds, double warnCooldown)? _rpcLimitOverride;
         private TransformSyncManager _transformSyncManager;
         private MessageProcessor _messageProcessor;
         private ServerDiscoveryManager _discoveryManager;
@@ -916,6 +922,12 @@ namespace Styly.NetSync
                 _connectionManager = new ConnectionManager(this, _messageProcessor, _enableDebugLogs, _logNetworkTraffic);
             _avatarManager = new AvatarManager(_enableDebugLogs);
             _rpcManager = new RPCManager(_connectionManager, _deviceId, this);
+            if (_rpcLimitOverride.HasValue)
+            {
+                var config = _rpcLimitOverride.Value;
+                _rpcManager.ConfigureRpcLimit(config.rpcLimit, config.windowSeconds, config.warnCooldown);
+                DebugLog($"Applied deferred RPC rate limit: {config.rpcLimit}/{config.windowSeconds}s");
+            }
             _transformSyncManager = new TransformSyncManager(_connectionManager, _deviceId, _transformSendRate);
             _discoveryManager = new ServerDiscoveryManager(_enableDebugLogs);
             _discoveryManager.SetServerDiscoveryPort(ServerDiscoveryPort);


### PR DESCRIPTION
## Summary

`NetSyncManager.ConfigureRpcLimit()` silently dropped the request when `_rpcManager` did not exist yet. On Android the device ID permission dialog defers `InitializeManagers()` to a later `Update()` frame, so an app calling the API from its own `Awake()`/`Start()` kept the default 30 RPCs/s while believing the limit had been raised — an intermittent, timing-dependent failure.

This implements the deferred application the issue prefers:

- `ConfigureRpcLimit()` applies the values directly when `RPCManager` exists, otherwise stores them in `_pendingRpcLimit`
- `InitializeManagers()` applies them immediately after `RPCManager` is constructed, before anything can send
- The pending values are cleared once applied, matching the existing `_pendingSelfClientNV` pattern (`InitializeManagers()` runs once per instance, so nothing needs to be re-applied later)
- The public XML doc now states the call is safe before initialization

No `Debug.LogWarning` was added: with deferred application the call is no longer a misconfiguration, so warning on it would warn on correct behavior. A `DebugLog` line is emitted when the pending config is applied.

Fixes #506

## Scope notes

- Clamping stays in `RPCManager.ConfigureRpcLimit()`; the cached raw values only ever flow into it, so there is no divergence.
- The `if (_rpcManager != null)` early-outs on the RPC *send* paths have the same silent-drop window, but RPC delivery is not last-value-wins like config is (`_rpcTtlSeconds = 5.0` would expire anything buffered across a multi-second permission dialog). Buffering there needs its own design decision on queue depth, TTL and ordering, so it is left for a separate issue.
- Creating `RPCManager` up front would remove the need for the pending field and is the root-cause direction (the window exists since #391 moved initialization into `CompleteDeviceIdResolution()`). It is left out here because `RPCManager`, `ConnectionManager`, `NetworkVariableManager`, `TransformSyncManager` and `ObjectSyncManager` all capture `deviceId` readonly at construction, and it is unresolved in `Awake()` on the Android deferred path; moving only `RPCManager` would split the initialization model.
- Unity-only change; the Python client has no client-side RPC rate limiter, so there is no parity gap.

## Test evidence

Not yet verified in the Editor — needs a compilation check and a Demo-01 smoke test before merge. On the Android deferred path, enable `_enableDebugLogs` and confirm the `Applied pending RPC rate limit:` log appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AAnXyVaW1AtydxVSoqtLHF
