### PR TITLE
fix: move default server discovery port into dynamic/private range

### DIFF
--- a/STYLY-NetSync-Server/AGENTS.md
+++ b/STYLY-NetSync-Server/AGENTS.md
@@ -19,7 +19,7 @@ pip install -e ".[dev]"
 
 # Run server
 styly-netsync-server
-styly-netsync-server --control-port 5555 --transform-port 5557 --pub-port 5556 --server-discovery-port 9999
+styly-netsync-server --control-port 5555 --transform-port 5557 --pub-port 5556 --server-discovery-port 49999
 styly-netsync-server --config my-config.toml
 
 # Quality pipeline (run before committing)

--- a/STYLY-NetSync-Server/src/styly_netsync/client.py
+++ b/STYLY-NetSync-Server/src/styly_netsync/client.py
@@ -1447,7 +1447,7 @@ class net_sync_manager:
         return dispatched
 
     # Discovery API
-    def start_discovery(self, server_discovery_port: int = 9999) -> None:
+    def start_discovery(self, server_discovery_port: int = 49999) -> None:
         """Start UDP discovery for servers.
 
         Creates one UDP socket per physical NIC and broadcasts discovery

--- a/STYLY-NetSync-Server/src/styly_netsync/default.toml
+++ b/STYLY-NetSync-Server/src/styly_netsync/default.toml
@@ -23,8 +23,8 @@ transform_port = 5557
 # ZeroMQ PUB port for server-to-client broadcasts
 pub_port = 5556
 
-# UDP port for server discovery service
-server_discovery_port = 9999
+# UDP port for server discovery service (dynamic/private range: 49152-65535)
+server_discovery_port = 49999
 
 # HTTP port for REST API bridge (FastAPI)
 rest_api_port = 8800

--- a/STYLY-NetSync-Server/tests/test_config.py
+++ b/STYLY-NetSync-Server/tests/test_config.py
@@ -41,7 +41,7 @@ class TestLoadDefaultConfig:
         assert config.dealer_port == 5555
         assert config.transform_port == 5557
         assert config.pub_port == 5556
-        assert config.server_discovery_port == 9999
+        assert config.server_discovery_port == 49999
         assert config.rest_api_port == 8800
         assert config.server_name == "STYLY-NetSync-Server"
         assert config.enable_server_discovery is True
@@ -611,7 +611,7 @@ class TestMergeCliArgs:
         merged = merge_cli_args(default_config, args)
         assert merged.server_discovery_port == 8888
         # Original config unchanged
-        assert default_config.server_discovery_port == 9999
+        assert default_config.server_discovery_port == 49999
 
     def test_cli_overrides_rest_api_port(self, default_config: ServerConfig) -> None:
         """Test that CLI rest_api_port overrides config."""
@@ -646,7 +646,7 @@ class TestMergeCliArgs:
         )
 
         merged = merge_cli_args(default_config, args)
-        assert merged.server_discovery_port == 9999
+        assert merged.server_discovery_port == 49999
 
     def test_missing_attributes_handled(self, default_config: ServerConfig) -> None:
         """Test that missing CLI attributes are handled gracefully."""

--- a/STYLY-NetSync-Unity/Assets/Samples_Dev/Debug/Debug Scene.unity
+++ b/STYLY-NetSync-Unity/Assets/Samples_Dev/Debug/Debug Scene.unity
@@ -153,7 +153,7 @@ MonoBehaviour:
   _subPort: 5556
   _roomId: default_room
   _enableDiscovery: 1
-  _serverDiscoveryPort: 9999
+  _serverDiscoveryPort: 49999
   _discoveryTimeout: 5
   _localPlayerPrefab: {fileID: 4943129801574805003, guid: 578f2705388a88c409e0069cca33abda, type: 3}
   _remotePlayerPrefab: {fileID: 4943129801574805003, guid: 4fff81e11e6a17a42b5ff718067168c6, type: 3}

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Editor/StartPythonServer.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Editor/StartPythonServer.cs
@@ -94,7 +94,7 @@ namespace Styly.NetSync.Editor
 
     internal static class StartPythonServer
     {
-        internal const int DefaultServerDiscoveryPort = 9999;
+        internal const int DefaultServerDiscoveryPort = 49999;
 
         internal static bool TryGetServerDiscoveryPortFromScene(out int port)
         {

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/ServerDiscoveryManager.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/Internal Scripts/ServerDiscoveryManager.cs
@@ -29,7 +29,7 @@ namespace Styly.NetSync
 
         public bool EnableDiscovery { get; set; } = true;
         public float DiscoveryTimeout { get; set; } = 1f;
-        private int _serverDiscoveryPort = 9999;
+        private int _serverDiscoveryPort = 49999;
         public int ServerDiscoveryPort
         {
             get => Volatile.Read(ref _serverDiscoveryPort);

--- a/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/NetSyncManager.cs
+++ b/STYLY-NetSync-Unity/Packages/com.styly.styly-netsync/Runtime/NetSyncManager.cs
@@ -60,8 +60,8 @@ namespace Styly.NetSync
         private bool _offlineMode = false;
         [SerializeField, Range(0.5f, 60), Tooltip("Transform sync frequency in Hz (sends per second). Higher values provide smoother movement but increase network traffic.")]
         private float _transformSendRate = 10f;
-        [Tooltip("UDP port used for server discovery.")]
-        [SerializeField, Min(1)] private int _serverDiscoveryPort = 9999;
+        [Tooltip("UDP port used for server discovery. Should be in the dynamic/private port range (49152-65535) to avoid conflicts with well-known services.")]
+        [SerializeField, Range(49152, 65535)] private int _serverDiscoveryPort = 49999;
         [Tooltip("Enable synchronization of battery levels across devices.")]
         [SerializeField] private bool _syncBatteryLevel = true;
         [SerializeField, Tooltip("Clear this client's network variables once after the first connection.")]


### PR DESCRIPTION
## Summary
- Change the default `ServerDiscoveryPort` from `9999` to `49999`, inside the IANA dynamic/private port range (49152-65535), on both the Unity and Python sides.
- Tighten the Unity inspector field from `[Min(1)]` to `[Range(49152, 65535)]` to steer future configuration into the safe range, per the issue's suggestion.

Closes #230

## Scope
Only the discovery port default is changed here. The ZeroMQ communication ports (5555/5556/5557) raised in the issue comment (potential conflict with Windows IP Helper Service) are intentionally out of scope for this PR — a much wider-reaching change across Unity + Python defaults, docs, and samples — and can be tracked separately if desired.

## Breaking change note
`[Range]` only clamps the Unity Inspector; it does not migrate already-serialized field values. Existing `NetSyncManager` scenes/prefabs with a serialized `_serverDiscoveryPort: 9999` keep using `9999` after upgrading this package. Deployments relying on the old default must explicitly re-set the discovery port to keep client and server matched (or accept the new default on both sides).

The Editor's "Start Python Server" helper self-heals for this case: it detects the scene's discovery port differs from the new default and passes `--server-discovery-port` explicitly. Deployments starting `styly-netsync-server` standalone (not via the Editor helper) do not get this auto-detection.

## Test plan
- [x] `black src/ tests/ && ruff check src/ tests/ && mypy src/` pass
- [x] `pytest tests/test_config.py` passes with updated default-port assertions
- [x] `pytest` (full suite) shows no new failures vs. the `develop` baseline (pre-existing sandbox/socket-permission failures confirmed via `git stash` comparison, unrelated to this change)
- [ ] Automated Unity compile check was not run this session (Unity CLI Loop server was not enabled in the running Editor); the change is a literal value + attribute swap following an existing pattern already used in the same file (`_transformSendRate`'s `[Range(0.5f, 60)]`), verified by inspection

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F78VxfKnYh4r7Uh9emsgxx