### PR TITLE
fix: exit non-zero when server startup fails (#497)

### DIFF
--- a/STYLY-NetSync-Server/src/styly_netsync/server.py
+++ b/STYLY-NetSync-Server/src/styly_netsync/server.py
@@ -3187,9 +3187,11 @@ def main() -> None:
                 break
 
     except SystemExit:
-        # Server failed to start due to port already in use
-        logger.info("Server startup failed. Exiting...")
-        return
+        # Any fatal startup abort from start() (REST bridge failure, port in
+        # use). Re-raise so the process exits non-zero for supervisors and
+        # $?-based deploy gates.
+        logger.error("Server startup failed. Exiting...")
+        raise
     except KeyboardInterrupt:
         # Handle Ctrl+C during startup
         logger.info("\nReceived interrupt signal during startup...")

--- a/STYLY-NetSync-Server/tests/test_startup_exit_code.py
+++ b/STYLY-NetSync-Server/tests/test_startup_exit_code.py
@@ -1,0 +1,36 @@
+"""Regression test for issue #497: main() must exit non-zero on startup failure.
+
+Previously, ``main()`` caught the ``SystemExit(1)`` raised by
+``NetSyncServer.start()`` on a fatal startup abort (REST bridge failure, port
+already in use) and swallowed it with a bare ``return``. That made the
+process exit with code 0 even though startup failed, so supervisors
+(systemd ``Restart=on-failure``), ``$?``-based deploy gates, and container
+healthchecks all read the failed startup as success.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from styly_netsync.server import NetSyncServer, main
+
+
+def test_main_exits_nonzero_when_start_fails() -> None:
+    """main() must propagate SystemExit(1) when NetSyncServer.start() aborts."""
+    with (
+        patch(
+            "sys.argv",
+            ["styly-netsync-server", "--no-server-discovery"],
+        ),
+        patch.object(NetSyncServer, "start", side_effect=SystemExit(1)) as mock_start,
+        patch.object(NetSyncServer, "stop") as mock_stop,
+    ):
+        with pytest.raises(SystemExit) as excinfo:
+            main()
+
+    assert excinfo.value.code == 1
+    mock_start.assert_called_once()
+    # The finally block's teardown must still run even though we re-raise.
+    mock_stop.assert_called_once()


### PR DESCRIPTION
## Summary

Fatal startup failures make the server **refuse to start**, but the process still exits with code **0**. Supervisors (`systemd Restart=on-failure`), `$?`-based deploy gates, and container healthchecks all read a refused startup as success — so in exactly the unattended setups that need to notice, the failure slips by.

Every fatal abort path in `NetSyncServer.start()` raises `SystemExit(1)`, but `main()` caught it and returned normally, so the interpreter exited 0. `cli_main()` already re-raises `SystemExit` unchanged, so `main()` was the only place swallowing it.

Fixes #497.

## Changes

- `main()` re-raises `SystemExit` instead of `return`ing, so the process exit code reflects the failure.
- The abort is logged at `ERROR` instead of `INFO` — a refused startup is invisible to level-filtered log pipelines at INFO.
- Stale comment updated: the handler covers every fatal startup abort, not just port-in-use.
- New regression test `tests/test_startup_exit_code.py` pins `SystemExit(1)` propagation out of `main()` and asserts the `finally` teardown (`server.stop()`) still runs on the re-raise. Socket-free and hermetic.

The `try/except/finally` structure is otherwise untouched, so `finally`'s `server.stop()` still runs before `SystemExit` propagates — teardown behavior is unchanged.

This is issue #497's **Option 1** (all abort paths exit non-zero). Both existing paths funnel through this single handler:

- REST bridge failed to start — `server.py:1017`
- ZMQ port already in use — `server.py:1048`

## Relationship to #498

#498 (discovery-port conflict abort, currently DRAFT) adds a third `SystemExit(1)` path through this same handler, so it inherits the non-zero exit automatically — no follow-up needed there. Landing this first means #498 does not introduce a fourth exit-0 path that then has to be cleaned up.

## ⚠ Behavior change

A refused startup now exits **1** instead of **0**. Any environment that relied on the old exit 0 to *ignore* startup failures (a supervisor that deliberately does not restart, a deploy gate that passes regardless) will now see a failure. That is the point of the change, but it is worth a release note.

## Test evidence

Quality pipeline from `STYLY-NetSync-Server/`:

```
black --check src/ tests/   All done! 41 files would be left unchanged.
ruff check src/ tests/      All checks passed!
mypy src/                   Success: no issues found in 16 source files
pytest                      309 passed, 2 skipped
```

309 passed = pre-existing 308 + 1 new test. The 2 skips are the documented baseline (legacy NV integration scenarios pending delta-NV migration), unchanged. No existing test needed modification — they all exercise `server.start()` directly and none pinned `main()`'s exit code.

End-to-end through the real `styly-netsync-server` CLI, starting a second server on ports already held by the first:

```
19:12:27 | ERROR | Error: Another server instance is already running on one of the NetSync ports (15555, 15557, 15556)
19:12:27 | ERROR | Server startup failed. Exiting...
SECOND SERVER EXIT CODE = 1
```

Before this change the same scenario reported `0`. The log line also confirms the INFO → ERROR level change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0194aPdGChPJRvAiaYbuMGRe
